### PR TITLE
add enable-0x-prefix flag

### DIFF
--- a/cmd/XDC/config.go
+++ b/cmd/XDC/config.go
@@ -165,6 +165,10 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, XDCConfig) {
 		common.TIPXDCXCancellationFee = common.TIPXDCXCancellationFeeTestnet
 	}
 
+	if ctx.GlobalBool(utils.Enable0xPrefixFlag.Name) {
+		common.Enable0xPrefix = true;
+	}
+	
 	// Rewound
 	if rewound := ctx.GlobalInt(utils.RewoundFlag.Name); rewound != 0 {
 		common.Rewound = uint64(rewound)

--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -113,6 +113,7 @@ var (
 		//utils.RinkebyFlag,
 		//utils.VMEnableDebugFlag,
 		utils.XDCTestnetFlag,
+		utils.Enable0xPrefixFlag,
 		utils.RewoundFlag,
 		utils.NetworkIdFlag,
 		utils.RPCCORSDomainFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -115,6 +115,10 @@ var (
 		Usage: "Rollback chain at hash",
 		Value: "",
 	}
+	Enable0xPrefixFlag = cli.BoolFlag{
+		Name:  "enable-0x-prefix",
+		Usage: "Addres use 0x-prefix (default = false)",
+	}
 	// General settings
 	AnnounceTxsFlag = cli.BoolFlag{
 		Name:  "announce-txs",

--- a/common/constants.go
+++ b/common/constants.go
@@ -45,6 +45,7 @@ var TIPXDCXCancellationFeeTestnet = big.NewInt(38383838)
 
 var TIPXDCXTestnet = big.NewInt(38383838)
 var IsTestnet bool = false
+var Enable0xPrefix bool = false
 var StoreRewardFolder string
 var RollbackHash Hash
 var BasePrice = big.NewInt(1000000000000000000)                       // 1

--- a/common/types.go
+++ b/common/types.go
@@ -250,8 +250,11 @@ func (a *Address) Set(other Address) {
 // MarshalText returns the hex representation of a.
 func (a Address) MarshalText() ([]byte, error) {
 	// Handle '0x' or 'xdc' prefix here.
-	// return hexutil.Bytes(a[:]).MarshalText()
-	return hexutil.Bytes(a[:]).MarshalXDCText()
+	if (Enable0xPrefix) {
+		return hexutil.Bytes(a[:]).MarshalText()
+	} else {
+		return hexutil.Bytes(a[:]).MarshalXDCText()
+	}
 }
 
 // UnmarshalText parses a hash in hex syntax.


### PR DESCRIPTION
Add a bool flag `--enable-0x-prefix`. This default value of this flag is false, and can be set to true when startup. The function `MarshalText` choose address prefix with this flag:

```go
func (a Address) MarshalText() ([]byte, error) {
	// Handle '0x' or 'xdc' prefix here.
	if (Enable0xPrefix) {
		return hexutil.Bytes(a[:]).MarshalText()
	} else {
		return hexutil.Bytes(a[:]).MarshalXDCText()
	}
}
```