### PR TITLE
fix candidates bugs in eth api

### DIFF
--- a/XDCxlending/lendingstate/common.go
+++ b/XDCxlending/lendingstate/common.go
@@ -2,16 +2,15 @@ package lendingstate
 
 import (
 	"encoding/json"
-	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"math/big"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
 )
 
 var (
-	EmptyAddress = "xdc0000000000000000000000000000000000000000"
-	EmptyRoot    = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+	EmptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 )
 
 var EmptyHash = common.Hash{}

--- a/XDCxlending/lendingstate/lendingitem.go
+++ b/XDCxlending/lendingstate/lendingitem.go
@@ -2,14 +2,15 @@ package lendingstate
 
 import (
 	"fmt"
+	"math/big"
+	"strconv"
+	"time"
+
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto/sha3"
 	"github.com/globalsign/mgo/bson"
-	"math/big"
-	"strconv"
-	"time"
 )
 
 const (
@@ -243,7 +244,7 @@ func (l *LendingItem) VerifyLendingSide() error {
 }
 
 func (l *LendingItem) VerifyCollateral(state *state.StateDB) error {
-	if l.CollateralToken.String() == EmptyAddress || l.CollateralToken.String() == l.LendingToken.String() {
+	if l.CollateralToken.IsZero() || l.CollateralToken == l.LendingToken {
 		return fmt.Errorf("invalid collateral %s", l.CollateralToken.Hex())
 	}
 	validCollateral := false
@@ -329,7 +330,7 @@ func (l *LendingItem) EncodedSide() *big.Int {
 	return big.NewInt(1)
 }
 
-//verify signatures
+// verify signatures
 func (l *LendingItem) VerifyLendingSignature() error {
 	V := big.NewInt(int64(l.Signature.V))
 	R := l.Signature.R.Big()

--- a/common/types.go
+++ b/common/types.go
@@ -73,6 +73,9 @@ func BigToHash(b *big.Int) Hash  { return BytesToHash(b.Bytes()) }
 func Uint64ToHash(b uint64) Hash { return BytesToHash(new(big.Int).SetUint64(b).Bytes()) }
 func HexToHash(s string) Hash    { return BytesToHash(FromHex(s)) }
 
+// IsZero returns if a Hash is empty
+func (h Hash) IsZero() bool { return h == Hash{} }
+
 // Get the string representation of the underlying hash
 func (h Hash) Str() string   { return string(h[:]) }
 func (h Hash) Bytes() []byte { return h[:] }

--- a/common/types.go
+++ b/common/types.go
@@ -193,6 +193,9 @@ func IsHexAddress(s string) bool {
 	return len(s) == 2*AddressLength && isHex(s)
 }
 
+// IsZero returns if a address is empty
+func (a Address) IsZero() bool { return a == Address{} }
+
 // Get the string representation of the underlying address
 func (a Address) Str() string   { return string(a[:]) }
 func (a Address) Bytes() []byte { return a[:] }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2554,8 +2554,8 @@ func (bc *BlockChain) UpdateM1() error {
 		if err != nil {
 			return err
 		}
-		//TODO: smart contract shouldn't return "0x0000000000000000000000000000000000000000"
-		if candidate.String() != "xdc0000000000000000000000000000000000000000" {
+		// TODO: smart contract shouldn't return "0x0000000000000000000000000000000000000000"
+		if !candidate.IsZero() {
 			ms = append(ms, utils.Masternode{Address: candidate, Stake: v})
 		}
 	}

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -431,7 +431,7 @@ func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLe
 		return ErrInvalidLendingType
 	}
 	if tx.Side() == lendingstate.Borrowing {
-		if tx.CollateralToken().String() == lendingstate.EmptyAddress || tx.CollateralToken().String() == tx.LendingToken().String() {
+		if tx.CollateralToken().IsZero() || tx.CollateralToken() == tx.LendingToken() {
 			return ErrInvalidLendingCollateral
 		}
 		validCollateral := false
@@ -541,7 +541,7 @@ func (pool *LendingPool) validateBalance(cloneStateDb *state.StateDB, cloneLendi
 	// collateralPrice = BTC/USD (eg: 8000 USD)
 	// lendTokenXDCPrice: price of lendingToken in XDC quote
 	var lendTokenXDCPrice, collateralPrice, collateralTokenDecimal *big.Int
-	if collateralToken.String() != lendingstate.EmptyAddress {
+	if !collateralToken.IsZero() {
 		collateralTokenDecimal, err = XDCXServ.GetTokenDecimal(pool.chain, cloneStateDb, collateralToken)
 		if err != nil {
 			return fmt.Errorf("validateOrder: failed to get collateralTokenDecimal. err: %v", err)

--- a/core/state/statedb_utils.go
+++ b/core/state/statedb_utils.go
@@ -93,16 +93,17 @@ func GetCandidates(statedb *StateDB) []common.Address {
 	slot := slotValidatorMapping["candidates"]
 	slotHash := common.BigToHash(new(big.Int).SetUint64(slot))
 	arrLength := statedb.GetState(common.HexToAddress(common.MasternodeVotingSMC), slotHash)
-	keys := []common.Hash{}
-	for i := uint64(0); i < arrLength.Big().Uint64(); i++ {
+	count := arrLength.Big().Uint64()
+	rets := make([]common.Address, 0, count)
+
+	for i := uint64(0); i < count; i++ {
 		key := GetLocDynamicArrAtElement(slotHash, i, 1)
-		keys = append(keys, key)
-	}
-	rets := []common.Address{}
-	for _, key := range keys {
 		ret := statedb.GetState(common.HexToAddress(common.MasternodeVotingSMC), key)
-		rets = append(rets, common.HexToAddress(ret.Hex()))
+		if !ret.IsZero() {
+			rets = append(rets, common.HexToAddress(ret.Hex()))
+		}
 	}
+
 	return rets
 }
 

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -238,9 +238,7 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 			if err != nil {
 				return nil, err
 			}
-			if address.String() != "xdc0000000000000000000000000000000000000000" {
-				candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
-			}
+			candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
 		}
 		// sort candidates by stake descending
 		sort.Slice(candidates, func(i, j int) bool {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1008,11 +1008,12 @@ func (s *PublicBlockChainAPI) getCandidatesFromSmartContract() ([]utils.Masterno
 	var candidatesWithStakeInfo []utils.Masternode
 
 	for _, candidate := range candidates {
-		v, err := validator.GetCandidateCap(opts, candidate)
-		if err != nil {
-			return []utils.Masternode{}, err
-		}
-		if candidate.String() != "xdc0000000000000000000000000000000000000000" {
+		if !candidate.IsZero() {
+			v, err := validator.GetCandidateCap(opts, candidate)
+			if err != nil {
+				return []utils.Masternode{}, err
+			}
+
 			candidatesWithStakeInfo = append(candidatesWithStakeInfo, utils.Masternode{Address: candidate, Stake: v})
 		}
 
@@ -1022,6 +1023,7 @@ func (s *PublicBlockChainAPI) getCandidatesFromSmartContract() ([]utils.Masterno
 			})
 		}
 	}
+
 	return candidatesWithStakeInfo, nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -819,7 +819,7 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 		})
 	}
 
-	// Third, Get penalties list
+	// Get penalties list
 	penalties = append(penalties, header.Penalties...)
 	// check last 5 epochs to find penalize masternodes
 	for i := 1; i <= common.LimitPenaltyEpoch; i++ {
@@ -837,12 +837,22 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 	penaltyList = common.ExtractAddressFromBytes(penalties)
 
 	// map slashing status
-	for _, pen := range penaltyList {
-		if coinbaseAddress == pen {
-			result[fieldStatus] = statusSlashed
-			return result, nil
+	total := len(masternodes)
+	for _, candidate := range candidates {
+		for _, pen := range penaltyList {
+			if candidate.Address == pen {
+				if coinbaseAddress == pen {
+					result[fieldStatus] = statusSlashed
+					return result, nil
+				}
+				total++
+				if total >= maxMasternodes {
+					return result, nil
+				}
+			}
 		}
 	}
+
 	return result, nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -756,9 +756,7 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 		candidatesAddresses := state.GetCandidates(statedb)
 		for _, address := range candidatesAddresses {
 			v := state.GetCandidateCap(statedb, address)
-			if address.String() != "xdc0000000000000000000000000000000000000000" {
-				candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
-			}
+			candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
 		}
 	}
 	if err != nil || len(candidates) == 0 {
@@ -882,9 +880,7 @@ func (s *PublicBlockChainAPI) GetCandidates(ctx context.Context, epoch rpc.Epoch
 		candidatesAddresses := state.GetCandidates(statedb)
 		for _, address := range candidatesAddresses {
 			v := state.GetCandidateCap(statedb, address)
-			if address.String() != "xdc0000000000000000000000000000000000000000" {
-				candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
-			}
+			candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
 		}
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1016,7 +1016,7 @@ func (s *PublicBlockChainAPI) getCandidatesFromSmartContract() ([]utils.Masterno
 		return []utils.Masternode{}, err
 	}
 
-	var candidatesWithStakeInfo []utils.Masternode
+	candidatesWithStakeInfo := make([]utils.Masternode, 0, len(candidates))
 
 	for _, candidate := range candidates {
 		if !candidate.IsZero() {
@@ -1026,12 +1026,6 @@ func (s *PublicBlockChainAPI) getCandidatesFromSmartContract() ([]utils.Masterno
 			}
 
 			candidatesWithStakeInfo = append(candidatesWithStakeInfo, utils.Masternode{Address: candidate, Stake: v})
-		}
-
-		if len(candidatesWithStakeInfo) > 0 {
-			sort.Slice(candidatesWithStakeInfo, func(i, j int) bool {
-				return candidatesWithStakeInfo[i].Stake.Cmp(candidatesWithStakeInfo[j].Stake) >= 0
-			})
 		}
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -754,6 +754,7 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 			return result, err
 		}
 		candidatesAddresses := state.GetCandidates(statedb)
+		candidates = make([]utils.Masternode, 0, len(candidatesAddresses))
 		for _, address := range candidatesAddresses {
 			v := state.GetCandidateCap(statedb, address)
 			candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
@@ -764,6 +765,7 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 		result[fieldSuccess] = false
 		return result, err
 	}
+
 	var maxMasternodes int
 	if s.b.ChainConfig().IsTIPIncreaseMasternodes(block.Number()) {
 		maxMasternodes = common.MaxMasternodesV2
@@ -805,6 +807,12 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 			result[fieldStatus] = statusMasternode
 			return result, nil
 		}
+	}
+
+	if len(candidates) > maxMasternodes {
+		sort.Slice(candidates, func(i, j int) bool {
+			return candidates[i].Stake.Cmp(candidates[j].Stake) > 0
+		})
 	}
 
 	// Third, Get penalties list

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -954,8 +954,8 @@ func (s *PublicBlockChainAPI) GetCandidates(ctx context.Context, epoch rpc.Epoch
 	penaltyList = common.ExtractAddressFromBytes(penalties)
 
 	var topCandidates []utils.Masternode
-	if len(candidates) > common.MaxMasternodes {
-		topCandidates = candidates[:common.MaxMasternodes]
+	if len(candidates) > maxMasternodes {
+		topCandidates = candidates[:maxMasternodes]
 	} else {
 		topCandidates = candidates
 	}


### PR DESCRIPTION
The issue #280 reported a problem about `eth_getCandidateStatus`. I found some bugs about candidate functions during troubleshooting.

## Bugs

### Bug 1

#### the master branch

The function `GetPreviousCheckpointFromEpoch` returns wrong result when `epochNum == rpc.LatestEpochNumber` and blockNumer is 900\*N.

https://github.com/XinFinOrg/XDPoSChain/blob/master/internal/ethapi/api.go#L965-L984:

```go
func (s *PublicBlockChainAPI) GetPreviousCheckpointFromEpoch(ctx context.Context, epochNum rpc.EpochNumber) (rpc.BlockNumber, rpc.EpochNumber) {
	var checkpointNumber uint64
	epoch := s.b.ChainConfig().XDPoS.Epoch

	if epochNum == rpc.LatestEpochNumber {
		blockNumer := s.b.CurrentBlock().Number().Uint64()
		diff := blockNumer % epoch
		// checkpoint number
		checkpointNumber = blockNumer - diff
		epochNum = rpc.EpochNumber(checkpointNumber / epoch)
		if diff > 0 {
			epochNum += 1
		}
	} else if epochNum < 2 {
		checkpointNumber = 0
	} else {
		checkpointNumber = epoch * (uint64(epochNum) - 1)
	}
	return rpc.BlockNumber(checkpointNumber), epochNum
}
```

Eg: when the `blockNumer` is 1800, the right return values should be (900, 1), but the above codes returns (1800, 2).

#### the dev-upgrade branch

The function `GetPreviousCheckpointFromEpoch` returns wrong result when not `epochNum == rpc.LatestEpochNumber` and not `epochNum < 2`.

https://github.com/XinFinOrg/XDPoSChain/blob/dev-upgrade/internal/ethapi/api.go#L968-L992

```go
func (s *PublicBlockChainAPI) GetPreviousCheckpointFromEpoch(ctx context.Context, epochNum rpc.EpochNumber) (rpc.BlockNumber, rpc.EpochNumber) {
	var checkpointNumber uint64

	if engine, ok := s.b.GetEngine().(*XDPoS.XDPoS); ok {
		currentCheckpointNumber, epochNumber, err := engine.GetCurrentEpochSwitchBlock(s.chainReader, s.b.CurrentBlock().Number())
		if err != nil {
			log.Error("[GetPreviousCheckpointFromEpoch] Error while trying to get current epoch switch block information", "Block", s.b.CurrentBlock(), "Error", err)
		}
		if epochNum == rpc.LatestEpochNumber {
			checkpointNumber = currentCheckpointNumber
			epochNum = rpc.EpochNumber(epochNumber)
		} else if epochNum < 2 {
			checkpointNumber = 0
		} else {
			blockNumberBeforeCurrentEpochSwitch := currentCheckpointNumber - 1
			checkpointNumber, _, err = engine.GetCurrentEpochSwitchBlock(s.chainReader, big.NewInt(int64(blockNumberBeforeCurrentEpochSwitch)))
			if err != nil {
				log.Error("[GetPreviousCheckpointFromEpoch] Error while trying to get last epoch switch block information", "Number", blockNumberBeforeCurrentEpochSwitch, "Error", err)
			}
		}
		return rpc.BlockNumber(checkpointNumber), epochNum
	} else {
		panic("[GetPreviousCheckpointFromEpoch] Error while trying to get XDPoS consensus engine")
	}
}
```

### Bug 2

The function `GetCandidateStatus` does not sort candidates by stake: https://github.com/XinFinOrg/XDPoSChain/blob/master/internal/ethapi/api.go#L754-L760

```go
        candidatesAddresses := state.GetCandidates(statedb)
        for _, address := range candidatesAddresses {
            v := state.GetCandidateCap(statedb, address)
            if address.String() != "xdc0000000000000000000000000000000000000000" {
                candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
            }
        }
```

The right codes should be:

```go
        candidatesAddresses := state.GetCandidates(statedb)
        candidates = make([]utils.Masternode, 0, len(candidatesAddresses))
        for _, address := range candidatesAddresses {
            v := state.GetCandidateCap(statedb, address)
            candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
        }
        if len(candidates) > maxMasternodes {
            sort.Slice(candidates, func(i, j int) bool {
                return candidates[i].Stake.Cmp(candidates[j].Stake) > 0
            })
        }
```

The function `GetCandidates` does not sort candidates by stake also. This bug maybe causes wrong "SLASHED" status, such as:

- marks "PROPOSED" status as "SLASHED" status
- marks "SLASHED" status as "PROPOSED" status

### Bug 3

The function `GetCandidates` checks 15 top candidates only, not 108: https://github.com/XinFinOrg/XDPoSChain/blob/master/internal/ethapi/api.go#L942-L948

```go
    var topCandidates []utils.Masternode
    if len(candidates) > common.MaxMasternodes {
        topCandidates = candidates[:common.MaxMasternodes]
    } else {
        topCandidates = candidates
    }
```

The right codes should be:

```go
    var maxMasternodes int
    if s.b.ChainConfig().IsTIPIncreaseMasternodes(block.Number()) {
        maxMasternodes = common.MaxMasternodesV2
    } else {
        maxMasternodes = common.MaxMasternodes
    }

    var topCandidates []utils.Masternode
    if len(candidates) > maxMasternodes {
        sort.Slice(candidates, func(i, j int) bool {
            return candidates[i].Stake.Cmp(candidates[j].Stake) > 0
        })
        topCandidates = candidates[:maxMasternodes]
    } else {
        topCandidates = candidates
    }
```

This bug causes the response of `eth_getCandidates` lacks slashed nodes sometimes, such as:

```bash
export SERVER="https://arpc.xinfin.network/"
export EPOCH=68576

curl -s -X POST -H "Content-Type: application/json" ${SERVER} -d '
{
  "jsonrpc": "2.0",
  "id": 2005,
  "method": "eth_getCandidates",
  "params": [
    "'"$(printf 0x%x ${EPOCH})"'"
  ]
}' | jq
```

The above command only returns 106 `MASTERNODE` nodes and 0 `SLASHED` nodes, the total quantity is not 108. After apply this PR, the result includes 106 `MASTERNODE` nodes and 1 `SLASHED` nodes.

### Bug 4

Both of function `eth_getCandidates` and `eth_getCandidateStatus` didn't handle the case that the masternode is not candidate:
https://github.com/XinFinOrg/XDPoSChain/blob/master/internal/ethapi/api.go#L914-L918

```go
    for _, masternode := range masternodes {
        if candidatesStatusMap[masternode.String()] != nil {
            candidatesStatusMap[masternode.String()][fieldStatus] = statusMasternode
        }
    }
```

I found that `candidatesStatusMap[masternode.String()] == nil` somtimes, such as:

| checkpointNumber |      masternode which is not candidate      |
| :--------------: | :-----------------------------------------: |
|     59507100     | xdc296F771674987B4d465E3563dAf2A75bfce811b6 |
|     59507100     | xdcb1EFD51De35f2966c770Cd35B953f4FDADE3c3E8 |
|     60991200     | xdcc98159feD7eE13D769f36D894E56db4061900485 |
|     61386300     | xdc785ec59C0F72Eccd094BE2429a47fF6Ad45b585D |
|     61386300     | xdc886e4E46b549c690fd069AB89c195B1bE62DbEE3 |
|     61386300     | xdcCBA3656A88647B475650CC000672adddAfC21b5D |

If the masternodes are right, this bug causes some masternodes are missing in the response. The reason of this bug needs further research. Maybe the below code:

```go
candidatesAddresses := state.GetCandidates(statedb)
```

returns the wrong `candidatesAddresses`.

### Bug 5

The signers are sorted by the unstable function `sort.Slice`.

https://github.com/XinFinOrg/XDPoSChain/blob/master/core/blockchain.go#L2489-L2491

```go
        sort.Slice(ms, func(i, j int) bool {
            return ms[i].Stake.Cmp(ms[j].Stake) >= 0
        })
```

https://github.com/XinFinOrg/XDPoSChain/blob/master/internal/ethapi/api.go#L1017-L1019

```go
            sort.Slice(candidatesWithStakeInfo, func(i, j int) bool {
                return candidatesWithStakeInfo[i].Stake.Cmp(candidatesWithStakeInfo[j].Stake) >= 0
            })
```

https://github.com/XinFinOrg/XDPoSChain/blob/master/eth/hooks/engine_v1_hooks.go#L246-L251

```go
        sort.Slice(candidates, func(i, j int) bool {
            return candidates[i].Stake.Cmp(candidates[j].Stake) >= 0
        })
        if len(candidates) > 150 {
            candidates = candidates[:150]
        }
```

There are many signers with same stake value. eg: the signer's stake value is 10000000000000000000000000 before and after 108th poistion. The right codes should be:

```go
        sort.Slice(ms, func(i, j int) bool {
            c := ms[i].Stake.Cmp(ms[j].Stake)
            return c > 0 || (c == 0 && bytes.Compare(ms[i].Address[:], ms[j].Address[:]) > 0)
        })
```

```go
        sort.Slice(candidates, func(i, j int) bool {
            c := candidates[i].Stake.Cmp(candidates[j].Stake)
            return c > 0 || (c == 0 && bytes.Compare(candidates[i].Address[:], candidates[j].Address[:]) > 0)
        })
```

```go
        sort.Slice(candidates, func(i, j int) bool {
            c := candidates[i].Stake.Cmp(candidates[j].Stake)
            return c > 0 || (c == 0 && bytes.Compare(candidates[i].Address[:], candidates[j].Address[:]) > 0)
        })
        if len(candidates) > maxMasternodes {
            candidates = candidates[:maxMasternodes]
        }
```

## About this PR

This PR fixes the above bugs 1-4, so it makes:

- `eth_getCandidateStatus` output the right status for a candidate
- `eth_getCandidates` returns the right MASTERNODE and SLASHED list, the total count of MASTERNODE and SLASHED is 108.

The 5th bug affects masternodes, and it is it is releated to sync, such as the issue #268. I will make some new sync tests, then submit another PR to fix the 5th bug later.

My test script file is as follows:

```bash
#!/bin/bash

SERVER="http://localhost:8545/"

for (( BLOCK = 59175000, EPOCH = 65750; ; EPOCH++, BLOCK+=900 )); do
  RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" ${SERVER} -d '
  {
    "jsonrpc": "2.0",
    "id": 2005,
    "method": "eth_getCandidates",
    "params": [
      "'"$(printf 0x%x ${EPOCH})"'"
    ]
  }')

  MASTERNODE=$(echo ${RESPONSE} | grep -o "MASTERNODE" | wc -l)
  SLASHED=$(echo ${RESPONSE} | grep -o "SLASHED" | wc -l)
  TOTAL=$(expr ${MASTERNODE} + ${SLASHED})

  echo "B=${BLOCK} E=${EPOCH} M=${MASTERNODE} S=${SLASHED} T=${TOTAL}"

  if [ ${MASTERNODE} == 0 ]; then
    break
  fi
done

LATEST=$(curl -s -X POST -H "Content-Type: application/json" ${SERVER} -d '
{
  "jsonrpc": "2.0",
  "id": 2004,
  "method": "eth_getCandidates",
  "params": [
    "latest"
  ]
}')

EPOCH=$(echo ${LATEST} | jq ".result.epoch")
MASTERNODE=$(echo ${LATEST} | grep -o "MASTERNODE" | wc -l)
SLASHED=$(echo ${LATEST} | grep -o "SLASHED" | wc -l)
TOTAL=$(expr ${MASTERNODE} + ${SLASHED})
echo "LATEST E=${EPOCH} M=${MASTERNODE} S=${SLASHED} T=${TOTAL}"
```
