### PR TITLE
Setup terraform 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ profile.cov
 **/yarn-error.log
 coverage.txt
 go.sum
+
+
+cicd/devnet/terraform/.terraform

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,8 +84,8 @@ jobs:
       - GO111MODULE=auto
     name: T-Z tests
   
-  - stage: (Devnet) Build and push image
-    if: branch = dev-upgrade
+  - stage: (Devnet) Build, push and deploy
+    if: branch = dev-upgrade AND type = push AND tag IS blank
     services:
       - docker
     install: skip
@@ -98,3 +98,5 @@ jobs:
       - eval $(aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_BASE_URI > /dev/null 2>&1) #needs AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY envvars
       - docker tag xdc-devnet:latest $ECR_BASE_URI/$ECR_REPO_NAME:latest # Need ECR_REPO_NAME
       - docker push $ECR_BASE_URI/$ECR_REPO_NAME:latest
+      - aws ecs update-service --region us-east-1 --cluster devnet --service devnet-group-1 --force-new-deployment #TODO: Temporary solution until we have proper automated scripts ready
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ env:
   global:
     - GOPROXY=https://proxy.golang.org
     - GO111MODULE=on
+    # Terraform env
+    - tf_version=1.3.0
+    # Setting terraform init CLI options - https://www.terraform.io/docs/commands/init.html
+    - tf_init_cli_options=" -input=false"
+    # Set terraform validation CLI options - https://www.terraform.io/docs/commands/validate.html
+    - tf_validation_cli_options=""
+    # Set terraform plan CLI options - https://www.terraform.io/docs/commands/plan.html
+    - tf_plan_cli_options=" -lock=false -input=false"
+    # Set terraform apply CLI options - https://www.terraform.io/docs/commands/apply.html
+    - tf_apply_cli_options=" -auto-approve -input=false"
 
 
 jobs:
@@ -83,6 +93,40 @@ jobs:
     env:
       - GO111MODULE=auto
     name: T-Z tests
+    
+  - stage: (Devnet)Terraform plan
+    if: branch = dev-upgrade AND type = pull_request
+    dist: xenial
+    language: bash
+    install:
+      - wget https://releases.hashicorp.com/terraform/"$tf_version"/terraform_"$tf_version"_linux_amd64.zip
+      - unzip terraform_"$tf_version"_linux_amd64.zip
+      - sudo mv terraform /usr/local/bin/
+      - rm terraform_"$tf_version"_linux_amd64.zip
+    script:
+        - echo "Pull request detected, creating change plan(Devnet)"
+        - cd cicd/devnet/terraform
+        # Terraform init, validate, then create change plan. If any fail, fail validation
+        - terraform init $tf_init_cli_options
+        - terraform validate $tf_validation_cli_options
+        - terraform plan $tf_plan_cli_options
+  
+  - stage: (Devnet)Terraform apply
+    if: branch = dev-upgrade AND type = push AND tag IS blank
+    dist: xenial
+    language: bash
+    install:
+        # Download and install terraform before each run
+        - wget https://releases.hashicorp.com/terraform/"$tf_version"/terraform_"$tf_version"_linux_amd64.zip
+        - unzip terraform_"$tf_version"_linux_amd64.zip
+        - sudo mv terraform /usr/local/bin/
+        - rm terraform_"$tf_version"_linux_amd64.zip
+    script:
+      - echo "Merge detected, executing changes(Devnet)"
+      - cd cicd/devnet/terraform
+      # Terraform init and then apply changes to environment
+      - terraform init $tf_init_cli_options
+      - terraform apply $tf_apply_cli_options
   
   - stage: (Devnet) Build, push and deploy
     if: branch = dev-upgrade AND type = push AND tag IS blank
@@ -99,4 +143,5 @@ jobs:
       - docker tag xdc-devnet:latest $ECR_BASE_URI/$ECR_REPO_NAME:latest # Need ECR_REPO_NAME
       - docker push $ECR_BASE_URI/$ECR_REPO_NAME:latest
       - aws ecs update-service --region us-east-1 --cluster devnet --service devnet-group-1 --force-new-deployment #TODO: Temporary solution until we have proper automated scripts ready
+  
   

--- a/cicd/devnet/start.sh
+++ b/cicd/devnet/start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "Preparing to start the XDC chain, it's likely to take up to 1 minute"
+# Sleep for > 30 as we need to wait for the ECS tasks container being killed by fargate. Otherwise it will ended up with two same nodes running on a single /work/xdcchain directory
+sleep 45
+
 if [ ! -d /work/xdcchain/XDC/chaindata ]
 then
   # Randomly select a key from environment variable, seperated by ','

--- a/cicd/devnet/terraform/.terraform.lock.hcl
+++ b/cicd/devnet/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.32.0"
+  constraints = "~> 4.16"
+  hashes = [
+    "h1:d4aUL6/J+BFhh1/Nh2rgctt+dqf07H9PipRn297hIIo=",
+    "zh:062c30cd8bcf29f8ee34c2b2509e4e8695c2bcac8b7a8145e1c72e83d4e68b13",
+    "zh:1503fabaace96a7eea4d73ced36a02a75ec587760850e58162e7eff419dcbb31",
+    "zh:39a1fa36f8cb999f048bf0000d9dab40b8b0c77df35584fb08aa8bd6c5052dee",
+    "zh:471a755d43b51cd7be3e386cebc151ad8d548c5dea798343620476887e721882",
+    "zh:61ed56fab811e62b8286e606d003f7eeb7e940ef99bb49c1d283d91c0b748cc7",
+    "zh:80607dfe5f7770d136d5c451308b9861084ffad08139de8014e48672ec43ea3f",
+    "zh:863bf0a6576f7a969a89631525250d947fbb207d3d13e7ca4f74d86bd97cdda3",
+    "zh:9a8f2e77e4f99dbb618eb8ad17218a4698833754b50d46da5727323a2050a400",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b74ff6e638c2a470b3599d57c2081e0095976da0a54b6590884d571f930b53b",
+    "zh:da4fc553d50ae833d860ec95120e271c29b4cb636917ab5991327362b7486bb7",
+    "zh:f4b86e7df4e846a38774e8e648b41c5ebaddcefa913cfa1864568086b7735575",
+  ]
+}

--- a/cicd/devnet/terraform/main.tf
+++ b/cicd/devnet/terraform/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.16"
+    }
+  }
+
+  required_version = ">= 1.2.0"
+}
+
+provider "aws" {
+  region  = "us-east-1"
+}
+
+# This bucket had to be created before you can run the terraform init
+resource "aws_s3_bucket" "terraform_s3_bucket" {
+  bucket = "terraform-devnet-bucket"
+  versioning {
+    enabled = true
+  }
+}
+
+# Bucket need to be created first. If first time run terraform init, need to comment out the below section
+terraform {
+  backend "s3" {
+    bucket = "terraform-devnet-bucket"
+    key    = "tf/terraform.tfstate"
+    region = "us-east-1"
+    encrypt = true
+  }
+}
+
+resource "aws_vpc" "devnet_vpc" {
+  cidr_block = "10.0.0.0/16"
+  instance_tenancy = "default"
+  
+  tags = {
+    Name = "TfDevnetVpc"
+  }
+}
+
+resource "aws_subnet" "devnet_subnet" {
+  vpc_id = aws_vpc.devnet_vpc.id
+  cidr_block = "10.0.0.0/20"
+  map_public_ip_on_launch = true
+  availability_zone = "us-east-1a"
+  
+  tags = {
+    Name = "TfDevnetVpcSubnet"
+  }
+}
+
+resource "aws_internet_gateway" "devnet_gatewat" {
+  vpc_id = aws_vpc.devnet_vpc.id
+
+  tags = {
+    Name = "TfDevnetGateway"
+  }
+}
+
+resource "aws_route_table" "devnet_route_table" {
+  vpc_id = aws_vpc.devnet_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.devnet_gatewat.id
+  }
+
+  tags = {
+    Name = "TfDevnetVpcRoutingTable"
+  }
+}
+
+resource "aws_route_table_association" "devnet_route_table_association" {
+  subnet_id      = aws_subnet.devnet_subnet.id
+  route_table_id = aws_route_table.devnet_route_table.id
+}


### PR DESCRIPTION
- Add delay to the devnet docker image as the ECS fargate will take 30s to stop the previous deployed node. We will wait for 45s before start the new node.
- Add new terraform feature to create AWS infrastructures. This PR including VPC, subnet, Internet gateway, S3 bucket and other major initial setup.