### PR TITLE
XIN-245: Push devnet build image to docker hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 language: go
 go_import_path: github.com/XinFinOrg/XDPoSChain
+branches:
+  only:
+  - master
+  - dev-upgrade
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,14 +134,15 @@ jobs:
       - docker
     install: skip
     before_script:
+      - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker --version  # document the version travis is using
       - docker build -t xdc-devnet -f cicd/devnet/Dockerfile .
     script:
       - pip install --user awscli # install aws cli w/o sudo
       - export PATH=$PATH:$HOME/.local/bin # put aws in the path
-      - eval $(aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ECR_BASE_URI > /dev/null 2>&1) #needs AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY envvars
-      - docker tag xdc-devnet:latest $ECR_BASE_URI/$ECR_REPO_NAME:latest # Need ECR_REPO_NAME
-      - docker push $ECR_BASE_URI/$ECR_REPO_NAME:latest
+      - docker tag xdc-devnet:latest xinfinorg/devnet:latest # Always push to the latest
+      - docker push xinfinorg/devnet:latest
+      - sleep 10 # Wait for 10 second before asking the ecs to update the images
       - aws ecs update-service --region us-east-1 --cluster devnet --service devnet-group-1 --force-new-deployment #TODO: Temporary solution until we have proper automated scripts ready
   
   


### PR DESCRIPTION
- Use docker hub instead of ECR for XDC docker images