### PR TITLE
return right blockHash in logs

### DIFF
--- a/core/database_util.go
+++ b/core/database_util.go
@@ -22,10 +22,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -259,6 +259,10 @@ func GetBlockReceipts(db DatabaseReader, hash common.Hash, number uint64) types.
 	receipts := make(types.Receipts, len(storageReceipts))
 	for i, receipt := range storageReceipts {
 		receipts[i] = (*types.Receipt)(receipt)
+		for _, log := range receipts[i].Logs {
+			// update BlockHash to fix #208
+			log.BlockHash = hash
+		}
 	}
 	return receipts
 }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -28,6 +28,7 @@ import (
 	ethereum "github.com/XinFinOrg/XDPoSChain"
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
+	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/event"
@@ -418,6 +419,10 @@ func (api *PublicFilterAPI) GetFilterChanges(id rpc.ID) (interface{}, error) {
 		case LogsSubscription:
 			logs := f.logs
 			f.logs = nil
+			for _, log := range logs {
+				// update BlockHash to fix #208
+				log.BlockHash = core.GetCanonicalHash(api.chainDb, log.BlockNumber)
+			}
 			return returnLogs(logs), nil
 		}
 	}


### PR DESCRIPTION
# Proposed changes

Fix issue #208, make below JSONRPC metheds return right blockHash in logs:

- eth_getLogs
- eth_getFilterLogs
- eth_getFilterChanges
- eth_getTransactionReceipt

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components

Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [✅] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [✅] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A

## Test cases for method `eth_getTransactionReceipt`

### Case 1: [block number 36381303](https://explorer.apothem.network/blocks/36381303#transactions)

#### 1.1 without patch

return wrong block hash: 0x194a513ea40c94fccaca470cccb24c2ff3bd6398dec9a04e3eb3a4bfef8a330e

```shell
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_getTransactionReceipt",
    "params": [
        "0xbebc0bab1a0f9844b86b8edf3a169bb1eef9337ac8d2684d5ae758b6521c12fe"
    ]
}' | jq
```

![1677553246624](https://user-images.githubusercontent.com/7695325/221742501-50836231-9439-43b3-8491-17958435a713.png)

---

#### 1.2 with patch

return right block hash: 0xe8ec0bfc021f839fd0a69ae89689e309632af2cc434e8a096732068f0736864b

```shell
curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 2,
    "jsonrpc": "2.0",
    "method": "eth_getTransactionReceipt",
    "params": [
        "0xbebc0bab1a0f9844b86b8edf3a169bb1eef9337ac8d2684d5ae758b6521c12fe"
    ]
}' | jq
```

![1677553145812](https://user-images.githubusercontent.com/7695325/221742301-dff02e25-fd99-4112-91bc-3c1ce238230f.png)

### Case 2: [block number 45631260](https://explorer.apothem.network/blocks/45631260#transactions)

#### 2.1 without patch

return wrong block hash: 0x851cb67720d6a78bef95be0148d0ef620c6daf6fd662befcccf38097f2973873

```shell
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 3,
    "jsonrpc": "2.0",
    "method": "eth_getTransactionReceipt",
    "params": [
        "0x0b1c97fabd7d7a9505e5df426ecf5f8ebbf8bae988eb64e394c177d656cb7199"
    ]
}' | jq
```

![1677551181168](https://user-images.githubusercontent.com/7695325/221737356-531e3206-2bfb-4ebe-90b3-dee09b43ea8b.png)

---

#### 2.2 with patch

return right block hash: 0xd10ca14840489e88070508428fed14f96e39ad20cc524468a0d54a221b9b87e1

```shell
curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 4,
    "jsonrpc": "2.0",
    "method": "eth_getTransactionReceipt",
    "params": [
        "0x0b1c97fabd7d7a9505e5df426ecf5f8ebbf8bae988eb64e394c177d656cb7199"
    ]
}' | jq
```

![1677551265400](https://user-images.githubusercontent.com/7695325/221737543-d2174ec7-767e-49cf-a30e-cb9558c34429.png)

## Test cases for method `eth_getLogs`

### Case 1: [block number 36381303](https://explorer.apothem.network/blocks/36381303#transactions)

#### 1.1 without patch

return wrong block hash: 0x194a513ea40c94fccaca470cccb24c2ff3bd6398dec9a04e3eb3a4bfef8a330e

```shell
curl -s -X POST https://arpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 11,
    "jsonrpc": "2.0",
    "method": "eth_getLogs",
    "params": [
        {
            "fromBlock": "0x22b2277",
            "toBlock": "0x22b2277"
        }
    ]
}' | jq
```

![1677551902935](https://user-images.githubusercontent.com/7695325/221739294-82d3492c-8b30-4004-bc7c-9b2f9786746b.png)

---

#### 1.2 with patch

return right block hash: 0xe8ec0bfc021f839fd0a69ae89689e309632af2cc434e8a096732068f0736864b

```shell
curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 12,
    "jsonrpc": "2.0",
    "method": "eth_getLogs",
    "params": [
        {
            "fromBlock": "0x22b2277",
            "toBlock": "0x22b2277"
        }
    ]
}' | jq
```

![1677552004447](https://user-images.githubusercontent.com/7695325/221739466-7744d4a7-b8b0-415f-8a65-bcc3949199f8.png)

### Case 2: block number 45631260-45631262

#### 2.1 without patch

return wrong block hash:

- [45631260](https://explorer.apothem.network/blocks/45631260#transactions): 0x851cb67720d6a78bef95be0148d0ef620c6daf6fd662befcccf38097f2973873
- [45631261](https://explorer.apothem.network/blocks/45631261#transactions): 0x2a24c1d6b6c8a08fc805022b82f1b5e91851b92476a5ed0bba174ebbcbca45a1
- [45631262](https://explorer.apothem.network/blocks/45631262#transactions): 0xfa2059b48d7df89b1c8f366953f56e87c778808e85997a9a2b0e634c7037d470

```shell
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 13,
    "jsonrpc": "2.0",
    "method": "eth_getLogs",
    "params": [
        {
            "fromBlock": "0x2b8471c",
            "toBlock": "0x2b8471e"
        }
    ]
}' | jq | grep -i block
```

![1677552118622](https://user-images.githubusercontent.com/7695325/221739767-694416e9-1fbf-4204-a1e6-ab66401a2798.png)

---

#### 2.2 with patch

return right block hash:

- [45631260](https://explorer.apothem.network/blocks/45631260#transactions): 0xd10ca14840489e88070508428fed14f96e39ad20cc524468a0d54a221b9b87e1
- [45631261](https://explorer.apothem.network/blocks/45631261#transactions): 0x781d947687cdad5cb1b0022c13effc9904b70a37bf1af0afe425ccd287225794
- [45631262](https://explorer.apothem.network/blocks/45631262#transactions): 0xb6a64ba4d6ffefd8040c1fdaf3a75e6612a7346062b48a6e0ece68d57eb3f25f

```shell
curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 14,
    "jsonrpc": "2.0",
    "method": "eth_getLogs",
    "params": [
        {
            "fromBlock": "0x2b8471c",
            "toBlock": "0x2b8471e"
        }
    ]
}' | jq | grep -i block
```

![1677552396632](https://user-images.githubusercontent.com/7695325/221740394-b0166ed9-a64c-40d3-b60d-705f41ba07ef.png)

## Test cases for method `eth_getFilterLogs`

### case 1: block number 45838897-45838899

#### 1.1 without patch

return wrong block hash:

```shell
# create a filter
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 111,
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params":[
        {
            "fromBlock": "0x2bb7231",
            "toBlock": "0x2bb7233"
        }
    ]
}' | jq

# 0x6e12f3f9faae153addcac28b33ede959 is filter id in above response, replace it with your actual value
FILTER_ID="0xaf54be244f6c1e2b927324f1882ebf46"

curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 112,
    "method": "eth_getFilterLogs",
    "params": ["'"${FILTER_ID}"'"]
}' | jq | grep block
```

![1677906265755](https://user-images.githubusercontent.com/7695325/222876967-fe80b591-9096-4ce3-a4e1-6b5f0ebbd3f9.png)

| block number                                                              | right block hash                                                   | return wrong block hash                                            |
| :------------------------------------------------------------------------ | :----------------------------------------------------------------- | :----------------------------------------------------------------- |
| [45838897](https://explorer.apothem.network/blocks/45838897#transactions) | 0x1a7ed2982008d515dfe6f9b779be673268d9ec84d95cf254963b8c8c0f496dee | 0x0e3bef8f80d6194dd6da777e6d275b8632d4c8ec2bd8396e75159effebd9cd2b |
| [45838898](https://explorer.apothem.network/blocks/45838898#transactions) | 0x24b3018c78198ba2e4eb86b4a02eb5e06ea9230974b676c241ccc516ba8caf3c | 0x55ecfa357b1d699294dcf9bc1ea935d5aa44a771011964f3470efe976944b8ac |
| [45838899](https://explorer.apothem.network/blocks/45838899#transactions) | 0x00743071dc87ea3de489b53218b12d0c39fea13a3192a67c521556743d60b11b | 0x4dea4cda26b661c4d17fdf496a5e72be48ada092a789979d29b8498af8e64c32 |

---

#### 1.2 with patch

return right block hash:

```shell
# create a filter
curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 113,
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params": [
        {
            "fromBlock": "0x2bb7231",
            "toBlock": "0x2bb7233"
        }
    ]
}' | jq

# 0x810ef8bf7733dd95ef52174b7b7ed676 is filter id in above response, replace it with your actual value
FILTER_ID="0x810ef8bf7733dd95ef52174b7b7ed676"

curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 114,
    "method": "eth_getFilterLogs",
    "params": ["'"${FILTER_ID}"'"]
}' | jq | grep block
```

![1677906852691](https://user-images.githubusercontent.com/7695325/222877281-f33e55c0-f047-41ae-b3c5-aa9d7b5cf869.png)

| block number                                                              | right block hash                                                   |
| :------------------------------------------------------------------------ | :----------------------------------------------------------------- |
| [45838897](https://explorer.apothem.network/blocks/45838897#transactions) | 0x1a7ed2982008d515dfe6f9b779be673268d9ec84d95cf254963b8c8c0f496dee |
| [45838898](https://explorer.apothem.network/blocks/45838898#transactions) | 0x24b3018c78198ba2e4eb86b4a02eb5e06ea9230974b676c241ccc516ba8caf3c |
| [45838899](https://explorer.apothem.network/blocks/45838899#transactions) | 0x00743071dc87ea3de489b53218b12d0c39fea13a3192a67c521556743d60b11b |

## Test cases for method `eth_getFilterChanges`

### without patch

```shell
# create a filter
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 1111,
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params": [
        {}
    ]
}' | jq

# 0x68ce60ffdb0c9480c307b0c3d2ae9391 is filter id in above response, replace it with your actual value
FILTER_ID="0x68ce60ffdb0c9480c307b0c3d2ae9391"

curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 1112,
    "method": "eth_getFilterChanges",
    "params": ["'"${FILTER_ID}"'"]
}' | jq | grep block
```

![1677902592177](https://user-images.githubusercontent.com/7695325/222874821-32af385b-53d7-4bb9-9a86-ef0d414b109e.png)

| block number                                                              | right block hash                                                   | return wrong block hash                                            |
| :------------------------------------------------------------------------ | :----------------------------------------------------------------- | :----------------------------------------------------------------- |
| [46012631](https://explorer.apothem.network/blocks/46012631#transactions) | 0xc9c375a8758d9b50c5292b714d99b8372ab45b9ec138d7187d31be0cb4ce8293 | 0xd288fc1f08a68188d31879f91b43bb640cbbe64248bea8956f7c2e188d0f9b35 |
| [46012632](https://explorer.apothem.network/blocks/46012632#transactions) | 0x4519feb874b65166614ad9051f3bfec2119c1e7c5a17a66cc6b34263b7150201 | 0x5699860a5f43dbb8df294a0d289a8e92921977e447562aaea96b2e9146b827fe |
| [46012633](https://explorer.apothem.network/blocks/46012633#transactions) | 0x98ca3c24ca35bbea26a646b0c5044d0e417f644ad4859e569d7c227d5f8322e1 | 0x5e453ed091a11ccb8472d297e315dc24a14cd46a59f95d330f86b6e8ddf85b5a |
| [46012634](https://explorer.apothem.network/blocks/46012634#transactions) | 0x4d73756f56dfbe96897e5fca1db730dcadd712d0c24e23acc738ccfeb50f610e | 0xc02434f03580ec7b7477537df81f009aa8474043a6b947c32bacb4614d5aac0f |
| [46012635](https://explorer.apothem.network/blocks/46012635#transactions) | 0x6460dc32d700bb9af70537a4b04af0c6dd088b741fdc5bbab12a2bf3b08ea678 | 0x31883a10bcdfa46cd4802f7358fe6791059963451e9aba2095c29b3d1ebc81b5 |
| [46012636](https://explorer.apothem.network/blocks/46012636#transactions) | 0xbe7584e54ed359814f38453eee00a029bc3136a30b005e448e0f078f6b1ad4dc | 0x34ab5bee1cfded4a7bb0b3f221f6e576c42aa115d0c89a47f37ccf90806e2f2c |
| [46012637](https://explorer.apothem.network/blocks/46012637#transactions) | 0xc73c19ba416affd8c516c4781008a5630809abfaaecd831a8b7bef8cf66bec65 | 0xe9371b3c728e110eb1a6288b27cdd9035b66d9bec470a0bd5dcfa009e4c09282 |
| [46012638](https://explorer.apothem.network/blocks/46012638#transactions) | 0xb0a80f91ccd7d4965fe88b234c62629c2c14ed1ebdb331ab8acdfdf8e82647dc | 0x632c8f424752d6b365f27e8c6131f9c92849284df070050a692750841c78b4e7 |
| [46012639](https://explorer.apothem.network/blocks/46012639#transactions) | 0x9a37917fefa343b9804d6d99ffa054a1428167cdce6ba067657a65b4d1902862 | 0xcc7220f6363610b4d66ce34d8218b52947d678e05a408d8574349febf3f4c852 |

### with patch

```shell
# create a filter
curl -s -X POST http://103.101.129.240:8545/ -H "Content-Type: application/json" -d '
{
    "id": 1113,
    "jsonrpc": "2.0",
    "method": "eth_newFilter",
    "params": [
        {}
    ]
}' | jq

# 0x8936ced335de251e1211799d7550b7ca is filter id in above response, replace it with your actual value
FILTER_ID="0x8936ced335de251e1211799d7550b7ca"

curl -s -X POST http://103.101.129.240:8545/  -H "Content-Type: application/json" -d '
{
    "id": 1114,
    "method": "eth_getFilterChanges",
    "params": ["'"${FILTER_ID}"'"]
}' | jq | grep block
```

![1677904808735](https://user-images.githubusercontent.com/7695325/222876049-68cd4847-a8fd-41c8-970e-f8a6f0e1bd28.png)

|                               block number                                |                          right block hash                          |
| :-----------------------------------------------------------------------: | :----------------------------------------------------------------: |
| [46013738](https://explorer.apothem.network/blocks/46013738#transactions) | 0xe2e20073ab2eb0cb7ee76fd744e01a90e9c15ab14473f577429e69bea2635812 |
| [46013739](https://explorer.apothem.network/blocks/46013739#transactions) | 0xd681e4a7e8d0d74a6ab235b5adebdf4b187fe52284a91531fb223f9adf1913f8 |
| [46013740](https://explorer.apothem.network/blocks/46013740#transactions) | 0x412062ec3a890e0f3b4bda0cad82804f63cc2c3383bea1e873eb904978522ade |
