### PR TITLE
make sync mode full to avoid race condition

### DIFF
--- a/cicd/devnet/start.sh
+++ b/cicd/devnet/start.sh
@@ -55,7 +55,7 @@ echo "Starting nodes with $bootnodes ..."
 # Note: --gcmode=archive means node will store all historical data. This will lead to high memory usage. Only needed if you need the node to perform historical operations
 XDC --ethstats ${netstats} --gcmode=full \
 --nat extip:${INSTANCE_IP} \
---bootnodes ${bootnodes} --syncmode fast \
+--bootnodes ${bootnodes} --syncmode full \
 --datadir /work/xdcchain --networkid 551 \
 -port 30303 --rpc --rpccorsdomain "*" --rpcaddr 0.0.0.0 \
 --rpcport 8545 \


### PR DESCRIPTION
## Proposed changes
Make Sync Mode Full to Avoid Race Condition.

## Issue Root Cause
The Fast Sync mode doesn't handle verify headers properly. It will download lots of headers but those headers doesn't save into disk yet. We need to fix it issue or Just use Sync Full mode to avoid this behaviour.

## Issue Log:
```
August 07, 2023 at 12:24 (UTC+4:00)	panic: runtime error: invalid memory address or nil pointer dereference	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6daffa]	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	goroutine 54169 [running]:	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/core/types.(*Block).Hash(0x0, 0x0, 0x0, 0x0, 0x0)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/core/types/block.go:420 +0x4a	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/core/state.GetSigners(0xc00e9e6780, 0x0, 0xd8d6c2147d0c2503, 0x310b38d628a5a619, 0x23f44e96510941e8)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/core/state/statedb_utils.go:22 +0x81	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/contracts.GetSignersFromContract(...)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/contracts/utils.go:214	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/eth/hooks.AttachConsensusV1Hooks.func1(0x174ae80, 0xc0000f9440, 0x384, 0x212ae60, 0x1, 0xc00152dc00, 0xffffffffffffffff, 0x0)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/eth/hooks/engine_v1_hooks.go:45 +0x41c	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v1.(*XDPoS_v1).checkSignersOnCheckpoint(0xc0000f3760, 0x174ae80, 0xc0000f9440, 0xc00e094780, 0xc00e71f880, 0x3, 0x3, 0xc7fbc3b28d9c0725, 0xc00c271000)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/consensus/XDPoS/engines/engine_v1/engine.go:289 +0x8a0	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v1.(*XDPoS_v1).verifyCascadingFields(0xc0000f3760, 0x174ae80, 0xc0000f9440, 0xc00e094780, 0xc00c271000, 0xa3, 0x100, 0xc00e9ee200, 0x12828c0, 0xc00e9ee240)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/consensus/XDPoS/engines/engine_v1/engine.go:260 +0x217	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v1.(*XDPoS_v1).verifyHeader(0xc0000f3760, 0x174ae80, 0xc0000f9440, 0xc00e094780, 0xc00c271000, 0xa3, 0x100, 0x0, 0xc00dc6ff14, 0x0)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/consensus/XDPoS/engines/engine_v1/engine.go:218 +0x3ae	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v1.(*XDPoS_v1).verifyHeaderWithCache(0xc0000f3760, 0x174ae80, 0xc0000f9440, 0xc00e094780, 0xc00c271000, 0xa3, 0x100, 0xc4cc00, 0x0, 0x0)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/consensus/XDPoS/engines/engine_v1/engine.go:145 +0x17c	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v1.(*XDPoS_v1).VerifyHeaders.func1(0xc00c271000, 0xc0, 0x100, 0xc0000f3760, 0x174ae80, 0xc0000f9440, 0xc00e1be000, 0xc0, 0xc0, 0xc00df410e0, ...)	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/consensus/XDPoS/engines/engine_v1/engine.go:129 +0x12f	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	created by github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v1.(*XDPoS_v1).VerifyHeaders	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	/builder/consensus/XDPoS/engines/engine_v1/engine.go:127 +0xc5	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	INFO [08-07|08:24:28] Allocated fast sync bloom size=1.05mB	f6f05ff69071499fb74d3869b43dfce8	tfXdcNode
August 07, 2023 at 12:24 (UTC+4:00)	INFO [08-07|08:24:28] Initialized fast sync bloom items=0 errorrate=0.000 elapsed=1.045µs	f6f05ff69071499fb74d3869b43dfce8	tfXdcNod
```