### PR TITLE
XDP-02 fix Panic In ProcessOrderPending Leads To Chain Halt

### DIFF
--- a/core/types/order_transaction.go
+++ b/core/types/order_transaction.go
@@ -304,6 +304,9 @@ func NewOrderTransactionByNonce(signer OrderSigner, txs map[common.Address]Order
 	// Initialize a price based heap with the head transactions
 	heads := make(OrderTxByNonce, 0, len(txs))
 	for from, accTxs := range txs {
+		if len(accTxs) == 0 {
+			continue
+		}
 		heads = append(heads, accTxs[0])
 		// Ensure the sender address is from the signer
 		acc, _ := OrderSender(signer, accTxs[0])

--- a/core/types/order_transaction_test.go
+++ b/core/types/order_transaction_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+)
+
+func TestNewOrderTransactionByNonce(t *testing.T) {
+	// Generate a batch of accounts to start with
+	keys := make([]*ecdsa.PrivateKey, 1)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+
+	groups := map[common.Address]OrderTransactions{}
+	for start, key := range keys {
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		for i := 0; i < 1; i++ {
+			//tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
+			orderTx := NewOrderTransaction(uint64(start+i), big.NewInt(1), big.NewInt(2), common.Address{}, common.Address{}, common.Address{}, common.Address{}, "new", "BID", "test", common.Hash{}, 1001)
+
+			groups[addr] = append(groups[addr], orderTx)
+		}
+	}
+	tx := NewOrderTransactionByNonce(OrderTxSigner{}, groups)
+	t.Log(tx)
+}


### PR DESCRIPTION
# Proposed changes
In the implementation, if from != acc and len(accTxs) == 1, the key from will be deleted from the map txs, and an empty array accTxs[1:] will be assigned to the key acc. As a result, when the for loop checks the key acc, a panic will occur with the error index out of range [0] with length 0 because the code is trying to get the value of accTxs[0].

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
