### PR TITLE
Optimize address comparison and empty address

### DIFF
--- a/XDCx/XDCx.go
+++ b/XDCx/XDCx.go
@@ -597,7 +597,7 @@ func (XDCx *XDCX) GetTriegc() *prque.Prque {
 func (XDCx *XDCX) GetTradingStateRoot(block *types.Block, author common.Address) (common.Hash, error) {
 	for _, tx := range block.Transactions() {
 		from := *(tx.From())
-		if tx.To() != nil && tx.To().Hex() == common.TradingStateAddr && from.String() == author.String() {
+		if tx.To() != nil && tx.To().Hex() == common.TradingStateAddr && from == author {
 			if len(tx.Data()) >= 32 {
 				return common.BytesToHash(tx.Data()[:32]), nil
 			}

--- a/XDCx/order_processor.go
+++ b/XDCx/order_processor.go
@@ -2,10 +2,11 @@ package XDCx
 
 import (
 	"encoding/json"
-	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"math/big"
 	"strconv"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 
 	"github.com/XinFinOrg/XDPoSChain/consensus"
 
@@ -373,7 +374,7 @@ func (XDCx *XDCX) getTradeQuantity(quotePrice *big.Int, coinbase common.Address,
 	if makerOrder.QuoteToken.String() == common.XDCNativeAddress {
 		quotePrice = quoteTokenDecimal
 	}
-	if takerOrder.ExchangeAddress.String() == makerOrder.ExchangeAddress.String() {
+	if takerOrder.ExchangeAddress == makerOrder.ExchangeAddress {
 		if err := tradingstate.CheckRelayerFee(takerOrder.ExchangeAddress, new(big.Int).Mul(common.RelayerFee, big.NewInt(2)), statedb); err != nil {
 			log.Debug("Reject order Taker Exchnage = Maker Exchange , relayer not enough fee ", "err", err)
 			return tradingstate.Zero, false, nil, nil

--- a/XDCxlending/XDCxlending.go
+++ b/XDCxlending/XDCxlending.go
@@ -706,7 +706,7 @@ func (l *Lending) GetTriegc() *prque.Prque {
 func (l *Lending) GetLendingStateRoot(block *types.Block, author common.Address) (common.Hash, error) {
 	for _, tx := range block.Transactions() {
 		from := *(tx.From())
-		if tx.To() != nil && tx.To().Hex() == common.TradingStateAddr && from.String() == author.String() {
+		if tx.To() != nil && tx.To().Hex() == common.TradingStateAddr && from == author {
 			if len(tx.Data()) >= 64 {
 				return common.BytesToHash(tx.Data()[32:]), nil
 			}

--- a/XDCxlending/lendingstate/common.go
+++ b/XDCxlending/lendingstate/common.go
@@ -2,16 +2,15 @@ package lendingstate
 
 import (
 	"encoding/json"
-	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"math/big"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
 )
 
 var (
-	EmptyAddress = "xdc0000000000000000000000000000000000000000"
-	EmptyRoot    = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+	EmptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 )
 
 var EmptyHash = common.Hash{}

--- a/XDCxlending/lendingstate/lendingitem.go
+++ b/XDCxlending/lendingstate/lendingitem.go
@@ -244,13 +244,13 @@ func (l *LendingItem) VerifyLendingSide() error {
 }
 
 func (l *LendingItem) VerifyCollateral(state *state.StateDB) error {
-	if l.CollateralToken.IsZero() || l.CollateralToken.String() == l.LendingToken.String() {
+	if l.CollateralToken.IsZero() || l.CollateralToken == l.LendingToken {
 		return fmt.Errorf("invalid collateral %s", l.CollateralToken.Hex())
 	}
 	validCollateral := false
 	collateralList, _ := GetCollaterals(state, l.Relayer, l.LendingToken, l.Term)
 	for _, collateral := range collateralList {
-		if l.CollateralToken.String() == collateral.String() {
+		if l.CollateralToken == collateral {
 			validCollateral = true
 			break
 		}

--- a/XDCxlending/lendingstate/lendingitem.go
+++ b/XDCxlending/lendingstate/lendingitem.go
@@ -2,14 +2,15 @@ package lendingstate
 
 import (
 	"fmt"
+	"math/big"
+	"strconv"
+	"time"
+
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto/sha3"
 	"github.com/globalsign/mgo/bson"
-	"math/big"
-	"strconv"
-	"time"
 )
 
 const (
@@ -243,7 +244,7 @@ func (l *LendingItem) VerifyLendingSide() error {
 }
 
 func (l *LendingItem) VerifyCollateral(state *state.StateDB) error {
-	if l.CollateralToken.String() == EmptyAddress || l.CollateralToken.String() == l.LendingToken.String() {
+	if l.CollateralToken.IsZero() || l.CollateralToken.String() == l.LendingToken.String() {
 		return fmt.Errorf("invalid collateral %s", l.CollateralToken.Hex())
 	}
 	validCollateral := false

--- a/XDCxlending/order_processor.go
+++ b/XDCxlending/order_processor.go
@@ -445,7 +445,7 @@ func (l *Lending) getLendQuantity(
 	if err != nil || collateralTokenDecimal.Sign() == 0 {
 		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal. Token: %v . Err: %v", collateralToken.String(), err)
 	}
-	if takerOrder.Relayer.String() == makerOrder.Relayer.String() {
+	if takerOrder.Relayer == makerOrder.Relayer {
 		if err := lendingstate.CheckRelayerFee(takerOrder.Relayer, new(big.Int).Mul(common.RelayerLendingFee, big.NewInt(2)), statedb); err != nil {
 			log.Debug("Reject order Taker Exchnage = Maker Exchange , relayer not enough fee ", "err", err)
 			return lendingstate.Zero, lendingstate.Zero, false, nil, nil
@@ -772,10 +772,10 @@ func (l *Lending) ProcessTopUp(lendingStateDB *lendingstate.LendingStateDB, stat
 	if lendingTrade == lendingstate.EmptyLendingTrade {
 		return fmt.Errorf("process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex()), true, nil
 	}
-	if order.UserAddress.String() != lendingTrade.Borrower.String() {
+	if order.UserAddress != lendingTrade.Borrower {
 		return fmt.Errorf("ProcessTopUp: invalid userAddress . UserAddress: %s . Borrower: %s", order.UserAddress.Hex(), lendingTrade.Borrower.Hex()), true, nil
 	}
-	if order.Relayer.String() != lendingTrade.BorrowingRelayer.String() {
+	if order.Relayer != lendingTrade.BorrowingRelayer {
 		return fmt.Errorf("ProcessTopUp: invalid relayerAddress . Got: %s . Expect: %s", order.Relayer.Hex(), lendingTrade.BorrowingRelayer.Hex()), true, nil
 	}
 	if order.Quantity.Sign() <= 0 || lendingTrade.TradeId != lendingTradeId.Big().Uint64() {
@@ -793,10 +793,10 @@ func (l *Lending) ProcessRepay(header *types.Header, chain consensus.ChainContex
 	if lendingTrade == lendingstate.EmptyLendingTrade || lendingTrade.TradeId != lendingTradeIdHash.Big().Uint64() {
 		return nil, fmt.Errorf("ProcessRepay for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId)
 	}
-	if order.UserAddress.String() != lendingTrade.Borrower.String() {
+	if order.UserAddress != lendingTrade.Borrower {
 		return nil, fmt.Errorf("ProcessRepay: invalid userAddress . UserAddress: %s . Borrower: %s", order.UserAddress.Hex(), lendingTrade.Borrower.Hex())
 	}
-	if order.Relayer.String() != lendingTrade.BorrowingRelayer.String() {
+	if order.Relayer != lendingTrade.BorrowingRelayer {
 		return nil, fmt.Errorf("ProcessRepay: invalid relayerAddress . Got: %s . Expect: %s", order.Relayer.Hex(), lendingTrade.BorrowingRelayer.Hex())
 	}
 	return l.ProcessRepayLendingTrade(header, chain, lendingStateDB, statedb, tradingstateDB, lendingBook, lendingTradeId)

--- a/XDCxlending/order_processor.go
+++ b/XDCxlending/order_processor.go
@@ -3,6 +3,8 @@ package XDCxlending
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
+
 	"github.com/XinFinOrg/XDPoSChain/XDCx/tradingstate"
 	"github.com/XinFinOrg/XDPoSChain/XDCxlending/lendingstate"
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -10,7 +12,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
-	"math/big"
 )
 
 func (l *Lending) CommitOrder(header *types.Header, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, lendingStateDB *lendingstate.LendingStateDB, tradingStateDb *tradingstate.TradingStateDB, lendingOrderBook common.Hash, order *lendingstate.LendingItem) ([]*lendingstate.LendingTrade, []*lendingstate.LendingItem, error) {
@@ -262,7 +263,7 @@ func (l *Lending) processOrderList(header *types.Header, coinbase common.Address
 			collateralToken = oldestOrder.CollateralToken
 			borrowFee = lendingstate.GetFee(statedb, oldestOrder.Relayer)
 		}
-		if collateralToken.String() == lendingstate.EmptyAddress {
+		if collateralToken.IsZero() {
 			return nil, nil, nil, fmt.Errorf("empty collateral")
 		}
 		collateralPrice := common.BasePrice

--- a/common/types.go
+++ b/common/types.go
@@ -229,6 +229,16 @@ func (a Address) Format(s fmt.State, c rune) {
 	fmt.Fprintf(s, "%"+string(c), a[:])
 }
 
+// IsZero check if an address is empty
+func (a Address) IsZero() bool {
+	return a == Address{}
+}
+
+// NotZero check if an address is not empty
+func (a Address) NotZero() bool {
+	return a != Address{}
+}
+
 // Sets the address to the value of b. If b is larger than len(a) it will panic
 func (a *Address) SetBytes(b []byte) {
 	if len(b) > len(a) {

--- a/consensus/XDPoS/engines/engine_v2/snapshot.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot.go
@@ -64,7 +64,7 @@ func (s *SnapshotV2) GetMappedMasterNodes() map[common.Address]struct{} {
 
 func (s *SnapshotV2) IsMasterNodes(address common.Address) bool {
 	for _, n := range s.NextEpochMasterNodes {
-		if n.String() == address.String() {
+		if n == address {
 			return true
 		}
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2555,7 +2555,7 @@ func (bc *BlockChain) UpdateM1() error {
 			return err
 		}
 		//TODO: smart contract shouldn't return "0x0000000000000000000000000000000000000000"
-		if candidate.String() != "xdc0000000000000000000000000000000000000000" {
+		if candidate.NotZero() {
 			ms = append(ms, utils.Masternode{Address: candidate, Stake: v})
 		}
 	}

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -431,7 +431,7 @@ func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLe
 		return ErrInvalidLendingType
 	}
 	if tx.Side() == lendingstate.Borrowing {
-		if tx.CollateralToken().String() == lendingstate.EmptyAddress || tx.CollateralToken().String() == tx.LendingToken().String() {
+		if tx.CollateralToken().IsZero() || tx.CollateralToken().String() == tx.LendingToken().String() {
 			return ErrInvalidLendingCollateral
 		}
 		validCollateral := false
@@ -541,7 +541,7 @@ func (pool *LendingPool) validateBalance(cloneStateDb *state.StateDB, cloneLendi
 	// collateralPrice = BTC/USD (eg: 8000 USD)
 	// lendTokenXDCPrice: price of lendingToken in XDC quote
 	var lendTokenXDCPrice, collateralPrice, collateralTokenDecimal *big.Int
-	if collateralToken.String() != lendingstate.EmptyAddress {
+	if collateralToken.NotZero() {
 		collateralTokenDecimal, err = XDCXServ.GetTokenDecimal(pool.chain, cloneStateDb, collateralToken)
 		if err != nil {
 			return fmt.Errorf("validateOrder: failed to get collateralTokenDecimal. err: %v", err)

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -431,13 +431,13 @@ func (pool *LendingPool) validateNewLending(cloneStateDb *state.StateDB, cloneLe
 		return ErrInvalidLendingType
 	}
 	if tx.Side() == lendingstate.Borrowing {
-		if tx.CollateralToken().IsZero() || tx.CollateralToken().String() == tx.LendingToken().String() {
+		if tx.CollateralToken().IsZero() || tx.CollateralToken() == tx.LendingToken() {
 			return ErrInvalidLendingCollateral
 		}
 		validCollateral := false
 		collateralList, _ := lendingstate.GetCollaterals(cloneStateDb, tx.RelayerAddress(), tx.LendingToken(), tx.Term())
 		for _, collateral := range collateralList {
-			if tx.CollateralToken().String() == collateral.String() {
+			if tx.CollateralToken() == collateral {
 				validCollateral = true
 				break
 			}
@@ -478,10 +478,10 @@ func (pool *LendingPool) validateRepayLending(cloneStateDb *state.StateDB, clone
 	if lendingTrade == lendingstate.EmptyLendingTrade {
 		return ErrInvalidLendingTradeID
 	}
-	if tx.UserAddress().String() != lendingTrade.Borrower.String() {
+	if tx.UserAddress() != lendingTrade.Borrower {
 		return ErrInvalidLendingUserAddress
 	}
-	if tx.RelayerAddress().String() != lendingTrade.BorrowingRelayer.String() {
+	if tx.RelayerAddress() != lendingTrade.BorrowingRelayer {
 		return ErrInvalidLendingRelayer
 	}
 	if err := pool.validateBalance(cloneStateDb, cloneLendingStateDb, tx, tx.CollateralToken()); err != nil {
@@ -501,10 +501,10 @@ func (pool *LendingPool) validateTopupLending(cloneStateDb *state.StateDB, clone
 	if lendingTrade == lendingstate.EmptyLendingTrade {
 		return ErrInvalidLendingTradeID
 	}
-	if tx.UserAddress().String() != lendingTrade.Borrower.String() {
+	if tx.UserAddress() != lendingTrade.Borrower {
 		return ErrInvalidLendingUserAddress
 	}
-	if tx.RelayerAddress().String() != lendingTrade.BorrowingRelayer.String() {
+	if tx.RelayerAddress() != lendingTrade.BorrowingRelayer {
 		return ErrInvalidLendingRelayer
 	}
 	if err := pool.validateBalance(cloneStateDb, cloneLendingStateDb, tx, lendingTrade.CollateralToken); err != nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -426,7 +426,7 @@ func (tx *Transaction) IsXDCXApplyTransaction() bool {
 	if common.IsTestnet {
 		addr = common.XDCXListingSMCTestNet
 	}
-	if tx.To().String() != addr.String() {
+	if *tx.To() != addr {
 		return false
 	}
 
@@ -453,7 +453,7 @@ func (tx *Transaction) IsXDCZApplyTransaction() bool {
 	if common.IsTestnet {
 		addr = common.TRC21IssuerSMCTestNet
 	}
-	if tx.To().String() != addr.String() {
+	if *tx.To() != addr {
 		return false
 	}
 

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -238,7 +238,7 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 			if err != nil {
 				return nil, err
 			}
-			if address.String() != "xdc0000000000000000000000000000000000000000" {
+			if address.NotZero() {
 				candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
 			}
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -756,7 +756,7 @@ func (s *PublicBlockChainAPI) GetCandidateStatus(ctx context.Context, coinbaseAd
 		candidatesAddresses := state.GetCandidates(statedb)
 		for _, address := range candidatesAddresses {
 			v := state.GetCandidateCap(statedb, address)
-			if address.String() != "xdc0000000000000000000000000000000000000000" {
+			if address.NotZero() {
 				candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
 			}
 		}
@@ -882,7 +882,7 @@ func (s *PublicBlockChainAPI) GetCandidates(ctx context.Context, epoch rpc.Epoch
 		candidatesAddresses := state.GetCandidates(statedb)
 		for _, address := range candidatesAddresses {
 			v := state.GetCandidateCap(statedb, address)
-			if address.String() != "xdc0000000000000000000000000000000000000000" {
+			if address.NotZero() {
 				candidates = append(candidates, utils.Masternode{Address: address, Stake: v})
 			}
 		}
@@ -1016,7 +1016,7 @@ func (s *PublicBlockChainAPI) getCandidatesFromSmartContract() ([]utils.Masterno
 		if err != nil {
 			return []utils.Masternode{}, err
 		}
-		if candidate.String() != "xdc0000000000000000000000000000000000000000" {
+		if candidate.NotZero() {
 			candidatesWithStakeInfo = append(candidatesWithStakeInfo, utils.Masternode{Address: candidate, Stake: v})
 		}
 


### PR DESCRIPTION
# Proposed changes

This PR

- remove the literal `xdc0000000000000000000000000000000000000000`
- remove the variable `EmptyAddress` which value is "xdc0000000000000000000000000000000000000000" also in package lendingstate
- not compare 2 addresses by the function `String()`

The reasons:

- compare binary addresses directly is quicker than convert them to strings then compare strings
- decoupling the codes from address prefix

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [✅] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [✅] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
