### PR TITLE
call to time.Since is not deferred

### DIFF
--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -944,9 +944,10 @@ func (pool *LendingPool) removeTx(hash common.Hash) {
 // future queue to the set of pending transactions. During this process, all
 // invalidated transactions (low nonce, low balance) are deleted.
 func (pool *LendingPool) promoteExecutables(accounts []common.Address) {
-	start := time.Now()
 	log.Debug("start promoteExecutables")
-	defer log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
+	defer func(start time.Time) {
+		log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
+	}(time.Now())
 	// Gather all the accounts potentially needing updates
 	if accounts == nil {
 		accounts = make([]common.Address, 0, len(pool.queue))

--- a/core/order_pool.go
+++ b/core/order_pool.go
@@ -859,8 +859,10 @@ func (pool *OrderPool) removeTx(hash common.Hash) {
 // future queue to the set of pending transactions. During this process, all
 // invalidated transactions (low nonce, low balance) are deleted.
 func (pool *OrderPool) promoteExecutables(accounts []common.Address) {
-	start := time.Now()
-	defer log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
+	defer func(start time.Time) {
+		log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
+	}(time.Now())
+
 	// Gather all the accounts potentially needing updates
 	if accounts == nil {
 		accounts = make([]common.Address, 0, len(pool.queue))

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1045,9 +1045,11 @@ func (pool *TxPool) removeTx(hash common.Hash) {
 // future queue to the set of pending transactions. During this process, all
 // invalidated transactions (low nonce, low balance) are deleted.
 func (pool *TxPool) promoteExecutables(accounts []common.Address) {
-	start := time.Now()
 	log.Debug("start promoteExecutables")
-	defer log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
+	defer func(start time.Time) {
+		log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
+	}(time.Now())
+
 	// Gather all the accounts potentially needing updates
 	if accounts == nil {
 		accounts = make([]common.Address, 0, len(pool.queue))


### PR DESCRIPTION
# Proposed changes

This PR fix the incorrect usages of `time.Since` with `defer`. The defered function arguments are evaluated immediately. We can wrap it into an anonymous function to delay their evaluation until the defer actually gets triggered.

Wrong:
 
```go
start := time.Now()
defer log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
```

Right:

```go
defer func(start time.Time) {
    log.Debug("end promoteExecutables", "time", common.PrettyDuration(time.Since(start)))
}(time.Now())
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [✅] Not sure (Please specify below)

fix time in log messages

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
