### PR TITLE
fix sync problems

### DIFF
--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -1022,6 +1022,7 @@ func (x *XDPoS_v1) getSignersFromContract(chain consensus.ChainReader, checkpoin
 	}
 	signers, err := x.HookGetSignersFromContract(startGapBlockHeader.Hash())
 	if err != nil {
+		log.Error("getSignersFromContract", "number", number, "err", err)
 		return []common.Address{}, fmt.Errorf("Can't get signers from Smart Contract . Err: %v", err)
 	}
 	return signers, nil

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -228,11 +228,12 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		)
 
 		stateDB, err := bc.StateAt(bc.GetBlockByHash(block).Root())
-		candidateAddresses = state.GetCandidates(stateDB)
-
 		if err != nil {
 			return nil, err
 		}
+
+		candidateAddresses = state.GetCandidates(stateDB)
+
 		for _, address := range candidateAddresses {
 			v, err := validator.GetCandidateCap(opts, address)
 			if err != nil {


### PR DESCRIPTION
# Proposed changes

The issues #268, #271, #324 and https://github.com/XinFinOrg/Local_DPoS_Setup/issues/16 reported below problems about sync:

- 1. panic: The panic problem can be solved by add a flag `--gcmode archive` in command.
- 2. sync errors: The function `checkSignersOnCheckpoint` returns below error during sync:
  - 2.1 ErrInvalidCheckpointPenalties: `invalid penalty list on checkpoint block`
  - 2.2 `Masternodes lists are different in checkpoint header and snapshot`

This PR fix the first problem. The second problem is caused by golang with v1.19 or above versions. The golang v1.14.15 is suggested to build this repo.

## Types of changes

What types of changes does your code introduce to XDC network?

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components

Which part of the codebase this PR will touch base on,

- [ ] Consensus
- [ ] Account
- [✅] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A

## Test

I made some tests.

### 1.1 xinfin network

#### 1.1.1 sync from genesis

sync script: https://github.com/gzliudan/Local_DPoS_Setup/blob/sync/xinfin-from-genesis.sh
result: catch up the latest block without any problem.

#### 1.1.2 sync from snapshot

sync script: https://github.com/gzliudan/Local_DPoS_Setup/blob/sync/xinfin-from-snapshot.sh
result: catch up the latest block without any problem.

### 1.2 apothem network

#### 1.2.1 sync from genesis

sync script: https://github.com/gzliudan/Local_DPoS_Setup/blob/sync/apothem-from-genesis.sh
result:

- failed at block 23779191 with error `invalid gas used` when I use master branch. This error is solved by [the commit
  `apothem network upgrade block`](https://github.com/XinFinOrg/XDPoSChain/commit/ffa2bb5a44b5d1166a6099e9ce50ab89cc04e80d on apothem branch).
- catch up the latest block without any problem after switched to apothem branch.

#### 1.2.2 sync from snapshot

sync script: https://github.com/gzliudan/Local_DPoS_Setup/blob/sync/apothem-from-snapshot.sh
result: catch up the latest block without any problem.
