### PR TITLE
New api to list out missed rounds miners

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -433,8 +433,7 @@ func (x *XDPoS) GetCurrentEpochSwitchBlock(chain consensus.ChainReader, blockNum
 	}
 }
 
-func (x *XDPoS) CalculateMissingRounds(chain consensus.ChainReader, hash common.Hash) (*utils.PublicApiMissedRoundsMetadata, error) {
-	header := chain.GetHeaderByHash(hash)
+func (x *XDPoS) CalculateMissingRounds(chain consensus.ChainReader, header *types.Header) (*utils.PublicApiMissedRoundsMetadata, error) {
 	switch x.config.BlockConsensusVersion(header.Number, header.Extra, ExtraFieldCheck) {
 	case params.ConsensusEngineVersion2:
 		return x.EngineV2.CalculateMissingRounds(chain, header)

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -433,6 +433,16 @@ func (x *XDPoS) GetCurrentEpochSwitchBlock(chain consensus.ChainReader, blockNum
 	}
 }
 
+func (x *XDPoS) CalculateMissingRounds(chain consensus.ChainReader, hash common.Hash) (*utils.PublicApiMissedRoundsMetadata, error) {
+	header := chain.GetHeaderByHash(hash)
+	switch x.config.BlockConsensusVersion(header.Number, header.Extra, ExtraFieldCheck) {
+	case params.ConsensusEngineVersion2:
+		return x.EngineV2.CalculateMissingRounds(chain, header)
+	default: // Default "v1"
+		return nil, fmt.Errorf("Not supported in the v1 consensus")
+	}
+}
+
 // Same DB across all consensus engines
 func (x *XDPoS) GetDb() ethdb.Database {
 	return x.db

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -279,7 +279,7 @@ func (api *API) NetworkInformation() NetworkInformation {
 /*
 An API exclusively for V2 consensus, designed to assist in troubleshooting miners by identifying who mined during their allocated term.
 */
-func (api *API) GetMissiedRoundsInEpochByBlockNum(number *rpc.BlockNumber) (*utils.PublicApiMissedRoundsMetadata, error) {
+func (api *API) GetMissedRoundsInEpochByBlockNum(number *rpc.BlockNumber) (*utils.PublicApiMissedRoundsMetadata, error) {
 	return api.XDPoS.CalculateMissingRounds(api.chain, api.getHeaderFromApiBlockNum(number))
 }
 

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -285,6 +285,13 @@ func (api *API) NetworkInformation() NetworkInformation {
 	return info
 }
 
+/*
+An API exclusively for V2 consensus, designed to assist in troubleshooting miners by identifying who mined during their allocated term.
+*/
+func (api *API) GetMissiedRoundsInEpochByBlockHash(hash common.Hash) (*utils.PublicApiMissedRoundsMetadata, error) {
+	return api.XDPoS.CalculateMissingRounds(api.chain, hash)
+}
+
 func calculateSigners(message map[string]SignerTypes, pool map[string]map[common.Hash]utils.PoolObj, masternodes []common.Address) {
 	for name, objs := range pool {
 		var currentSigners []common.Address

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -360,7 +360,7 @@ func (x *XDPoS_v2) Prepare(chain consensus.ChainReader, header *types.Header) er
 	}
 
 	if header.Coinbase != signer {
-		log.Error("[Prepare] The mined blocker header coinbase address mismatch with waller address", "headerCoinbase", header.Coinbase.Hex(), "WalletAddress", signer.Hex())
+		log.Error("[Prepare] The mined blocker header coinbase address mismatch with wallet address", "headerCoinbase", header.Coinbase.Hex(), "WalletAddress", signer.Hex())
 		return consensus.ErrCoinbaseMismatch
 	}
 

--- a/consensus/XDPoS/engines/engine_v2/mining.go
+++ b/consensus/XDPoS/engines/engine_v2/mining.go
@@ -50,6 +50,7 @@ func (x *XDPoS_v2) yourturn(chain consensus.ChainReader, round types.Round, pare
 		return false, nil
 	}
 
+	// TODO: USE BELOW FOR THE NEW API
 	leaderIndex := uint64(round) % x.config.Epoch % uint64(len(masterNodes))
 	x.whosTurn = masterNodes[leaderIndex]
 	if x.whosTurn != signer {

--- a/consensus/XDPoS/engines/engine_v2/mining.go
+++ b/consensus/XDPoS/engines/engine_v2/mining.go
@@ -50,7 +50,6 @@ func (x *XDPoS_v2) yourturn(chain consensus.ChainReader, round types.Round, pare
 		return false, nil
 	}
 
-	// TODO: USE BELOW FOR THE NEW API
 	leaderIndex := uint64(round) % x.config.Epoch % uint64(len(masterNodes))
 	x.whosTurn = masterNodes[leaderIndex]
 	if x.whosTurn != signer {

--- a/consensus/XDPoS/engines/engine_v2/utils.go
+++ b/consensus/XDPoS/engines/engine_v2/utils.go
@@ -184,19 +184,21 @@ func (x *XDPoS_v2) CalculateMissingRounds(chain consensus.ChainReader, header *t
 		if err != nil {
 			return nil, err
 		}
-		// This means there is a missing round incrementation when producing blocks
+		// This indicates that an increment in the round number is missing during the block production process.
 		if parentRound+1 != currRound {
-			// We need to loop through between parentRound and the currRound to assess which miner did not mine
-			for i := parentRound; i < currRound; i++ {
+			// We need to iterate from the parentRound to the currRound to determine which miner did not perform mining.
+			for i := parentRound + 1; i < currRound; i++ {
 				leaderIndex := uint64(i) % x.config.Epoch % uint64(len(masternodes))
-				whosTerm := masternodes[leaderIndex]
+				whosTurn := masternodes[leaderIndex]
 				missedRounds = append(
 					missedRounds,
 					utils.MissedRoundInfo{
 						Round:            i,
-						Miner:            whosTerm,
+						Miner:            whosTurn,
 						CurrentBlockHash: nextHeader.Hash(),
+						CurrentBlockNum:  nextHeader.Number,
 						ParentBlockHash:  parentHeader.Hash(),
+						ParentBlockNum:   parentHeader.Number,
 					},
 				)
 			}

--- a/consensus/XDPoS/engines/engine_v2/utils.go
+++ b/consensus/XDPoS/engines/engine_v2/utils.go
@@ -163,3 +163,52 @@ func (x *XDPoS_v2) GetSignersFromSnapshot(chain consensus.ChainReader, header *t
 	snap, err := x.getSnapshot(chain, header.Number.Uint64(), false)
 	return snap.NextEpochMasterNodes, err
 }
+
+func (x *XDPoS_v2) CalculateMissingRounds(chain consensus.ChainReader, header *types.Header) (*utils.PublicApiMissedRoundsMetadata, error) {
+	var missedRounds []utils.MissedRoundInfo
+	switchInfo, err := x.getEpochSwitchInfo(chain, header, header.Hash())
+	if err != nil {
+		return nil, err
+	}
+	masternodes := switchInfo.Masternodes
+
+	// Loop through from the epoch switch block to the current "header" block
+	nextHeader := header
+	for nextHeader.Number.Cmp(switchInfo.EpochSwitchBlockInfo.Number) > 0 {
+		parentHeader := chain.GetHeaderByHash(nextHeader.ParentHash)
+		parentRound, err := x.GetRoundNumber(parentHeader)
+		if err != nil {
+			return nil, err
+		}
+		currRound, err := x.GetRoundNumber(nextHeader)
+		if err != nil {
+			return nil, err
+		}
+		// This means there is a missing round incrementation when producing blocks
+		if parentRound+1 != currRound {
+			// We need to loop through between parentRound and the currRound to assess which miner did not mine
+			for i := parentRound; i < currRound; i++ {
+				leaderIndex := uint64(i) % x.config.Epoch % uint64(len(masternodes))
+				whosTerm := masternodes[leaderIndex]
+				missedRounds = append(
+					missedRounds,
+					utils.MissedRoundInfo{
+						Round:            i,
+						Miner:            whosTerm,
+						CurrentBlockHash: nextHeader.Hash(),
+						ParentBlockHash:  parentHeader.Hash(),
+					},
+				)
+			}
+		}
+		// Assign the pointer to the next one
+		nextHeader = parentHeader
+	}
+	missedRoundsMetadata := &utils.PublicApiMissedRoundsMetadata{
+		EpochRound:       switchInfo.EpochSwitchBlockInfo.Round,
+		EpochBlockNumber: switchInfo.EpochSwitchBlockInfo.Number,
+		MissedRounds:     missedRounds,
+	}
+
+	return missedRoundsMetadata, nil
+}

--- a/consensus/XDPoS/utils/types.go
+++ b/consensus/XDPoS/utils/types.go
@@ -62,7 +62,9 @@ type MissedRoundInfo struct {
 	Round            types.Round
 	Miner            common.Address
 	CurrentBlockHash common.Hash
+	CurrentBlockNum  *big.Int
 	ParentBlockHash  common.Hash
+	ParentBlockNum   *big.Int
 }
 type PublicApiMissedRoundsMetadata struct {
 	EpochRound       types.Round

--- a/consensus/XDPoS/utils/types.go
+++ b/consensus/XDPoS/utils/types.go
@@ -57,3 +57,15 @@ type PublicApiSnapshot struct {
 	Votes   []*clique.Vote                  `json:"votes"`   // List of votes cast in chronological order
 	Tally   map[common.Address]clique.Tally `json:"tally"`   // Current vote tally to avoid recalculating
 }
+
+type MissedRoundInfo struct {
+	Round            types.Round
+	Miner            common.Address
+	CurrentBlockHash common.Hash
+	ParentBlockHash  common.Hash
+}
+type PublicApiMissedRoundsMetadata struct {
+	EpochRound       types.Round
+	EpochBlockNumber *big.Int
+	MissedRounds     []MissedRoundInfo
+}

--- a/consensus/tests/api_test.go
+++ b/consensus/tests/api_test.go
@@ -18,7 +18,6 @@ var (
 )
 
 func TestConfigApi(t *testing.T) {
-
 	bc := backends.NewXDCSimulatedBackend(core.GenesisAlloc{
 		voterAddr: {Balance: new(big.Int).SetUint64(10000000000)},
 	}, 10000000, params.TestXDPoSMockChainConfig)

--- a/consensus/tests/engine_v2_tests/api_test.go
+++ b/consensus/tests/engine_v2_tests/api_test.go
@@ -11,25 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetMissiedRoundsInEpochByBlockNumOnlyForV2Consensus(t *testing.T) {
+func TestGetMissedRoundsInEpochByBlockNumOnlyForV2Consensus(t *testing.T) {
 	_, bc, _, _, _ := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
 
 	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
 	blockNum := rpc.BlockNumber(123)
 
-	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
 	assert.EqualError(t, err, "Not supported in the v1 consensus")
 	assert.Nil(t, data)
 }
 
-func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2(t *testing.T) {
+func TestGetMissedRoundsInEpochByBlockNumReturnEmptyForV2(t *testing.T) {
 	_, bc, cb, _, _ := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
 
 	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
 	blockNum := rpc.BlockNumber(cb.NumberU64())
 
-	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
 	assert.Nil(t, err)
 	assert.Equal(t, types.Round(900), data.EpochRound)
@@ -38,7 +38,7 @@ func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2(t *testing.T) {
 
 	blockNum = rpc.BlockNumber(1800)
 
-	data, err = engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+	data, err = engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
 	assert.Nil(t, err)
 	assert.Equal(t, types.Round(900), data.EpochRound)
@@ -47,7 +47,7 @@ func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2(t *testing.T) {
 
 	blockNum = rpc.BlockNumber(1801)
 
-	data, err = engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+	data, err = engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
 	assert.Nil(t, err)
 	assert.Equal(t, types.Round(900), data.EpochRound)
@@ -55,13 +55,13 @@ func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2(t *testing.T) {
 	assert.Equal(t, 0, len(data.MissedRounds))
 }
 
-func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2FistEpoch(t *testing.T) {
+func TestGetMissedRoundsInEpochByBlockNumReturnEmptyForV2FistEpoch(t *testing.T) {
 	_, bc, _, _, _ := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
 
 	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
 	blockNum := rpc.BlockNumber(901)
 
-	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
 	assert.Nil(t, err)
 	assert.Equal(t, types.Round(1), data.EpochRound)
@@ -69,7 +69,7 @@ func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2FistEpoch(t *testing.T
 	assert.Equal(t, 0, len(data.MissedRounds))
 }
 
-func TestGetMissiedRoundsInEpochByBlockNum(t *testing.T) {
+func TestGetMissedRoundsInEpochByBlockNum(t *testing.T) {
 	blockchain, bc, currentBlock, signer, signFn := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
 	chainConfig := params.TestXDPoSMockChainConfig
 	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
@@ -92,7 +92,7 @@ func TestGetMissiedRoundsInEpochByBlockNum(t *testing.T) {
 
 	blockNum := rpc.BlockNumber(1803)
 
-	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
 	assert.Nil(t, err)
 	assert.Equal(t, types.Round(900), data.EpochRound)

--- a/consensus/tests/engine_v2_tests/api_test.go
+++ b/consensus/tests/engine_v2_tests/api_test.go
@@ -1,0 +1,111 @@
+package engine_v2_tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/rpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMissiedRoundsInEpochByBlockNumOnlyForV2Consensus(t *testing.T) {
+	_, bc, _, _, _ := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
+
+	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
+	blockNum := rpc.BlockNumber(123)
+
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+
+	assert.EqualError(t, err, "Not supported in the v1 consensus")
+	assert.Nil(t, data)
+}
+
+func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2(t *testing.T) {
+	_, bc, cb, _, _ := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
+
+	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
+	blockNum := rpc.BlockNumber(cb.NumberU64())
+
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+
+	assert.Nil(t, err)
+	assert.Equal(t, types.Round(900), data.EpochRound)
+	assert.Equal(t, big.NewInt(1800), data.EpochBlockNumber)
+	assert.Equal(t, 0, len(data.MissedRounds))
+
+	blockNum = rpc.BlockNumber(1800)
+
+	data, err = engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+
+	assert.Nil(t, err)
+	assert.Equal(t, types.Round(900), data.EpochRound)
+	assert.Equal(t, big.NewInt(1800), data.EpochBlockNumber)
+	assert.Equal(t, 0, len(data.MissedRounds))
+
+	blockNum = rpc.BlockNumber(1801)
+
+	data, err = engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+
+	assert.Nil(t, err)
+	assert.Equal(t, types.Round(900), data.EpochRound)
+	assert.Equal(t, big.NewInt(1800), data.EpochBlockNumber)
+	assert.Equal(t, 0, len(data.MissedRounds))
+}
+
+func TestGetMissiedRoundsInEpochByBlockNumReturnEmptyForV2FistEpoch(t *testing.T) {
+	_, bc, _, _, _ := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
+
+	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
+	blockNum := rpc.BlockNumber(901)
+
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+
+	assert.Nil(t, err)
+	assert.Equal(t, types.Round(1), data.EpochRound)
+	assert.Equal(t, big.NewInt(901), data.EpochBlockNumber)
+	assert.Equal(t, 0, len(data.MissedRounds))
+}
+
+func TestGetMissiedRoundsInEpochByBlockNum(t *testing.T) {
+	blockchain, bc, currentBlock, signer, signFn := PrepareXDCTestBlockChainWith128Candidates(t, 1802, params.TestXDPoSMockChainConfig)
+	chainConfig := params.TestXDPoSMockChainConfig
+	engine := bc.GetBlockChain().Engine().(*XDPoS.XDPoS)
+	blockCoinBase := signer.Hex()
+
+	startingBlockNum := currentBlock.Number().Int64() + 1
+	// Skipped the round
+	roundNumber := startingBlockNum - chainConfig.XDPoS.V2.SwitchBlock.Int64() + 2
+	block := CreateBlock(blockchain, chainConfig, currentBlock, int(startingBlockNum), roundNumber, blockCoinBase, signer, signFn, nil, nil, "b345a8560bd51926803dd17677c9f0751193914a851a4ec13063d6bf50220b53")
+	err := blockchain.InsertBlock(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update Signer as there is no previous signer assigned
+	err = UpdateSigner(blockchain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockNum := rpc.BlockNumber(1803)
+
+	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissiedRoundsInEpochByBlockNum(&blockNum)
+
+	assert.Nil(t, err)
+	assert.Equal(t, types.Round(900), data.EpochRound)
+	assert.Equal(t, big.NewInt(1800), data.EpochBlockNumber)
+	assert.Equal(t, 2, len(data.MissedRounds))
+	assert.NotEmpty(t, data.MissedRounds[0].Miner)
+	assert.Equal(t, data.MissedRounds[0].Round, types.Round(903))
+	assert.Equal(t, data.MissedRounds[0].CurrentBlockNum, big.NewInt(1803))
+	assert.Equal(t, data.MissedRounds[0].ParentBlockNum, big.NewInt(1802))
+	assert.NotEmpty(t, data.MissedRounds[1].Miner)
+	assert.Equal(t, data.MissedRounds[1].Round, types.Round(904))
+	assert.Equal(t, data.MissedRounds[0].CurrentBlockNum, big.NewInt(1803))
+	assert.Equal(t, data.MissedRounds[0].ParentBlockNum, big.NewInt(1802))
+
+	assert.NotEqual(t, data.MissedRounds[0].Miner, data.MissedRounds[1].Miner)
+}

--- a/consensus/tests/engine_v2_tests/helper.go
+++ b/consensus/tests/engine_v2_tests/helper.go
@@ -545,6 +545,18 @@ func PrepareXDCTestBlockChainWith128Candidates(t *testing.T, numOfBlocks int, ch
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// First v2 block
+		if (int64(i) - chainConfig.XDPoS.V2.SwitchBlock.Int64()) == 1 {
+			lastv1BlockNumber := block.Header().Number.Uint64() - 1
+			checkpointBlockNumber := lastv1BlockNumber - lastv1BlockNumber%chainConfig.XDPoS.Epoch
+			checkpointHeader := blockchain.GetHeaderByNumber(checkpointBlockNumber)
+			err := engine.EngineV2.Initial(blockchain, checkpointHeader)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		currentBlock = block
 	}
 

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -157,8 +157,8 @@ web3._extend({
 			call: 'XDPoS_getLatestPoolStatus'
 		}),
 		new web3._extend.Method({
-			name: 'getMissiedRoundsInEpochByBlockNum',
-			call: 'XDPoS_getMissiedRoundsInEpochByBlockNum',
+			name: 'getMissedRoundsInEpochByBlockNum',
+			call: 'XDPoS_getMissedRoundsInEpochByBlockNum',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -156,6 +156,11 @@ web3._extend({
 			name: 'getLatestPoolStatus',
 			call: 'XDPoS_getLatestPoolStatus'
 		}),
+		new web3._extend.Method({
+			name: 'GetMissiedRoundsInEpochByBlockHash',
+			call: 'XDPoS_GetMissiedRoundsInEpochByBlockHash',
+			params: 1
+		}),
 	],
 	properties: [
 		new web3._extend.Property({

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -157,8 +157,8 @@ web3._extend({
 			call: 'XDPoS_getLatestPoolStatus'
 		}),
 		new web3._extend.Method({
-			name: 'GetMissiedRoundsInEpochByBlockNum',
-			call: 'XDPoS_GetMissiedRoundsInEpochByBlockNum',
+			name: 'getMissiedRoundsInEpochByBlockNum',
+			call: 'XDPoS_getMissiedRoundsInEpochByBlockNum',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -157,9 +157,10 @@ web3._extend({
 			call: 'XDPoS_getLatestPoolStatus'
 		}),
 		new web3._extend.Method({
-			name: 'GetMissiedRoundsInEpochByBlockHash',
-			call: 'XDPoS_GetMissiedRoundsInEpochByBlockHash',
-			params: 1
+			name: 'GetMissiedRoundsInEpochByBlockNum',
+			call: 'XDPoS_GetMissiedRoundsInEpochByBlockNum',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
 	],
 	properties: [


### PR DESCRIPTION
# Proposed changes
**This PR is working in progress**
Adding a new API to help devs to debug when miners missed to produce block during their term (their round)

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)
- [x] API

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [x] Tested the backwards compatibility.
- [x] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
