### PR TITLE
Fix of discreason type problem

### DIFF
--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -93,10 +93,10 @@ var discReasonToString = [...]string{
 }
 
 func (d DiscReason) String() string {
-	if len(discReasonToString) < int(d) {
+	if len(discReasonToString) <= int(d) || int(d) < 0 {
 		return fmt.Sprintf("unknown disconnect reason %d", d)
 	}
-	return discReasonToString[d]
+	return discReasonToString[int(d)]
 }
 
 func (d DiscReason) Error() string {


### PR DESCRIPTION
Problem: https://github.com/advisories/GHSA-wjxw-gh3m-7pm5

Fix: add non-negative `if` condition.

cannot use fix in geth (https://github.com/ethereum/go-ethereum/pull/24507) since modifying DiscReason to uint8 messes up the message encode