### PR TITLE
set new gas price number for testnet and mainnet

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -77,7 +77,7 @@ var BaseTopUp = big.NewInt(100)
 var BaseRecall = big.NewInt(100)
 var TIPTRC21Fee = big.NewInt(38383838)
 var TIPTRC21FeeTestnet = big.NewInt(38383838)
-var BlockNumberGas50x = big.NewInt(TIPTRC21Fee.Int64() + 30000000)
+var BlockNumberGas50x = big.NewInt(TIPTRC21Fee.Int64() + 40000000)
 var LimitTimeFinality = uint64(30) // limit in 30 block
 
 var IgnoreSignerCheckBlockArray = map[uint64]bool{

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -77,6 +77,7 @@ var BaseTopUp = big.NewInt(100)
 var BaseRecall = big.NewInt(100)
 var TIPTRC21Fee = big.NewInt(23779191)
 var TIPTRC21FeeTestnet = big.NewInt(23779191)
+var BlockNumberGas50x = big.NewInt(TIPTRC21Fee.Int64() + 40000000)
 var LimitTimeFinality = uint64(30) // limit in 30 block
 
 var IgnoreSignerCheckBlockArray = map[uint64]bool{

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 4        // Minor version component of the current release
-	VersionPatch = 9        // Patch version component of the current release
-	VersionMeta  = "beta"   // Version metadata to append to the version string
+	VersionMajor = 1       // Major version component of the current release
+	VersionMinor = 4       // Minor version component of the current release
+	VersionPatch = 10      // Patch version component of the current release
+	VersionMeta  = "beta1" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
# Proposed changes

In PR #291 the block number for testnet is not set. This PR:

- set the block number of new gas price to 63779191 for testnet 
- increases the block number of new gas price to 78383838 from 68383838 for mainnet
- bump the version to 1.4.9-beta2 from 1.4.9-beta

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [] Bugfix (non-breaking change which fixes an issue)
- [✅] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [✅] Network
- [ ] Geth
- [ ] Smart Contract
- [] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
