### PR TITLE
xin-250 skip process message whenever synchronising

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -849,8 +849,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			pm.lendingpool.AddRemotes(txs)
 		}
 	case msg.Code == VoteMsg:
-		// VoteMsg arrived, make sure we have a valid and fresh chain to handle them
-		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+		if pm.downloader.Synchronising() {
 			break
 		}
 
@@ -868,8 +867,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == TimeoutMsg:
-		// TimeoutMsg arrived, make sure we have a valid and fresh chain to handle them
-		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+		if pm.downloader.Synchronising() {
 			break
 		}
 
@@ -888,8 +886,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 	case msg.Code == SyncInfoMsg:
-		// SyncInfoMsg arrived, make sure we have a valid and fresh chain to handle them
-		if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+		if pm.downloader.Synchronising() {
 			break
 		}
 


### PR DESCRIPTION
Currently to stop message scam, we put the message in the queue, and skip process if this message is already processed no matter its final status ( success or failure ). But here comes the case, the syncInfo message comes during synchronization. This is the problem, syncInfo comes along with latest round number which way ahead to mining nodes round number at sync point of time, so the message will get dropped because node filters out this kind of message.

Skip message processing during synchronising will help resolve this issue.