### PR TITLE
check v2 switch block is epoch number

### DIFF
--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -77,7 +77,7 @@ func (w *wizard) makeGenesis() {
 		genesis.Difficulty = big.NewInt(1)
 		genesis.Config.Clique = &params.CliqueConfig{
 			Period: 15,
-			Epoch:  30000,
+			Epoch:  900,
 		}
 		fmt.Println()
 		fmt.Println("How many seconds should blocks take? (default = 15)")
@@ -114,7 +114,7 @@ func (w *wizard) makeGenesis() {
 		genesis.Difficulty = big.NewInt(1)
 		genesis.Config.XDPoS = &params.XDPoSConfig{
 			Period: 15,
-			Epoch:  30000,
+			Epoch:  900,
 			Reward: 0,
 			V2: &params.V2{
 				SwitchBlock:   big.NewInt(0),

--- a/common/constants.go
+++ b/common/constants.go
@@ -36,7 +36,7 @@ var TIP2019Block = big.NewInt(1)
 var TIPSigning = big.NewInt(3000000)
 var TIPRandomize = big.NewInt(3464000)
 
-var TIPV2SwitchBlock = big.NewInt(99999999999)
+var TIPV2SwitchBlock = big.NewInt(99999999900)
 
 var TIPIncreaseMasternodes = big.NewInt(5000000) // Upgrade MN Count at Block.
 var TIPNoHalvingMNReward = big.NewInt(38383838)  // hardfork no halving masternodes reward

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -36,7 +36,7 @@ var TIP2019Block = big.NewInt(1)
 var TIPSigning = big.NewInt(3000000)
 var TIPRandomize = big.NewInt(3464000)
 
-var TIPV2SwitchBlock = big.NewInt(56000000)
+var TIPV2SwitchBlock = big.NewInt(56430000)
 
 var TIPIncreaseMasternodes = big.NewInt(5000000) // Upgrade MN Count at Block.
 var TIPNoHalvingMNReward = big.NewInt(23779191)  // hardfork no halving masternodes reward

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -17,6 +17,7 @@
 package XDPoS
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -93,6 +94,10 @@ func New(chainConfig *params.ChainConfig, db ethdb.Database) *XDPoS {
 			CurrentConfig: params.MainnetV2Configs[0],
 			AllConfigs:    params.MainnetV2Configs,
 		}
+	}
+
+	if config.V2.SwitchBlock.Uint64()%config.Epoch != 0 {
+		panic(fmt.Sprintf("v2 switch number is not epoch switch block %d", config.V2.SwitchBlock.Uint64()))
 	}
 
 	log.Info("xdc config loading", "config", config)

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -100,7 +100,7 @@ func New(chainConfig *params.ChainConfig, db ethdb.Database) *XDPoS {
 		panic(fmt.Sprintf("v2 switch number is not epoch switch block %d", config.V2.SwitchBlock.Uint64()))
 	}
 
-	log.Info("xdc config loading", "config", config)
+	log.Info("xdc config loading", "v2 config", config.V2)
 
 	minePeriodCh := make(chan int)
 

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -97,7 +97,7 @@ func New(chainConfig *params.ChainConfig, db ethdb.Database) *XDPoS {
 	}
 
 	if config.V2.SwitchBlock.Uint64()%config.Epoch != 0 {
-		panic(fmt.Sprintf("v2 switch number is not epoch switch block %d", config.V2.SwitchBlock.Uint64()))
+		panic(fmt.Sprintf("v2 switch number is not epoch switch block %d, epoch %d", config.V2.SwitchBlock.Uint64(), config.Epoch))
 	}
 
 	log.Info("xdc config loading", "v2 config", config.V2)

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -219,9 +219,10 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 			log.Error("[initial] Error while get masternodes", "error", err)
 			return err
 		}
+
 		if len(masternodes) == 0 {
-			log.Error("[initial] masternodes are empty", "v2switch", x.config.V2.SwitchBlock.Uint64(), "")
-			return err
+			log.Error("[initial] masternodes are empty", "v2switch", x.config.V2.SwitchBlock.Uint64())
+			return fmt.Errorf("masternodes are empty v2 switch number: %d", x.config.V2.SwitchBlock.Uint64())
 		}
 
 		snap := newSnapshot(lastGapNum, lastGapHeader.Hash(), masternodes)

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -164,7 +164,7 @@ func (x *XDPoS_v2) Initial(chain consensus.ChainReader, header *types.Header) er
 }
 
 func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) error {
-	log.Info("[initial] initial v2 related parameters")
+	log.Warn("[initial] initial v2 related parameters")
 
 	if x.highestQuorumCert.ProposedBlockInfo.Hash != (common.Hash{}) { // already initialized
 		log.Info("[initial] Already initialized", "x.highestQuorumCert.ProposedBlockInfo.Hash", x.highestQuorumCert.ProposedBlockInfo.Hash)
@@ -219,6 +219,11 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 			log.Error("[initial] Error while get masternodes", "error", err)
 			return err
 		}
+		if len(masternodes) == 0 {
+			log.Error("[initial] masternodes are empty", "v2switch", x.config.V2.SwitchBlock.Uint64(), "")
+			return err
+		}
+
 		snap := newSnapshot(lastGapNum, lastGapHeader.Hash(), masternodes)
 		x.snapshots.Add(snap.Hash, snap)
 		err = storeSnapshot(snap, x.db)
@@ -229,7 +234,7 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 	}
 
 	// Initial timeout
-	log.Info("[initial] miner wait period", "period", x.config.V2.CurrentConfig.MinePeriod)
+	log.Warn("[initial] miner wait period", "period", x.config.V2.CurrentConfig.MinePeriod)
 	// avoid deadlock
 	go func() {
 		x.minePeriodCh <- x.config.V2.CurrentConfig.MinePeriod
@@ -239,7 +244,7 @@ func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) er
 	x.timeoutWorker.Reset(chain)
 	x.isInitilised = true
 
-	log.Info("[initial] finish initialisation")
+	log.Warn("[initial] finish initialisation")
 
 	return nil
 }

--- a/consensus/tests/engine_v2_tests/initial_test.go
+++ b/consensus/tests/engine_v2_tests/initial_test.go
@@ -1,6 +1,7 @@
 package engine_v2_tests
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -123,4 +124,22 @@ func TestSnapshotShouldAlreadyCreatedByUpdateM1(t *testing.T) {
 	snap, err := adaptor.EngineV2.GetSnapshot(blockchain, currentBlock.Header())
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(1350), snap.Number)
+}
+
+func TestInitialWithWrongSwitchNumber(t *testing.T) {
+	b, err := json.Marshal(params.TestXDPoSMockChainConfig)
+	assert.Nil(t, err)
+	configString := string(b)
+
+	var config params.ChainConfig
+	err = json.Unmarshal([]byte(configString), &config)
+	assert.Nil(t, err)
+
+	blockchain, _, currentBlock, _, _, _ := PrepareXDCTestBlockChainForV2Engine(t, 800, &config, nil)
+	adaptor := blockchain.Engine().(*XDPoS.XDPoS)
+	header := currentBlock.Header()
+	config.XDPoS.V2.SwitchBlock = big.NewInt(800) // not epoch number
+
+	err = adaptor.EngineV2.Initial(blockchain, header)
+	assert.NotNil(t, err)
 }

--- a/params/config.go
+++ b/params/config.go
@@ -337,10 +337,6 @@ func (c *XDPoSConfig) String() string {
 }
 
 func (c *XDPoSConfig) BlockConsensusVersion(num *big.Int, extraByte []byte, extraCheck bool) string {
-	// https://github.com/XinFinOrg/XDPoSChain/pull/186
-	if extraCheck && (len(extraByte) == 0 || extraByte[0] != 2) {
-		return ConsensusEngineVersion1
-	}
 
 	if c.V2 != nil && c.V2.SwitchBlock != nil && num.Cmp(c.V2.SwitchBlock) > 0 {
 		return ConsensusEngineVersion2
@@ -362,7 +358,7 @@ func (v *V2) UpdateConfig(round uint64) {
 		}
 	}
 	// update to current config
-	log.Info("[updateV2Config] Update config", "index", index, "round", round, "SwitchRound", v.AllConfigs[index].SwitchRound)
+	log.Warn("[updateV2Config] Update config", "index", index, "round", round, "SwitchRound", v.AllConfigs[index].SwitchRound)
 	v.CurrentConfig = v.AllConfigs[index]
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -45,7 +45,7 @@ var (
 			CertThreshold:        73, // based on masternode is 108
 			TimeoutSyncThreshold: 3,
 			TimeoutPeriod:        60,
-			MinePeriod:           10,
+			MinePeriod:           2,
 		},
 	}
 
@@ -337,6 +337,7 @@ func (c *XDPoSConfig) String() string {
 }
 
 func (c *XDPoSConfig) BlockConsensusVersion(num *big.Int, extraByte []byte, extraCheck bool) string {
+	// https://github.com/XinFinOrg/XDPoSChain/pull/186
 	if extraCheck && (len(extraByte) == 0 || extraByte[0] != 2) {
 		return ConsensusEngineVersion1
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -197,7 +197,7 @@ var (
 		ConstantinopleBlock: nil,
 		XDPoS: &XDPoSConfig{
 			Period: 15,
-			Epoch:  30000,
+			Epoch:  900,
 			V2: &V2{
 				SwitchBlock:   big.NewInt(9999999999),
 				CurrentConfig: MainnetV2Configs[0],
@@ -218,8 +218,8 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllXDPoSProtocolChanges  = &ChainConfig{big.NewInt(89), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &XDPoSConfig{Period: 0, Epoch: 30000}}
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
+	AllXDPoSProtocolChanges  = &ChainConfig{big.NewInt(89), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &XDPoSConfig{Period: 0, Epoch: 900}}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 900}, nil}
 
 	// XDPoS config with v2 engine after block 901
 	TestXDPoSMockChainConfig = &ChainConfig{

--- a/params/config.go
+++ b/params/config.go
@@ -337,7 +337,6 @@ func (c *XDPoSConfig) String() string {
 }
 
 func (c *XDPoSConfig) BlockConsensusVersion(num *big.Int, extraByte []byte, extraCheck bool) string {
-
 	if c.V2 != nil && c.V2.SwitchBlock != nil && num.Cmp(c.V2.SwitchBlock) > 0 {
 		return ConsensusEngineVersion2
 	}


### PR DESCRIPTION
# Proposed changes
We have issue on test v2 on testnet which is setting up wrong switch number, this PR is for preventing same mistake on testnet and mainnet, to discover wrong number at boot stage.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A

<img width="929" alt="image" src="https://github.com/XinFinOrg/XDPoSChain/assets/17850890/eff4a457-45b9-4f5c-abac-8f0053e41506">
