### PR TITLE
Fix nil Error in function reportBlock

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2346,7 +2346,11 @@ func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, e
 	var roundNumber = types.Round(0)
 	engine, ok := bc.Engine().(*XDPoS.XDPoS)
 	if ok {
+		var err error
 		roundNumber, err = engine.EngineV2.GetRoundNumber(block.Header())
+		if err != nil {
+			log.Error("reportBlock", "GetRoundNumber", err)
+		}
 	}
 
 	var receiptString string


### PR DESCRIPTION
# Proposed changes

This PR fix a bug in function reportBlock as reported in [post](https://www.xdc.dev/sokiaoba/bad-block-error-in-testnet-after-upgrading-to-v1410-beta2-2gp6) and issue #369:

```text
Error: <nil>
```

The Error is always nil from EngineV2. This bug is caused by the function reportBlock:

```go
func (bc *BlockChain) reportBlock(block *types.Block, receipts types.Receipts, err error) {
	bc.addBadBlock(block)

	// V2 specific logs
	config, _ := json.Marshal(bc.chainConfig)

	var roundNumber = types.Round(0)
	engine, ok := bc.Engine().(*XDPoS.XDPoS)
	if ok {
		roundNumber, err = engine.EngineV2.GetRoundNumber(block.Header())
	}

	var receiptString string
	for _, receipt := range receipts {
		receiptString += fmt.Sprintf("\t%v\n", receipt)
	}
	log.Error(fmt.Sprintf(`
########## BAD BLOCK #########
Chain config: %v

Number: %v
Hash: 0x%x
%v

Round: %v
Error: %v
##############################
`, string(config), block.Number(), block.Hash(), receiptString, roundNumber, err))
}
```

In above codes, the parameter err is reassigned to value nil by the line:

```go
roundNumber, err = engine.EngineV2.GetRoundNumber(block.Header())
```

after switch to EngineV2.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [✅] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
