### PR TITLE
Fix a loop closure bug in func  procFutureBlocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -987,8 +987,9 @@ func (bc *BlockChain) procFutureBlocks() {
 			if i == len(blocks)-1 && err == nil {
 				engine, ok := bc.Engine().(*XDPoS.XDPoS)
 				if ok {
+					j := i
 					go func() {
-						header := blocks[i].Header()
+						header := blocks[j].Header()
 						err = engine.HandleProposedBlock(bc, header)
 						if err != nil {
 							log.Info("[procFutureBlocks] handle proposed block has error", "err", err, "block hash", header.Hash(), "number", header.Number)


### PR DESCRIPTION
# Proposed changes

fix a bug in func `procFutureBlocks`: the loop variable i is captured by func literal

```go
		for i := range blocks {
			_, err := bc.InsertChain(blocks[i : i+1])
			// let consensus engine handle the last block (e.g. for voting)
			if i == len(blocks)-1 && err == nil {
				engine, ok := bc.Engine().(*XDPoS.XDPoS)
				if ok {
					go func() {
						header := blocks[i].Header()
						err = engine.HandleProposedBlock(bc, header)
						if err != nil {
							log.Info("[procFutureBlocks] handle proposed block has error", "err", err, "block hash", header.Hash(), "number", header.Number)
						}
					}()
				}
			}
		}
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [✅] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
