### PR TITLE
cmd/XDC: remove redundant newline in bugcmd.go to pass make test

### DIFF
--- a/cmd/XDC/bugcmd.go
+++ b/cmd/XDC/bugcmd.go
@@ -105,5 +105,4 @@ const header = `Please answer these questions before submitting your issue. Than
  
 #### What did you see instead?
  
-#### System details
-`
+#### System details`


### PR DESCRIPTION
The below error occurs when I run `make test` for current master branch:

```text
/usr/include/x86_64-linux-gnu/bits/stdio2.h:38:10: note: ‘__builtin___sprintf_chk’ output between 25 and 85 bytes into a destination of size 32
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
# github.com/XinFinOrg/XDPoSChain/cmd/XDC
cmd/XDC/bugcmd.go:52:2: fmt.Fprintln arg list ends with redundant newline
FAIL	github.com/XinFinOrg/XDPoSChain/cmd/XDC [build failed]
?   	github.com/XinFinOrg/XDPoSChain/cmd/abigen	[no test files]
```

After apply this commit:
```text
/usr/include/x86_64-linux-gnu/bits/stdio2.h:38:10: note: ‘__builtin___sprintf_chk’ output between 25 and 85 bytes into a destination of size 32
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
ok  	github.com/XinFinOrg/XDPoSChain/cmd/XDC	9.922s
?   	github.com/XinFinOrg/XDPoSChain/cmd/abigen	[no test files]
```