### PR TITLE
current testnet masternode in smart contract is 15

### DIFF
--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -15,7 +15,7 @@ const (
 	EpocBlockOpening           = 850
 	EpocBlockRandomize         = 900
 	MaxMasternodes             = 18
-	MaxMasternodesV2           = 10
+	MaxMasternodesV2           = 15
 	LimitPenaltyEpoch          = 4
 	LimitPenaltyEpochV2        = 0
 	BlocksPerYearTest          = uint64(200000)


### PR DESCRIPTION
# Proposed changes
Update masternode number to correct number to avoid. Otherwise we have issue on old node having different snapshot then latest one.
