### PR TITLE
fix timeout too fast issue

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -45,7 +45,7 @@ var (
 			SwitchRound:          0,
 			CertThreshold:        0.667,
 			TimeoutSyncThreshold: 3,
-			TimeoutPeriod:        20,
+			TimeoutPeriod:        30,
 			MinePeriod:           2,
 		},
 	}
@@ -64,7 +64,7 @@ var (
 			SwitchRound:          900000,
 			CertThreshold:        0.667,
 			TimeoutSyncThreshold: 3,
-			TimeoutPeriod:        20,
+			TimeoutPeriod:        30,
 			MinePeriod:           2,
 		},
 	}
@@ -74,8 +74,8 @@ var (
 			MaxMasternodes:       108,
 			SwitchRound:          0,
 			CertThreshold:        0.667,
-			TimeoutSyncThreshold: 5,
-			TimeoutPeriod:        10,
+			TimeoutSyncThreshold: 3,
+			TimeoutPeriod:        30,
 			MinePeriod:           2,
 		},
 	}


### PR DESCRIPTION
# Proposed changes
On devnet, 10 second timeout is too fast when there is heavy disk reading operation when receive/mine Epoch Block. Sometimes if disk performance is bad or no cache in the memory (reboot). Then it may occur timeout and round bump before sending Vote. 

On the other words: Block takes `x` second to be generated from miner and takes `y` second to consume to others. If `x + y > 10`, then timeout trigger, round++, then this block won't treat as valid.
```
WARN [01-16|07:09:22] Failed to pass the voting rule verification, blockRound is not equal currentRound x.currentRound=7954010 blockInfo.Round=7954009
```
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
