### PR TITLE
EstimateGas support the latest hardhat

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1206,7 +1206,7 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNr r
 
 // EstimateGas returns an estimate of the amount of gas needed to execute the
 // given transaction against the current pending block.
-func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (hexutil.Uint64, error) {
+func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Uint64, error) {
 	// Binary search the gas requirement, as it may be higher than the amount used
 	var (
 		lo  uint64 = params.TxGas - 1


### PR DESCRIPTION
# Proposed changes

This PR fixes the issue #326, make xdc blockchain supports the latest hardhat.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [✅] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components

Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [✅] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [✅] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A

## The problem

The issue #326 and [the post](https://www.xdc.dev/logeswaran/hardhat-upgradeable-proxy-support-for-xdc-bdp) reported that hardhat failed to deploy upgradeable contract to xdc blockchain. Below is the error message:

```text
yarn run v1.22.19
$ hardhat run --network apothem scripts/deployTestTokenV1.js
Deploy TestTokenV1 ...
ProviderError: too many arguments, want at most 1
    at HttpProvider.request (/home/me/erc20-hardhat/node_modules/hardhat/src/internal/core/providers/http.ts:88:21)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at HardhatEthersProvider.estimateGas (/home/me/erc20-hardhat/node_modules/@nomicfoundation/hardhat-ethers/src/internal/hardhat-ethers-provider.ts:237:27)
    at /home/me/erc20-hardhat/node_modules/@nomicfoundation/hardhat-ethers/src/signers.ts:235:35
    at async Promise.all (index 0)
    at HardhatEthersSigner._sendUncheckedTransaction (/home/me/erc20-hardhat/node_modules/@nomicfoundation/hardhat-ethers/src/signers.ts:256:7)
    at HardhatEthersSigner.sendTransaction (/home/me/erc20-hardhat/node_modules/@nomicfoundation/hardhat-ethers/src/signers.ts:125:18)
    at ContractFactory.deploy (/home/me/erc20-hardhat/node_modules/ethers/src.ts/contract/factory.ts:111:24)
    at ethersDeploy (/home/me/erc20-hardhat/node_modules/@openzeppelin/hardhat-upgrades/src/utils/deploy.ts:32:28)
    at deploy (/home/me/erc20-hardhat/node_modules/@openzeppelin/hardhat-upgrades/src/utils/deploy.ts:24:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I found the user is using @openzeppelin/hardhat-upgrades v2 and ethers v6. The problem was gone after downgrade to @openzeppelin/hardhat-upgrades v1 and ethers v5, so the user closed this issue. There are same issues in hardhat's repository:

- https://github.com/NomicFoundation/hardhat/issues/4010
- https://github.com/NomicFoundation/hardhat/issues/4332

## Further research

The error `too many arguments, want at most 1` is reported by the function `parsePositionalArguments` in file rpc/json.go:

```go
func parsePositionalArguments(rawArgs json.RawMessage, types []reflect.Type) ([]reflect.Value, Error) {
	// Read beginning of the args array.
	dec := json.NewDecoder(bytes.NewReader(rawArgs))
	if tok, _ := dec.Token(); tok != json.Delim('[') {
		return nil, &invalidParamsError{"non-array args"}
	}
	// Read args.
	args := make([]reflect.Value, 0, len(types))
	for i := 0; dec.More(); i++ {
		if i >= len(types) {
			return nil, &invalidParamsError{fmt.Sprintf("too many arguments, want at most %d", len(types))}
		}
```

I debugged the input parameter `rawArgs` in my development environment, found is error is triggered by an extra field "pending" in `rawArgs` array:

- When use @openzeppelin/hardhat-upgrades v2 and ethers v6, `rawArgs` has a field "pending":

```json
[
  {
    "from": "<address>",
    "data": "<data>"
  },
  "pending"
]
```

- When use @openzeppelin/hardhat-upgrades v1 and ethers v5, `rawArgs` has no field "pending":

```json
[
  {
    "from": "<address>",
    "data": "<data>"
  }
]
```

It is that xdc blockchain can't handle the extra field "pending".

## More tests

From the output of hardhat, it's `estimateGas` trigger the error. The following tests showed that the method eth_estimateGas does not support "pending", but the method eth_call support "pending".

### 1. test eth_estimateGas with field "pending"

request:

```bash
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "eth_estimateGas",
    "params": [
        {
            "data": "0x06fdde03",
            "to": "0x53350795c11cee781a7e174479778f848d76ab2a"
        },
        "pending"
    ]
}' | jq
```

respond with error:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32602,
    "message": "too many arguments, want at most 1"
  }
}
```

### 2. test eth_estimateGas without field "pending"

request:

```bash
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 2,
    "jsonrpc": "2.0",
    "method": "eth_estimateGas",
    "params": [
        {
            "data": "0x06fdde03",
            "to": "0x53350795c11cee781a7e174479778f848d76ab2a"
        }
    ]
}' | jq
```

works fine:

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "result": "0x5fd5"
}
```

### 3. test eth_call with field "pending"

request:

```bash
curl -s -X POST https://erpc.apothem.network/ -H "Content-Type: application/json" -d '
{
    "id": 3,
    "jsonrpc": "2.0",
    "method": "eth_call",
    "params": [
        {
            "data": "0x06fdde03",
            "to": "0x53350795c11cee781a7e174479778f848d76ab2a"
        },
        "pending"
    ]
}' | jq
```

works fine:

```json
{
  "jsonrpc": "2.0",
  "id": 3,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f44656d6f20476f6c6420546f6b656e0000000000000000000000000000000000"
}
```

## How to test this PR

### 1. prepare the environment

Use nodejs v16 and yarn v1.

```bash
sudo apt install -y curl jq
git clone https://github.com/gzliudan/erc20-hardhat.git
cd erc20-hardhat.git

# set DEPLOYER_PRIVATE_KEY in file .env
cp env.sample .env
vi .env

# set DEV_RPC_URL according to your environment
# here I use http://127.0.0.1:8545 for test with my private network
export DEV_RPC_URL="http://127.0.0.1:8545"
```

### 2. Test @openzeppelin/hardhat-upgrades v2 and ethers v6

Clean environment:

```bash
git checkout main
rm -rf node_modules deploy/dev.json
yarn
yarn clean && yarn compile
```

Deploy an upgradeable contract `TestTokenV1`:

```bash
yarn deploy-token-v1:dev
```

Upgrade contract `TestTokenV1` to `TestTokenV2`:

```bash
yarn deploy-token-v2:dev
```

Test method eth_estimateGas:

```bash
./scripts/test-estimate-gas.sh
```

The all outputs are normal.

### 3. Test @openzeppelin/hardhat-upgrades v1 and ethers v5

Clean environment:

```bash
git checkout ethers-v5
rm -rf node_modules deploy/dev.json
yarn
yarn clean && yarn compile
```

Deploy an upgradeable contract `TestTokenV1`:

```bash
yarn deploy-token-v1:dev
```

Upgrade contract `TestTokenV1` to `TestTokenV2`:

```bash
yarn deploy-token-v2:dev
```

Test method eth_estimateGas:

```bash
./scripts/test-estimate-gas.sh
```

The all outputs are normal.
