### PR TITLE
Skip trading lending tx for nonce increase

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -250,8 +251,11 @@ func (st *StateTransition) TransitionDb(owner common.Address) (ret []byte, usedG
 		contractAction = "contract creation"
 	} else {
 		// Increment the nonce for the next transaction
-		nonce = st.state.GetNonce(sender.Address()) + 1
-		st.state.SetNonce(sender.Address(), nonce)
+		senderAddress := sender.Address()
+		nonce = st.state.GetNonce(senderAddress)
+		if skip := types.IsSkipNonceTransaction(st.to().Address().String()); !skip {
+			st.state.SetNonce(senderAddress, nonce+1)
+		}
 		ret, st.gas, vmerr = evm.Call(sender, st.to().Address(), st.data, st.gas, st.value)
 		contractAction = "contract call"
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -357,6 +357,13 @@ func (tx *Transaction) IsSkipNonceTransaction() bool {
 	return false
 }
 
+func IsSkipNonceTransaction(address string) bool {
+	if skip := skipNonceDestinationAddress[address]; skip {
+		return true
+	}
+	return false
+}
+
 func (tx *Transaction) IsSigningTransaction() bool {
 	if tx.To() == nil {
 		return false

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -474,8 +474,6 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 		}
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer, balacne, block.Number())
-		// Set nonce to fix issue #256
-		msg.SetNonce(statedb.GetNonce(*tx.From()))
 		vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, XDCxState, api.config, vm.Config{})


### PR DESCRIPTION
# Proposed changes
Had another look of the fix from https://github.com/XinFinOrg/XDPoSChain/pull/260/files. I feel like while it fixed the "nonce too low" error but it would make the APIs and stateDB inconsistent across multiple APIs. 
From what it looks is that Xinfin's trading and lending transactions are mean to be "not incrementing the nonce" as they have their own mini version of the trading lending stateDB and its own nonce systems.

This PR is for discussion at this stage as the change to the `TransitionDb` function has very wide impact which require us to test it carefully.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)
Core stateDB change related to the trading and lending system built by Xinfin

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
