### PR TITLE
Add config into network information API

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
 )
@@ -53,6 +54,7 @@ type NetworkInformation struct {
 	XDCXListingAddress         common.Address
 	XDCZAddress                common.Address
 	LendingAddress             common.Address
+	ConsensusConfigs           params.XDPoSConfig
 }
 
 type SignerTypes struct {
@@ -278,6 +280,8 @@ func (api *API) NetworkInformation() NetworkInformation {
 		info.XDCXListingAddress = common.XDCXListingSMC
 		info.XDCZAddress = common.TRC21IssuerSMC
 	}
+	info.ConsensusConfigs = *api.XDPoS.config
+
 	return info
 }
 

--- a/consensus/tests/api_test.go
+++ b/consensus/tests/api_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind/backends"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
+	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	voterKey, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee04aefe388d1e14474d32c45c72ce7b7a")
+	voterAddr   = crypto.PubkeyToAddress(voterKey.PublicKey) //xdc5F74529C0338546f82389402a01c31fB52c6f434
+)
+
+func TestConfigApi(t *testing.T) {
+
+	bc := backends.NewXDCSimulatedBackend(core.GenesisAlloc{
+		voterAddr: {Balance: new(big.Int).SetUint64(10000000000)},
+	}, 10000000, params.TestXDPoSMockChainConfig)
+
+	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
+
+	info := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).NetworkInformation()
+
+	assert.Equal(t, info.NetworkId, big.NewInt(1337))
+	assert.Equal(t, info.ConsensusConfigs.V2.CurrentConfig.MaxMasternodes, 18)
+	assert.Equal(t, info.ConsensusConfigs.V2.CurrentConfig.CertThreshold, 0.667)
+	assert.Equal(t, info.ConsensusConfigs.V2.CurrentConfig.MinePeriod, 2)
+	assert.Equal(t, info.ConsensusConfigs.V2.CurrentConfig.TimeoutSyncThreshold, 2)
+}


### PR DESCRIPTION
# Proposed changes
Adding the consensus configurations into the existing networkInformation api to help debug issues

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [✅ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ✅] API

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ✅] Tested the backwards compatibility.
- [ ✅] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
