### PR TITLE
Allow the devnet environment to auto deploy new and old code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,9 +111,13 @@ jobs:
     before_script:
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker --version  # document the version travis is using
+      - docker pull xinfinorg/devnet:latest # build the "previous" tag so that our devnet environment can run with both old and new code at the same time.
+      - docker tag xinfinorg/devnet:latest xinfinorg/devnet:previous
+      - docker rmi xinfinorg/devnet:latest
       - docker build -t xinfinorg/devnet:latest -f cicd/Dockerfile .
     script:
       - docker push xinfinorg/devnet:latest
+      - docker push xinfinorg/devnet:previous
 
   - stage: (Devnet)Terraform plan
     if: branch = dev-upgrade AND type = push AND tag IS blank


### PR DESCRIPTION
# Proposed changes
This change only apply to devnet. We intend to improve the devnet deployment automation by running both old and new code at the same time to check the backwards compatibility.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [x] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [x] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [x] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
