### PR TITLE
eth/hooks: fix panic during sync (#271)

### DIFF
--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -228,11 +228,12 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		)
 
 		stateDB, err := bc.StateAt(bc.GetBlockByHash(block).Root())
-		candidateAddresses = state.GetCandidates(stateDB)
-
 		if err != nil {
 			return nil, err
 		}
+
+		candidateAddresses = state.GetCandidates(stateDB)
+
 		for _, address := range candidateAddresses {
 			v, err := validator.GetCandidateCap(opts, address)
 			if err != nil {


### PR DESCRIPTION
The issues #268 and #271 reported panic during sync. After debug, I found the panic is caused by https://github.com/XinFinOrg/XDPoSChain/blob/master/eth/hooks/engine_v1_hooks.go#L230-#L235

```go
		stateDB, err := bc.StateAt(bc.GetBlockByHash(block).Root())
		candidateAddresses = state.GetCandidates(stateDB)

		if err != nil {
			return nil, err
		}
```

In our sync test:
- `stateDB, err := bc.StateAt(bc.GetBlockByHash(block).Root())` returns nil and err:
  - stateDB=nil
  - err="missing trie Node 19eb36f323caa1f7569ebed6fd78bb221c6db43f94d183526b4aca7f8958026a (path )"
- then `state.GetCandidates(stateDB)` becomes `state.GetCandidates(nil)`

https://github.com/XinFinOrg/XDPoSChain/blob/master/core/state/statedb_utils.go#L92-#L95

```go
func GetCandidates(statedb *StateDB) []common.Address {
	slot := slotValidatorMapping["candidates"]
	slotHash := common.BigToHash(new(big.Int).SetUint64(slot))
	arrLength := statedb.GetState(common.HexToAddress(common.MasternodeVotingSMC), slotHash)
```

The function `GetCandidates` is called with parameter `statedb` which value is nil, so `statedb.GetState` in function `GetCandidates` becomes `nil.GetState`, this causes panic at last.

This PR avoids panic by check return values `err` and `stateDB` of `bc.StateAt` before call `state.GetCandidates`. The old codes check return value `err` after call `state.GetCandidates`. So this PR fix issue #271. 

**Notice: This PR does not fix the issue #268.**

