### PR TITLE
fix "nonce too low" error when call debug_traceBlock api

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -726,3 +726,5 @@ func (m Message) Gas() uint64               { return m.gasLimit }
 func (m Message) Nonce() uint64             { return m.nonce }
 func (m Message) Data() []byte              { return m.data }
 func (m Message) CheckNonce() bool          { return m.checkNonce }
+
+func (m *Message) SetNonce(nonce uint64) { m.nonce = nonce }

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -471,6 +471,8 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		}
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer, balacne, block.Number())
+		// Set nonce to fix issue #256
+		msg.SetNonce(statedb.GetNonce(*tx.From()))
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, XDCxState, api.config, vm.Config{})


### PR DESCRIPTION
This PR fix "nonce too low" error which is reported in #256 when calling below APIs:
- debug_traceBlockByNumber
- debug_traceBlockByHash
- debug_traceBlock 

The error is caused by function `ApplyEmptyTransaction` which does not increase nonce, such as:
 
```bash
curl -s -X POST -H "Content-Type: application/json" https://erpc.apothem.network/ -d '
{
    "jsonrpc": "2.0",
    "id": 6200,
    "method": "eth_getBlockByNumber",
    "params":["0x2e69c13", true]
}' | jq
```

```json
{
  "result": {
    "transactions": [
      {
        "from": "0xe65f06590ee4ed6d814309e5fa014b642b9272bd",
        "nonce": "0x93fbe",
        "to": "0x0000000000000000000000000000000000000092",
        "transactionIndex": "0x0",
      },
      {
        "from": "0xe65f06590ee4ed6d814309e5fa014b642b9272bd",
        "nonce": "0x93fbe",
        "to": "0x0000000000000000000000000000000000000089",
        "transactionIndex": "0x5",
      }
    ],
  }
}
```

We can see the nonce of account `0xe65f06590ee4ed6d814309e5fa014b642b9272bd` in transactions array are same. The [commit](https://github.com/XinFinOrg/XDPoSChain/pull/171/commits/67ec6556a5fd01c2c56dfd0a9733a52a21a73a17) can prevent from producing wrong new data.

