### PR TITLE
Fix errors: "list M1 not found " and "nonce too low"

### DIFF
--- a/cicd/devnet/start.sh
+++ b/cicd/devnet/start.sh
@@ -7,10 +7,10 @@ then
         exit 1
   fi
   echo $PRIVATE_KEY >> /tmp/key
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -v FS="({|})" '{print $2}')
+  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
   XDC --datadir /work/xdcchain init /work/genesis.json
 else
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -v FS="({|})" '{print $2}')
+  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
 fi
 
 input="/work/bootnodes.list"
@@ -80,6 +80,6 @@ XDC --ethstats ${netstats} --gcmode archive \
 --rpcapi admin,db,eth,debug,net,shh,txpool,personal,web3,XDPoS \
 --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd --mine \
 --gasprice "1" --targetgaslimit "420000000" --verbosity ${log_level} \
---periodicprofile --debugdatadir /work/xdcchain \
+--debugdatadir /work/xdcchain \
 --ws --wsaddr=0.0.0.0 --wsport $ws_port \
 --wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/cicd/mainnet/start.sh
+++ b/cicd/mainnet/start.sh
@@ -7,10 +7,10 @@ then
         exit 1
   fi
   echo $PRIVATE_KEY >> /tmp/key
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -v FS="({|})" '{print $2}')
+  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
   XDC --datadir /work/xdcchain init /work/genesis.json
 else
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -v FS="({|})" '{print $2}')
+  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
 fi
 
 input="/work/bootnodes.list"
@@ -79,6 +79,6 @@ XDC --ethstats ${netstats} --gcmode archive \
 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,XDPoS \
 --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd --mine \
 --gasprice "1" --targetgaslimit "420000000" --verbosity ${log_level} \
---periodicprofile --debugdatadir /work/xdcchain \
+--debugdatadir /work/xdcchain \
 --ws --wsaddr=0.0.0.0 --wsport $ws_port \
 --wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/cicd/testnet/start.sh
+++ b/cicd/testnet/start.sh
@@ -8,10 +8,10 @@ then
         exit 1
   fi
   echo $PRIVATE_KEY >> /tmp/key
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -v FS="({|})" '{print $2}')
+  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
   XDC --datadir /work/xdcchain init /work/genesis.json
 else
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -v FS="({|})" '{print $2}')
+  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
 fi
 
 input="/work/bootnodes.list"

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -120,7 +120,8 @@ func CreateTransactionSign(chainConfig *params.ChainConfig, pool *core.TxPool, m
 			// Only process when private key empty in state db.
 			// Save randomize key into state db.
 			randomizeKeyValue := RandStringByte(32)
-			tx, err := BuildTxSecretRandomize(nonce+1, common.HexToAddress(common.RandomizeSMC), chainConfig.XDPoS.Epoch, randomizeKeyValue)
+			nonce := pool.State().GetNonce(account.Address)
+			tx, err := BuildTxSecretRandomize(nonce, common.HexToAddress(common.RandomizeSMC), chainConfig.XDPoS.Epoch, randomizeKeyValue)
 			if err != nil {
 				log.Error("Fail to get tx opening for randomize", "error", err)
 				return err
@@ -149,7 +150,8 @@ func CreateTransactionSign(chainConfig *params.ChainConfig, pool *core.TxPool, m
 				return err
 			}
 
-			tx, err := BuildTxOpeningRandomize(nonce+1, common.HexToAddress(common.RandomizeSMC), randomizeKeyValue)
+			nonce := pool.State().GetNonce(account.Address)
+			tx, err := BuildTxOpeningRandomize(nonce, common.HexToAddress(common.RandomizeSMC), randomizeKeyValue)
 			if err != nil {
 				log.Error("Fail to get tx opening for randomize", "error", err)
 				return err

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -364,8 +364,10 @@ func GetRewardForCheckpoint(c *XDPoS.XDPoS, chain consensus.ChainReader, header 
 	header = chain.GetHeader(header.ParentHash, prevCheckpoint)
 	masternodes := c.GetMasternodesFromCheckpointHeader(header)
 
+	epoch := chain.Config().XDPoS.Epoch
 	for i := startBlockNumber; i <= endBlockNumber; i++ {
-		if i%common.MergeSignRange == 0 || !chain.Config().IsTIP2019(big.NewInt(int64(i))) {
+		// fix issue #228: i%epoch < common.MergeSignRange
+		if i%epoch < common.MergeSignRange || i%common.MergeSignRange == 0 || !chain.Config().IsTIP2019(big.NewInt(int64(i))) {
 			addrs := data[mapBlkHash[i]]
 			// Filter duplicate address.
 			if len(addrs) > 0 {

--- a/core/error.go
+++ b/core/error.go
@@ -35,7 +35,7 @@ var (
 
 	ErrNotXDPoS = errors.New("XDPoS not found in config")
 
-	ErrNotFoundM1 = errors.New("list M1 not found ")
+	ErrNotFoundM1 = errors.New("list M1 not found")
 
 	ErrStopPreparingBlock = errors.New("stop calculating a block not verified by M2")
 )

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -242,7 +242,8 @@ func New(ctx *node.ServiceContext, config *Config, XDCXServ *XDCx.XDCX, lendingS
 			if !ok {
 				return nil
 			}
-			if block.NumberU64()%common.MergeSignRange == 0 || !eth.chainConfig.IsTIP2019(block.Number()) {
+			// fix issue #228: block.NumberU64()%chainConfig.XDPoS.Epoch < common.MergeSignRange
+			if block.NumberU64()%chainConfig.XDPoS.Epoch < common.MergeSignRange || block.NumberU64()%common.MergeSignRange == 0 || !eth.chainConfig.IsTIP2019(block.Number()) {
 				if err := contracts.CreateTransactionSign(chainConfig, eth.txPool, eth.accountManager, block, chainDb, eb); err != nil {
 					return fmt.Errorf("Fail to create tx sign for importing block: %v", err)
 				}

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -29,7 +29,8 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		if canonicalState == nil || err != nil {
 			log.Crit("Can't get state at head of canonical chain", "head number", bc.CurrentHeader().Number.Uint64(), "err", err)
 		}
-		prevEpoc := blockNumberEpoc - chain.Config().XDPoS.Epoch
+		epoch := chain.Config().XDPoS.Epoch
+		prevEpoc := blockNumberEpoc - epoch
 		if prevEpoc >= 0 {
 			start := time.Now()
 			prevHeader := chain.GetHeaderByNumber(prevEpoc)
@@ -71,23 +72,24 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 
 	// Hook scans for bad masternodes and decide to penalty them
 	adaptor.EngineV1.HookPenaltyTIPSigning = func(chain consensus.ChainReader, header *types.Header, candidates []common.Address) ([]common.Address, error) {
-		prevEpoc := header.Number.Uint64() - chain.Config().XDPoS.Epoch
+		epoch := chain.Config().XDPoS.Epoch
+		prevEpoc := header.Number.Uint64() - epoch
 		combackEpoch := uint64(0)
-		comebackLength := (common.LimitPenaltyEpoch + 1) * chain.Config().XDPoS.Epoch
+		comebackLength := (common.LimitPenaltyEpoch + 1) * epoch
 		if header.Number.Uint64() > comebackLength {
 			combackEpoch = header.Number.Uint64() - comebackLength
 		}
 		if prevEpoc >= 0 {
 			start := time.Now()
 
-			listBlockHash := make([]common.Hash, chain.Config().XDPoS.Epoch)
+			listBlockHash := make([]common.Hash, epoch)
 
 			// get list block hash & stats total created block
 			statMiners := make(map[common.Address]int)
 			listBlockHash[0] = header.ParentHash
 			parentnumber := header.Number.Uint64() - 1
 			parentHash := header.ParentHash
-			for i := uint64(1); i < chain.Config().XDPoS.Epoch; i++ {
+			for i := uint64(1); i < epoch; i++ {
 				parentHeader := chain.GetHeader(parentHash, parentnumber)
 				miner, _ := adaptor.RecoverSigner(parentHeader)
 				value, exist := statMiners[miner]

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -321,18 +321,15 @@ func getValidators(bc *core.BlockChain, masternodes []common.Address) ([]byte, e
 	// Check m2 exists on chaindb.
 	// Get secrets and opening at epoc block checkpoint.
 
-	var candidates []int64
-	if err != nil {
-		return nil, err
-	}
 	lenSigners := int64(len(masternodes))
-	if lenSigners > 0 {
-		for _, addr := range masternodes {
+	if lenSigners != 0 {
+		candidates := make([]int64, len(masternodes))
+		for i, addr := range masternodes {
 			random, err := contracts.GetRandomizeFromContract(client, addr)
 			if err != nil {
 				return nil, err
 			}
-			candidates = append(candidates, random)
+			candidates[i] = random
 		}
 		// Get randomize m2 list.
 		m2, err := contracts.GenM2FromRandomize(candidates, lenSigners)

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -38,7 +38,8 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 			if len(penSigners) > 0 {
 				// Loop for each block to check missing sign.
 				for i := prevEpoc; i < blockNumberEpoc; i++ {
-					if i%common.MergeSignRange == 0 || !chainConfig.IsTIP2019(big.NewInt(int64(i))) {
+					// fix issue #228: i%epoch < common.MergeSignRange
+					if i%epoch < common.MergeSignRange || i%common.MergeSignRange == 0 || !chainConfig.IsTIP2019(big.NewInt(int64(i))) {
 						bheader := chain.GetHeaderByNumber(i)
 						bhash := bheader.Hash()
 						block := chain.GetBlock(bhash, i)
@@ -141,7 +142,8 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 				if len(penComebacks) > 0 {
 					blockNumber := header.Number.Uint64() - uint64(i) - 1
 					bhash := listBlockHash[i]
-					if blockNumber%common.MergeSignRange == 0 {
+					// fix issue #228: blockNumber%epoch < common.MergeSignRange
+					if blockNumber%epoch < common.MergeSignRange || blockNumber%common.MergeSignRange == 0 {
 						mapBlockHash[bhash] = true
 					}
 					signData, ok := adaptor.GetCachedSigningTxs(bhash)

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -106,7 +106,7 @@ var Flags = []cli.Flag{
 	//blockprofilerateFlag,
 	cpuprofileFlag,
 	//traceFlag,
-	periodicProfilingFlag,
+	//periodicProfilingFlag,
 	debugDataDirFlag,
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -432,7 +432,8 @@ func (self *worker) wait() {
 					}
 				}
 				// Send tx sign to smart contract blockSigners.
-				if block.NumberU64()%common.MergeSignRange == 0 || !self.config.IsTIP2019(block.Number()) {
+				// fix issue #228: block.NumberU64()%self.config.XDPoS.Epoch < common.MergeSignRange
+				if block.NumberU64()%self.config.XDPoS.Epoch < common.MergeSignRange || block.NumberU64()%common.MergeSignRange == 0 || !self.config.IsTIP2019(block.Number()) {
 					if err := contracts.CreateTransactionSign(self.config, self.eth.TxPool(), self.eth.AccountManager(), block, self.chainDb, self.coinbase); err != nil {
 						log.Error("Fail to create tx sign for signer", "error", err)
 					}


### PR DESCRIPTION
# About this PR

## 1. Fix errors "list M1 not found "

### 1.1 Symptom

- https://www.xdc.dev/poonam_singh_8d4036dd4427/setting-up-private-blockchain-network-118c
- https://www.xdc.dev/lucksin3/xdc-private-network-stuck-at-block-1799-with-error-failed-to-prepare-header-for-new-block-errlist-m1-not-found--7gc

### 1.2 Solution

This PR fix issue #228 by call function `contracts.CreateTransactionSign` at continuous block range [0, common.MergeSignRange) during each epoch. The block range is [0, 14] generally if common.MergeSignRange is default value 15.

## 2. Handle error "nonce too low"

### 2.1 Symptom

https://www.xdc.dev/raghuram/xdc-private-blockchain-fail-to-create-tx-sign-for-signer-error-5ck

### 2.2 Solution

Sometimes `pool.AddLocal(txSigned)` return error `ErrNonceTooLow` in function CreateTransactionSign when nonce conflicts. The log report error as below:

```
Fail to add tx sign to local pool. error="nonce too low"
```

If this error occurs, this PR will log a warn message and retry `pool.AddLocal(txSigned)` until reaches 10 times.