### PR TITLE
replace deprecated ioutil lib calls

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"io"
-	"io/ioutil"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts/keystore"
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -31,7 +30,7 @@ import (
 // NewTransactor is a utility method to easily create a transaction signer from
 // an encrypted json key stream and the associated passphrase.
 func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"sync"
@@ -76,7 +75,7 @@ type SimulatedBackend struct {
 func SimulateWalletAddressAndSignFn() (common.Address, func(account accounts.Account, hash []byte) ([]byte, error), error) {
 	veryLightScryptN := 2
 	veryLightScryptP := 1
-	dir, _ := ioutil.TempDir("", "eth-SimulateWalletAddressAndSignFn-test")
+	dir, _ := os.MkdirTemp("", "eth-SimulateWalletAddressAndSignFn-test")
 
 	new := func(kd string) *keystore.KeyStore {
 		return keystore.NewKeyStore(kd, veryLightScryptN, veryLightScryptP)

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -18,7 +18,6 @@ package bind
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -831,7 +830,7 @@ func TestBindings(t *testing.T) {
 		t.Skip("symlinked environment doesn't support bind (https://github.com/golang/go/issues/14845)")
 	}
 	// Create a temporary workspace for the test suite
-	ws, err := ioutil.TempDir("", "")
+	ws, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary workspace: %v", err)
 	}
@@ -848,7 +847,7 @@ func TestBindings(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test %d: failed to generate binding: %v", i, err)
 		}
-		if err = ioutil.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+".go"), []byte(bind), 0600); err != nil {
+		if err = os.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+".go"), []byte(bind), 0600); err != nil {
 			t.Fatalf("test %d: failed to write binding: %v", i, err)
 		}
 		// Generate the test file with the injected test code
@@ -857,7 +856,7 @@ func TestBindings(t *testing.T) {
 		if err != nil {
 			t.Fatalf("test %d: failed to generate tests: %v", i, err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+"_test.go"), blob, 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(pkg, strings.ToLower(tt.name)+"_test.go"), blob, 0600); err != nil {
 			t.Fatalf("test %d: failed to write tests: %v", i, err)
 		}
 	}

--- a/accounts/keystore/account_cache_test.go
+++ b/accounts/keystore/account_cache_test.go
@@ -18,7 +18,6 @@ package keystore
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -381,11 +380,11 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 		return
 	}
 
-	// needed so that modTime of `file` is different to its current value after ioutil.WriteFile
+	// needed so that modTime of `file` is different to its current value after os.WriteFile
 	time.Sleep(1000 * time.Millisecond)
 
 	// Now replace file contents with crap
-	if err := ioutil.WriteFile(file, []byte("foo"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("foo"), 0644); err != nil {
 		t.Fatal(err)
 		return
 	}
@@ -398,9 +397,9 @@ func TestUpdatedKeyfileContents(t *testing.T) {
 
 // forceCopyFile is like cp.CopyFile, but doesn't complain if the destination exists.
 func forceCopyFile(dst, src string) error {
-	data, err := ioutil.ReadFile(src)
+	data, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(dst, data, 0644)
+	return os.WriteFile(dst, data, 0644)
 }

--- a/accounts/keystore/key.go
+++ b/accounts/keystore/key.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,7 +187,7 @@ func writeKeyFile(file string, content []byte) error {
 	}
 	// Atomic write: create a temporary hidden file first
 	// then move it into place. TempFile assigns mode 0600.
-	f, err := ioutil.TempFile(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
+	f, err := os.CreateTemp(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
 	if err != nil {
 		return err
 	}

--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -33,7 +33,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -76,7 +76,7 @@ type keyStorePassphrase struct {
 
 func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
-	keyjson, err := ioutil.ReadFile(filename)
+	keyjson, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/keystore/keystore_passphrase_test.go
+++ b/accounts/keystore/keystore_passphrase_test.go
@@ -17,7 +17,7 @@
 package keystore
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -30,7 +30,7 @@ const (
 
 // Tests that a json key file can be decrypted and encrypted in multiple rounds.
 func TestKeyEncryptDecrypt(t *testing.T) {
-	keyjson, err := ioutil.ReadFile("testdata/very-light-scrypt.json")
+	keyjson, err := os.ReadFile("testdata/very-light-scrypt.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/keystore_plain_test.go
+++ b/accounts/keystore/keystore_plain_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,7 +31,7 @@ import (
 )
 
 func tmpKeyStoreIface(t *testing.T, encrypted bool) (dir string, ks keyStore) {
-	d, err := ioutil.TempDir("", "geth-keystore-test")
+	d, err := os.MkdirTemp("", "geth-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -17,7 +17,6 @@
 package keystore
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -375,7 +374,7 @@ func checkEvents(t *testing.T, want []walletEvent, have []walletEvent) {
 }
 
 func tmpKeyStore(t *testing.T, encrypted bool) (string, *KeyStore) {
-	d, err := ioutil.TempDir("", "eth-keystore-test")
+	d, err := os.MkdirTemp("", "eth-keystore-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/build/ci.go
+++ b/build/ci.go
@@ -39,7 +39,6 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -149,7 +148,7 @@ func doInstall(cmdline []string) {
 	goinstall.Args = append(goinstall.Args, packages...)
 	build.MustRun(goinstall)
 
-	if cmds, err := ioutil.ReadDir("cmd"); err == nil {
+	if cmds, err := os.ReadDir("cmd"); err == nil {
 		for _, cmd := range cmds {
 			pkgs, err := parser.ParseDir(token.NewFileSet(), filepath.Join(".", "cmd", cmd.Name()), nil, parser.PackageClauseOnly)
 			if err != nil {

--- a/cmd/XDC/accountcmd.go
+++ b/cmd/XDC/accountcmd.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts"
 	"github.com/XinFinOrg/XDPoSChain/accounts/keystore"
@@ -340,7 +340,7 @@ func importWallet(ctx *cli.Context) error {
 	if len(keyfile) == 0 {
 		utils.Fatalf("keyfile must be given as argument")
 	}
-	keyJson, err := ioutil.ReadFile(keyfile)
+	keyJson, err := os.ReadFile(keyfile)
 	if err != nil {
 		utils.Fatalf("Could not read wallet file: %v", err)
 	}

--- a/cmd/XDC/accountcmd_test.go
+++ b/cmd/XDC/accountcmd_test.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -115,7 +115,7 @@ Passphrase: {{.InputLine "foo"}}
 Address: {xdcd4584b5f6229b7be90727b0fc8c6b91bb427821f}
 `)
 
-	files, err := ioutil.ReadDir(filepath.Join(XDC.Datadir, "keystore"))
+	files, err := os.ReadDir(filepath.Join(XDC.Datadir, "keystore"))
 	if len(files) != 1 {
 		t.Errorf("expected one key file in keystore directory, found %d files (error: %v)", len(files), err)
 	}

--- a/cmd/XDC/bugcmd.go
+++ b/cmd/XDC/bugcmd.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -74,7 +74,7 @@ func printOSDetails(w io.Writer) {
 	case "openbsd", "netbsd", "freebsd", "dragonfly":
 		printCmdOut(w, "uname -v: ", "uname", "-v")
 	case "solaris":
-		out, err := ioutil.ReadFile("/etc/release")
+		out, err := os.ReadFile("/etc/release")
 		if err == nil {
 			fmt.Fprintf(w, "/etc/release: %s\n", out)
 		} else {

--- a/cmd/XDC/dao_test.go
+++ b/cmd/XDC/dao_test.go
@@ -17,12 +17,12 @@
 package main
 
 import (
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core"
@@ -108,7 +108,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	// Start a XDC instance with the requested flags set and immediately terminate
 	if genesis != "" {
 		json := filepath.Join(datadir, "genesis.json")
-		if err := ioutil.WriteFile(json, []byte(genesis), 0600); err != nil {
+		if err := os.WriteFile(json, []byte(genesis), 0600); err != nil {
 			t.Fatalf("test %d: failed to write genesis file: %v", test, err)
 		}
 		runXDC(t, "--datadir", datadir, "init", json).WaitExit()

--- a/cmd/XDC/run_test.go
+++ b/cmd/XDC/run_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 )
 
 func tmpdir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "XDC-test")
+	dir, err := os.MkdirTemp("", "XDC-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -100,7 +99,7 @@ func main() {
 		}
 	} else {
 		// Otherwise load up the ABI, optional bytecode and type name from the parameters
-		abi, err := ioutil.ReadFile(*abiFlag)
+		abi, err := os.ReadFile(*abiFlag)
 		if err != nil {
 			fmt.Printf("Failed to read input ABI: %v\n", err)
 			os.Exit(-1)
@@ -109,7 +108,7 @@ func main() {
 
 		bin := []byte{}
 		if *binFlag != "" {
-			if bin, err = ioutil.ReadFile(*binFlag); err != nil {
+			if bin, err = os.ReadFile(*binFlag); err != nil {
 				fmt.Printf("Failed to read input bytecode: %v\n", err)
 				os.Exit(-1)
 			}
@@ -133,7 +132,7 @@ func main() {
 		fmt.Printf("%s\n", code)
 		return
 	}
-	if err := ioutil.WriteFile(*outFlag, []byte(code), 0600); err != nil {
+	if err := os.WriteFile(*outFlag, []byte(code), 0600); err != nil {
 		fmt.Printf("Failed to write ABI binding: %v\n", err)
 		os.Exit(-1)
 	}

--- a/cmd/ethkey/generate.go
+++ b/cmd/ethkey/generate.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -100,7 +99,7 @@ If you want to encrypt an existing private key, it can be specified by setting
 		if err := os.MkdirAll(filepath.Dir(keyfilepath), 0700); err != nil {
 			utils.Fatalf("Could not create directory %s", filepath.Dir(keyfilepath))
 		}
-		if err := ioutil.WriteFile(keyfilepath, keyjson, 0600); err != nil {
+		if err := os.WriteFile(keyfilepath, keyjson, 0600); err != nil {
 			utils.Fatalf("Failed to write keyfile to %s: %v", keyfilepath, err)
 		}
 

--- a/cmd/ethkey/inspect.go
+++ b/cmd/ethkey/inspect.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts/keystore"
 	"github.com/XinFinOrg/XDPoSChain/cmd/utils"
@@ -54,7 +54,7 @@ make sure to use this feature with great caution!`,
 		keyfilepath := ctx.Args().First()
 
 		// Read key from file.
-		keyjson, err := ioutil.ReadFile(keyfilepath)
+		keyjson, err := os.ReadFile(keyfilepath)
 		if err != nil {
 			utils.Fatalf("Failed to read the keyfile at '%s': %v", keyfilepath, err)
 		}

--- a/cmd/ethkey/message.go
+++ b/cmd/ethkey/message.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts/keystore"
 	"github.com/XinFinOrg/XDPoSChain/cmd/utils"
@@ -56,7 +56,7 @@ To sign a message contained in a file, use the --msgfile flag.
 
 		// Load the keyfile.
 		keyfilepath := ctx.Args().First()
-		keyjson, err := ioutil.ReadFile(keyfilepath)
+		keyjson, err := os.ReadFile(keyfilepath)
 		if err != nil {
 			utils.Fatalf("Failed to read the keyfile at '%s': %v", keyfilepath, err)
 		}
@@ -146,7 +146,7 @@ func getMessage(ctx *cli.Context, msgarg int) []byte {
 		if len(ctx.Args()) > msgarg {
 			utils.Fatalf("Can't use --msgfile and message argument at the same time.")
 		}
-		msg, err := ioutil.ReadFile(file)
+		msg, err := os.ReadFile(file)
 		if err != nil {
 			utils.Fatalf("Can't read message file: %v", err)
 		}

--- a/cmd/ethkey/message_test.go
+++ b/cmd/ethkey/message_test.go
@@ -17,14 +17,13 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestMessageSignVerify(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "ethkey-test")
+	tmpdir, err := os.MkdirTemp("", "ethkey-test")
 	if err != nil {
 		t.Fatal("Can't create temporary directory:", err)
 	}

--- a/cmd/ethkey/utils.go
+++ b/cmd/ethkey/utils.go
@@ -19,7 +19,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/XinFinOrg/XDPoSChain/cmd/utils"
@@ -35,7 +35,7 @@ func getPassPhrase(ctx *cli.Context, confirmation bool) string {
 	// Look for the --passphrase flag.
 	passphraseFile := ctx.String(passphraseFlag.Name)
 	if passphraseFile != "" {
-		content, err := ioutil.ReadFile(passphraseFile)
+		content, err := os.ReadFile(passphraseFile)
 		if err != nil {
 			utils.Fatalf("Failed to read passphrase file '%s': %v",
 				passphraseFile, err)
@@ -64,7 +64,8 @@ func getPassPhrase(ctx *cli.Context, confirmation bool) string {
 // that can be safely used to calculate a signature from.
 //
 // The hash is calulcated as
-//   keccak256("\x19Ethereum Signed Message:\n"${message length}${message}).
+//
+//	keccak256("\x19Ethereum Signed Message:\n"${message length}${message}).
 //
 // This gives context to the signed message and prevents signing of transactions.
 func signHash(data []byte) []byte {

--- a/cmd/evm/compiler.go
+++ b/cmd/evm/compiler.go
@@ -19,7 +19,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/XinFinOrg/XDPoSChain/cmd/evm/internal/compiler"
 
@@ -41,7 +41,7 @@ func compileCmd(ctx *cli.Context) error {
 	}
 
 	fn := ctx.Args().First()
-	src, err := ioutil.ReadFile(fn)
+	src, err := os.ReadFile(fn)
 	if err != nil {
 		return err
 	}

--- a/cmd/evm/disasm.go
+++ b/cmd/evm/disasm.go
@@ -19,7 +19,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/XinFinOrg/XDPoSChain/core/asm"
@@ -39,7 +39,7 @@ func disasmCmd(ctx *cli.Context) error {
 	}
 
 	fn := ctx.Args().First()
-	in, err := ioutil.ReadFile(fn)
+	in, err := os.ReadFile(fn)
 	if err != nil {
 		return err
 	}

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime/pprof"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	goruntime "runtime"
 
@@ -125,13 +126,13 @@ func runCmd(ctx *cli.Context) error {
 		// If - is specified, it means that code comes from stdin
 		if ctx.GlobalString(CodeFileFlag.Name) == "-" {
 			//Try reading from stdin
-			if hexcode, err = ioutil.ReadAll(os.Stdin); err != nil {
+			if hexcode, err = io.ReadAll(os.Stdin); err != nil {
 				fmt.Printf("Could not load code from stdin: %v\n", err)
 				os.Exit(1)
 			}
 		} else {
 			// Codefile with hex assembly
-			if hexcode, err = ioutil.ReadFile(ctx.GlobalString(CodeFileFlag.Name)); err != nil {
+			if hexcode, err = os.ReadFile(ctx.GlobalString(CodeFileFlag.Name)); err != nil {
 				fmt.Printf("Could not load code from file: %v\n", err)
 				os.Exit(1)
 			}
@@ -142,7 +143,7 @@ func runCmd(ctx *cli.Context) error {
 		code = common.Hex2Bytes(ctx.GlobalString(CodeFlag.Name))
 	} else if fn := ctx.Args().First(); len(fn) > 0 {
 		// EASM-file to compile
-		src, err := ioutil.ReadFile(fn)
+		src, err := os.ReadFile(fn)
 		if err != nil {
 			return err
 		}

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/XinFinOrg/XDPoSChain/core/state"
@@ -76,7 +75,7 @@ func stateTestCmd(ctx *cli.Context) error {
 		debugger = vm.NewStructLogger(config)
 	}
 	// Load the test content from the input file
-	src, err := ioutil.ReadFile(ctx.Args().First())
+	src, err := os.ReadFile(ctx.Args().First())
 	if err != nil {
 		return err
 	}

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -28,7 +28,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/big"
 	"net/http"
@@ -139,7 +139,7 @@ func main() {
 		log.Crit("Failed to render the faucet template", "err", err)
 	}
 	// Load and parse the genesis block requested by the user
-	blob, err := ioutil.ReadFile(*genesisFlag)
+	blob, err := os.ReadFile(*genesisFlag)
 	if err != nil {
 		log.Crit("Failed to read genesis block contents", "genesis", *genesisFlag, "err", err)
 	}
@@ -157,13 +157,13 @@ func main() {
 		}
 	}
 	// Load up the account key and decrypt its password
-	if blob, err = ioutil.ReadFile(*accPassFlag); err != nil {
+	if blob, err = os.ReadFile(*accPassFlag); err != nil {
 		log.Crit("Failed to read account password contents", "file", *accPassFlag, "err", err)
 	}
 	pass := string(blob)
 
 	ks := keystore.NewKeyStore(filepath.Join(os.Getenv("HOME"), ".faucet", "keys"), keystore.StandardScryptN, keystore.StandardScryptP)
-	if blob, err = ioutil.ReadFile(*accJSONFlag); err != nil {
+	if blob, err = os.ReadFile(*accJSONFlag); err != nil {
 		log.Crit("Failed to read account key contents", "file", *accJSONFlag, "err", err)
 	}
 	acc, err := ks.Import(blob, pass, pass)
@@ -729,7 +729,7 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	}
 	username := parts[len(parts)-3]
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", "", common.Address{}, err
 	}
@@ -763,7 +763,7 @@ func authGooglePlus(url string) (string, string, common.Address, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", "", common.Address{}, err
 	}
@@ -797,7 +797,7 @@ func authFacebook(url string) (string, string, common.Address, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", "", common.Address{}, err
 	}

--- a/cmd/puppeth/ssh.go
+++ b/cmd/puppeth/ssh.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -72,7 +71,7 @@ func dial(server string, pubkey []byte) (*sshClient, error) {
 	var auths []ssh.AuthMethod
 
 	path := filepath.Join(user.HomeDir, ".ssh", "id_rsa")
-	if buf, err := ioutil.ReadFile(path); err != nil {
+	if buf, err := os.ReadFile(path); err != nil {
 		log.Warn("No SSH key, falling back to passwords", "path", path, "err", err)
 	} else {
 		key, err := ssh.ParsePrivateKey(buf)

--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -63,7 +62,7 @@ func (c config) flush() {
 	os.MkdirAll(filepath.Dir(c.path), 0755)
 
 	out, _ := json.MarshalIndent(c.Genesis, "", "  ")
-	if err := ioutil.WriteFile(c.path, out, 0644); err != nil {
+	if err := os.WriteFile(c.path, out, 0644); err != nil {
 		log.Warn("Failed to save puppeth configs", "file", c.path, "err", err)
 	}
 }

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -419,7 +419,7 @@ func (w *wizard) manageGenesis() {
 		fmt.Println()
 		fmt.Printf("Which file to save the genesis into? (default = %s.json)\n", w.network)
 		out, _ := json.MarshalIndent(w.conf.Genesis, "", "  ")
-		if err := ioutil.WriteFile(w.readDefaultString(fmt.Sprintf("%s.json", w.network)), out, 0644); err != nil {
+		if err := os.WriteFile(w.readDefaultString(fmt.Sprintf("%s.json", w.network)), out, 0644); err != nil {
 			log.Error("Failed to save genesis file", "err", err)
 		}
 		log.Info("Exported existing genesis block")

--- a/cmd/puppeth/wizard_intro.go
+++ b/cmd/puppeth/wizard_intro.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,7 +75,7 @@ func (w *wizard) run() {
 	// Load initial configurations and connect to all live servers
 	w.conf.path = filepath.Join(os.Getenv("HOME"), ".puppeth", w.network)
 
-	blob, err := ioutil.ReadFile(w.conf.path)
+	blob, err := os.ReadFile(w.conf.path)
 	if err != nil {
 		log.Warn("No previous configurations found", "path", w.conf.path)
 	} else if err := json.Unmarshal(blob, &w.conf); err != nil {

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -67,7 +66,7 @@ func TestFailsNoBzzAccount(t *testing.T) {
 }
 
 func TestCmdLineOverrides(t *testing.T) {
-	dir, err := ioutil.TempDir("", "bzztest")
+	dir, err := os.MkdirTemp("", "bzztest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +160,7 @@ func TestFileOverrides(t *testing.T) {
 		t.Fatalf("Error creating TOML file in TestFileOverride: %v", err)
 	}
 	//create file
-	f, err := ioutil.TempFile("", "testconfig.toml")
+	f, err := os.CreateTemp("", "testconfig.toml")
 	if err != nil {
 		t.Fatalf("Error writing TOML file in TestFileOverride: %v", err)
 	}
@@ -172,7 +171,7 @@ func TestFileOverrides(t *testing.T) {
 	}
 	f.Sync()
 
-	dir, err := ioutil.TempDir("", "bzztest")
+	dir, err := os.MkdirTemp("", "bzztest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +258,7 @@ func TestEnvVars(t *testing.T) {
 	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmSyncEnabledFlag.EnvVar, "true"))
 
-	dir, err := ioutil.TempDir("", "bzztest")
+	dir, err := os.MkdirTemp("", "bzztest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -368,7 +367,7 @@ func TestCmdLineOverridesFile(t *testing.T) {
 		t.Fatalf("Error creating TOML file in TestFileOverride: %v", err)
 	}
 	//write file
-	f, err := ioutil.TempFile("", "testconfig.toml")
+	f, err := os.CreateTemp("", "testconfig.toml")
 	if err != nil {
 		t.Fatalf("Error writing TOML file in TestFileOverride: %v", err)
 	}
@@ -379,7 +378,7 @@ func TestCmdLineOverridesFile(t *testing.T) {
 	}
 	f.Sync()
 
-	dir, err := ioutil.TempDir("", "bzztest")
+	dir, err := os.MkdirTemp("", "bzztest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -153,7 +152,7 @@ var (
 	}
 )
 
-//declare a few constant error messages, useful for later error check comparisons in test
+// declare a few constant error messages, useful for later error check comparisons in test
 var (
 	SWARM_ERR_NO_BZZACCOUNT   = "bzzaccount option is required but not set; check your config file, command line or environment variables"
 	SWARM_ERR_SWAP_SET_NO_API = "SWAP is enabled but --swap-api is not set"
@@ -504,7 +503,7 @@ func decryptStoreAccount(ks *keystore.KeyStore, account string, passwords []stri
 	if err != nil {
 		utils.Fatalf("Can't find swarm account key: %v - Is the provided bzzaccount(%s) from the right datadir/Path?", err, account)
 	}
-	keyjson, err := ioutil.ReadFile(a.URL.Path)
+	keyjson, err := os.ReadFile(a.URL.Path)
 	if err != nil {
 		utils.Fatalf("Can't load swarm account key: %v", err)
 	}

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -89,7 +88,7 @@ func newTestCluster(t *testing.T, size int) *testCluster {
 		}
 	}()
 
-	tmpdir, err := ioutil.TempDir("", "swarm-test")
+	tmpdir, err := os.MkdirTemp("", "swarm-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -51,7 +50,7 @@ func upload(ctx *cli.Context) {
 
 	if len(args) != 1 {
 		if fromStdin {
-			tmp, err := ioutil.TempFile("", "swarm-stdin")
+			tmp, err := os.CreateTemp("", "swarm-stdin")
 			if err != nil {
 				utils.Fatalf("error create tempfile: %s", err)
 			}

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -33,7 +32,7 @@ func TestCLISwarmUp(t *testing.T) {
 	defer cluster.Shutdown()
 
 	// create a tmp file
-	tmp, err := ioutil.TempFile("", "swarm-test")
+	tmp, err := os.CreateTemp("", "swarm-test")
 	assertNil(t, err)
 	defer tmp.Close()
 	defer os.Remove(tmp.Name())
@@ -68,7 +67,7 @@ func assertHTTPResponse(t *testing.T, res *http.Response, expectedStatus int, ex
 	if res.StatusCode != expectedStatus {
 		t.Fatalf("expected HTTP status %d, got %s", expectedStatus, res.Status)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	assertNil(t, err)
 	if string(data) != expectedBody {
 		t.Fatalf("expected HTTP body %q, got %q", expectedBody, data)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -20,7 +20,6 @@ package utils
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -848,7 +847,7 @@ func MakePasswordList(ctx *cli.Context) []string {
 	if path == "" {
 		return nil
 	}
-	text, err := ioutil.ReadFile(path)
+	text, err := os.ReadFile(path)
 	if err != nil {
 		Fatalf("Failed to read password file: %v", err)
 	}

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -18,13 +17,13 @@ func TestWalkMatch(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	test1Dir, _ := ioutil.TempDir(dir, "test1")
-	test2Dir, _ := ioutil.TempDir(dir, "test2")
-	err = ioutil.WriteFile(filepath.Join(test1Dir, "test1.ldb"), []byte("hello"), os.ModePerm)
+	test1Dir, _ := os.MkdirTemp(dir, "test1")
+	test2Dir, _ := os.MkdirTemp(dir, "test2")
+	err = os.WriteFile(filepath.Join(test1Dir, "test1.ldb"), []byte("hello"), os.ModePerm)
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = ioutil.WriteFile(filepath.Join(test2Dir, "test2.abc"), []byte("hello"), os.ModePerm)
+	err = os.WriteFile(filepath.Join(test2Dir, "test2.abc"), []byte("hello"), os.ModePerm)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/wnode/main.go
+++ b/cmd/wnode/main.go
@@ -28,7 +28,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -483,7 +482,7 @@ func sendFilesLoop() {
 			fmt.Println("Quit command received")
 			return
 		}
-		b, err := ioutil.ReadFile(s)
+		b, err := os.ReadFile(s)
 		if err != nil {
 			fmt.Printf(">>> Error: %s \n", err)
 		} else {
@@ -513,7 +512,7 @@ func fileReaderLoop() {
 			fmt.Println("Quit command received")
 			return
 		}
-		raw, err := ioutil.ReadFile(s)
+		raw, err := os.ReadFile(s)
 		if err != nil {
 			fmt.Printf(">>> Error: %s \n", err)
 		} else {
@@ -670,7 +669,7 @@ func writeMessageToFile(dir string, msg *whisper.ReceivedMessage, show bool) {
 	//}
 
 	fullpath := filepath.Join(dir, name)
-	err := ioutil.WriteFile(fullpath, env.Data, 0644)
+	err := os.WriteFile(fullpath, env.Data, 0644)
 	if err != nil {
 		fmt.Printf("\n%s {%x}: message received but not saved: %s\n", timestamp, address, err)
 	} else if show {

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -184,7 +184,7 @@ func (s *Solidity) run(cmd *exec.Cmd, source string) (map[string]*Contract, erro
 func slurpFiles(files []string) (string, error) {
 	var concat bytes.Buffer
 	for _, file := range files {
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			return "", err
 		}

--- a/common/test_utils.go
+++ b/common/test_utils.go
@@ -19,12 +19,12 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // LoadJSON reads the given file and unmarshals its content.
 func LoadJSON(file string, val interface{}) error {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -849,7 +849,7 @@ func (x *XDPoS_v1) Finalize(chain consensus.ChainReader, header *types.Header, s
 		if len(common.StoreRewardFolder) > 0 {
 			data, err := json.Marshal(rewards)
 			if err == nil {
-				err = ioutil.WriteFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()), data, 0644)
+				err = os.WriteFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()), data, 0644)
 			}
 			if err != nil {
 				log.Error("Error when save reward info ", "number", header.Number, "hash", header.Hash().Hex(), "err", err)

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -3,8 +3,8 @@ package engine_v2
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -385,7 +385,7 @@ func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, s
 		if len(common.StoreRewardFolder) > 0 {
 			data, err := json.Marshal(rewards)
 			if err == nil {
-				err = ioutil.WriteFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()), data, 0644)
+				err = os.WriteFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()), data, 0644)
 			}
 			if err != nil {
 				log.Error("Error when save reward info ", "number", header.Number, "hash", header.Hash().Hex(), "err", err)

--- a/consensus/XDPoS/engines/engine_v2/forensics_test.go
+++ b/consensus/XDPoS/engines/engine_v2/forensics_test.go
@@ -3,7 +3,6 @@ package engine_v2
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -48,7 +47,7 @@ func RandStringBytes(n int) string {
 func getSignerAndSignFn(pk *ecdsa.PrivateKey) (common.Address, func(account accounts.Account, hash []byte) ([]byte, error), error) {
 	veryLightScryptN := 2
 	veryLightScryptP := 1
-	dir, _ := ioutil.TempDir("", fmt.Sprintf("eth-getSignerAndSignFn-test-%v", RandStringBytes(5)))
+	dir, _ := os.MkdirTemp("", fmt.Sprintf("eth-getSignerAndSignFn-test-%v", RandStringBytes(5)))
 
 	new := func(kd string) *keystore.KeyStore {
 		return keystore.NewKeyStore(kd, veryLightScryptN, veryLightScryptP)

--- a/consensus/XDPoS/engines/engine_v2/snapshot_test.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot_test.go
@@ -2,7 +2,7 @@ package engine_v2
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -24,7 +24,7 @@ func TestGetMasterNodes(t *testing.T) {
 
 func TestStoreLoadSnapshot(t *testing.T) {
 	snap := newSnapshot(1, common.Hash{0x1}, nil)
-	dir, err := ioutil.TempDir("", "snapshot-test")
+	dir, err := os.MkdirTemp("", "snapshot-test")
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}

--- a/consensus/ethash/algorithm_test.go
+++ b/consensus/ethash/algorithm_test.go
@@ -18,7 +18,6 @@ package ethash
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -688,7 +687,7 @@ func TestHashimoto(t *testing.T) {
 // Tests that caches generated on disk may be done concurrently.
 func TestConcurrentDiskCacheGeneration(t *testing.T) {
 	// Create a temp folder to generate the caches into
-	cachedir, err := ioutil.TempDir("", "")
+	cachedir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary cache dir: %v", err)
 	}

--- a/consensus/ethash/ethash_test.go
+++ b/consensus/ethash/ethash_test.go
@@ -17,7 +17,6 @@
 package ethash
 
 import (
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -46,7 +45,7 @@ func TestTestMode(t *testing.T) {
 // This test checks that cache lru logic doesn't crash under load.
 // It reproduces https://github.com/XinFinOrg/XDPoSChain/issues/14943
 func TestCacheFileEvict(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "ethash-test")
+	tmpdir, err := os.MkdirTemp("", "ethash-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/tests/engine_v2_tests/helper.go
+++ b/consensus/tests/engine_v2_tests/helper.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -77,7 +76,7 @@ func RandStringBytes(n int) string {
 func getSignerAndSignFn(pk *ecdsa.PrivateKey) (common.Address, func(account accounts.Account, hash []byte) ([]byte, error), error) {
 	veryLightScryptN := 2
 	veryLightScryptP := 1
-	dir, _ := ioutil.TempDir("", fmt.Sprintf("eth-getSignerAndSignFn-test-%v", RandStringBytes(5)))
+	dir, _ := os.MkdirTemp("", fmt.Sprintf("eth-getSignerAndSignFn-test-%v", RandStringBytes(5)))
 
 	new := func(kd string) *keystore.KeyStore {
 		return keystore.NewKeyStore(kd, veryLightScryptN, veryLightScryptP)

--- a/console/console.go
+++ b/console/console.go
@@ -19,7 +19,6 @@ package console
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -28,11 +27,11 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/dop251/goja"
 	"github.com/XinFinOrg/XDPoSChain/internal/jsre"
 	"github.com/XinFinOrg/XDPoSChain/internal/jsre/deps"
 	"github.com/XinFinOrg/XDPoSChain/internal/web3ext"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
+	"github.com/dop251/goja"
 	"github.com/mattn/go-colorable"
 	"github.com/peterh/liner"
 )
@@ -137,7 +136,7 @@ func (c *Console) init(preload []string) error {
 
 	// Configure the input prompter for history and tab completion.
 	if c.prompter != nil {
-		if content, err := ioutil.ReadFile(c.histPath); err != nil {
+		if content, err := os.ReadFile(c.histPath); err != nil {
 			c.prompter.SetHistory(nil)
 		} else {
 			c.history = strings.Split(string(content), "\n")
@@ -452,7 +451,7 @@ func (c *Console) Execute(path string) error {
 
 // Stop cleans up the console and terminates the runtime environment.
 func (c *Console) Stop(graceful bool) error {
-	if err := ioutil.WriteFile(c.histPath, []byte(strings.Join(c.history, "\n")), 0600); err != nil {
+	if err := os.WriteFile(c.histPath, []byte(strings.Join(c.history, "\n")), 0600); err != nil {
 		return err
 	}
 	if err := os.Chmod(c.histPath, 0600); err != nil { // Force 0600, even if it was different previously

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -19,13 +19,13 @@ package console
 import (
 	"bytes"
 	"errors"
-	"github.com/XinFinOrg/XDPoSChain/XDCx"
-	"github.com/XinFinOrg/XDPoSChain/XDCxlending"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/XDCx"
+	"github.com/XinFinOrg/XDPoSChain/XDCxlending"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
@@ -86,7 +86,7 @@ type tester struct {
 // Please ensure you call Close() on the returned tester to avoid leaks.
 func newTester(t *testing.T, confOverride func(*eth.Config)) *tester {
 	// Create a temporary storage for the node keys and initialize it
-	workspace, err := ioutil.TempDir("", "console-tester-")
+	workspace, err := os.MkdirTemp("", "console-tester-")
 	if err != nil {
 		t.Fatalf("failed to create temporary keystore: %v", err)
 	}

--- a/contracts/chequebook/cheque.go
+++ b/contracts/chequebook/cheque.go
@@ -30,7 +30,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"sync"
@@ -160,7 +159,7 @@ func (self *Chequebook) setBalanceFromBlockChain() {
 // LoadChequebook loads a chequebook from disk (file path).
 func LoadChequebook(path string, prvKey *ecdsa.PrivateKey, backend Backend, checkBalance bool) (self *Chequebook, err error) {
 	var data []byte
-	data, err = ioutil.ReadFile(path)
+	data, err = os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -230,7 +229,7 @@ func (self *Chequebook) Save() (err error) {
 	}
 	self.log.Trace("Saving chequebook to disk", self.path)
 
-	return ioutil.WriteFile(self.path, data, os.ModePerm)
+	return os.WriteFile(self.path, data, os.ModePerm)
 }
 
 // Stop quits the autodeposit go routine to terminate

--- a/contracts/chequebook/gencode.go
+++ b/contracts/chequebook/gencode.go
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build none
 // +build none
 
 // This program generates contract/code.go, which contains the chequebook code
@@ -22,8 +23,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind"
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind/backends"
@@ -64,7 +65,7 @@ func main() {
 // updated when the contract code is changed.
 const ContractDeployedCode = "%#x"
 `, code)
-	if err := ioutil.WriteFile("contract/code.go", []byte(content), 0644); err != nil {
+	if err := os.WriteFile("contract/code.go", []byte(content), 0644); err != nil {
 		panic(err)
 	}
 }

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -18,11 +18,11 @@ package core
 
 import (
 	"crypto/ecdsa"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/math"
@@ -151,7 +151,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 	if !disk {
 		db = rawdb.NewMemoryDatabase()
 	} else {
-		dir, err := ioutil.TempDir("", "eth-core-bench")
+		dir, err := os.MkdirTemp("", "eth-core-bench")
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -248,7 +248,7 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 
 func benchWriteChain(b *testing.B, full bool, count uint64) {
 	for i := 0; i < b.N; i++ {
-		dir, err := ioutil.TempDir("", "eth-chain-bench")
+		dir, err := os.MkdirTemp("", "eth-chain-bench")
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
@@ -263,7 +263,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 }
 
 func benchReadChain(b *testing.B, full bool, count uint64) {
-	dir, err := ioutil.TempDir("", "eth-chain-bench")
+	dir, err := os.MkdirTemp("", "eth-chain-bench")
 	if err != nil {
 		b.Fatalf("cannot create temporary directory: %v", err)
 	}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -19,14 +19,14 @@ package core
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/consensus"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
@@ -1543,7 +1543,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary journal: %v", err)
 	}

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -20,9 +20,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -245,7 +245,7 @@ func TestWriteExpectedValues(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_ = ioutil.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
+		_ = os.WriteFile(fmt.Sprintf("testdata/testcases_%v.json", name), data, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -255,7 +255,7 @@ func TestWriteExpectedValues(t *testing.T) {
 // TestJsonTestcases runs through all the testcases defined as json-files
 func TestJsonTestcases(t *testing.T) {
 	for name := range twoOpMethods {
-		data, err := ioutil.ReadFile(fmt.Sprintf("testdata/testcases_%v.json", name))
+		data, err := os.ReadFile(fmt.Sprintf("testdata/testcases_%v.json", name))
 		if err != nil {
 			t.Fatal("Failed to read file", err)
 		}

--- a/core/vm/privacy/bulletproof_test.go
+++ b/core/vm/privacy/bulletproof_test.go
@@ -4,11 +4,12 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInnerProductProveLen1(t *testing.T) {
@@ -409,7 +410,7 @@ func parseTestData(filePath string) MultiRangeProof {
 
 	defer jsonFile.Close()
 
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 
 	// we initialize our Users array
 	// var result map[string]interface{}
@@ -448,7 +449,8 @@ func parseTestData(filePath string) MultiRangeProof {
 	return proof
 }
 
-/**
+/*
+*
 Utils for parsing data from json
 */
 func MapBigI(list []string, f func(string) *big.Int) []*big.Int {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"os"
 
@@ -175,7 +174,7 @@ func LoadECDSA(file string) (*ecdsa.PrivateKey, error) {
 // restrictive permissions. The key data is saved hex-encoded.
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
 	k := hex.EncodeToString(FromECDSA(key))
-	return ioutil.WriteFile(file, []byte(k), 0600)
+	return os.WriteFile(file, []byte(k), 0600)
 }
 
 func GenerateKey() (*ecdsa.PrivateKey, error) {

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -122,7 +121,7 @@ func TestLoadECDSAFile(t *testing.T) {
 		}
 	}
 
-	ioutil.WriteFile(fileName0, []byte(testPrivHex), 0600)
+	os.WriteFile(fileName0, []byte(testPrivHex), 0600)
 	defer os.Remove(fileName0)
 
 	key0, err := LoadECDSA(fileName0)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -21,8 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 
 	"github.com/XinFinOrg/XDPoSChain/XDCx/tradingstate"
@@ -301,7 +301,7 @@ func (b *EthApiBackend) GetEngine() consensus.Engine {
 func (s *EthApiBackend) GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int {
 	header := s.eth.blockchain.GetHeaderByHash(hash)
 	if header != nil {
-		data, err := ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()))
+		data, err := os.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()))
 		if err == nil {
 			rewards := make(map[string]map[string]map[string]*big.Int)
 			err = json.Unmarshal(data, &rewards)
@@ -309,7 +309,7 @@ func (s *EthApiBackend) GetRewardByHash(hash common.Hash) map[string]map[string]
 				return rewards
 			}
 		} else {
-			data, err = ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.HashNoValidator().Hex()))
+			data, err = os.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.HashNoValidator().Hex()))
 			if err == nil {
 				rewards := make(map[string]map[string]map[string]*big.Int)
 				err = json.Unmarshal(data, &rewards)

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"runtime"
 	"sync"
 	"time"
@@ -393,7 +393,7 @@ func (api *PrivateDebugAPI) TraceBlock(ctx context.Context, blob []byte, config 
 // TraceBlockFromFile returns the structured logs created during the execution of
 // EVM and returns them as a JSON object.
 func (api *PrivateDebugAPI) TraceBlockFromFile(ctx context.Context, file string, config *TraceConfig) ([]*txTraceResult, error) {
-	blob, err := ioutil.ReadFile(file)
+	blob, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file: %v", err)
 	}

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -18,11 +18,11 @@ package filters
 
 import (
 	"context"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
@@ -43,7 +43,7 @@ func makeReceipt(addr common.Address) *types.Receipt {
 }
 
 func BenchmarkFilters(b *testing.B) {
-	dir, err := ioutil.TempDir("", "filtertest")
+	dir, err := os.MkdirTemp("", "filtertest")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func BenchmarkFilters(b *testing.B) {
 }
 
 func TestFilters(t *testing.T) {
-	dir, err := ioutil.TempDir("", "filtertest")
+	dir, err := os.MkdirTemp("", "filtertest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -20,8 +20,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -204,7 +204,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 // Iterates over all the input-output datasets in the tracer test harness and
 // runs the JavaScript tracers against them.
 func TestCallTracer(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestCallTracer(t *testing.T) {
 			t.Parallel()
 
 			// Call tracer test found, read if from disk
-			blob, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))
+			blob, err := os.ReadFile(filepath.Join("testdata", file.Name()))
 			if err != nil {
 				t.Fatalf("failed to read testcase: %v", err)
 			}

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -81,7 +80,7 @@ func RunGit(args ...string) string {
 
 // readGitFile returns content of file in .git directory.
 func readGitFile(file string) string {
-	content, err := ioutil.ReadFile(path.Join(".git", file))
+	content, err := os.ReadFile(path.Join(".git", file))
 	if err != nil {
 		return ""
 	}
@@ -114,7 +113,7 @@ func CopyFile(dst, src string, mode os.FileMode) {
 // so that go commands executed by build use the same version of Go as the 'host' that runs
 // build code. e.g.
 //
-//     /usr/lib/go-1.11/bin/go run build/ci.go ...
+//	/usr/lib/go-1.11/bin/go run build/ci.go ...
 //
 // runs using go 1.11 and invokes go 1.11 tools from the same GOROOT. This is also important
 // because runtime.Version checks on the host should match the tools that are run.

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -77,7 +76,7 @@ func (tt *TestCmd) Run(name string, args ...string) {
 // InputLine writes the given text to the childs stdin.
 // This method can also be called from an expect template, e.g.:
 //
-//     geth.expect(`Passphrase: {{.InputLine "password"}}`)
+//	geth.expect(`Passphrase: {{.InputLine "password"}}`)
 func (tt *TestCmd) InputLine(s string) string {
 	io.WriteString(tt.stdin, s+"\n")
 	return ""
@@ -170,7 +169,7 @@ func (tt *TestCmd) ExpectRegexp(regex string) (*regexp.Regexp, []string) {
 func (tt *TestCmd) ExpectExit() {
 	var output []byte
 	tt.withKillTimeout(func() {
-		output, _ = ioutil.ReadAll(tt.stdout)
+		output, _ = io.ReadAll(tt.stdout)
 	})
 	tt.WaitExit()
 	if tt.Cleanup != nil {

--- a/internal/guide/guide_test.go
+++ b/internal/guide/guide_test.go
@@ -23,7 +23,6 @@
 package guide
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -37,7 +36,7 @@ import (
 // Tests that the account management snippets work correctly.
 func TestAccountManagement(t *testing.T) {
 	// Create a temporary folder to work with
-	workdir, err := ioutil.TempDir("", "")
+	workdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary work dir: %v", err)
 	}

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -22,8 +22,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -239,7 +239,7 @@ func (re *JSRE) Stop(waitForCallbacks bool) {
 // Exec(file) loads and runs the contents of a file
 // if a relative path is given, the jsre's assetPath is used
 func (re *JSRE) Exec(file string) error {
-	code, err := ioutil.ReadFile(common.AbsolutePath(re.assetPath, file))
+	code, err := os.ReadFile(common.AbsolutePath(re.assetPath, file))
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func (re *JSRE) Compile(filename string, src string) (err error) {
 func (re *JSRE) loadScript(call Call) (goja.Value, error) {
 	file := call.Argument(0).ToString().String()
 	file = common.AbsolutePath(re.assetPath, file)
-	source, err := ioutil.ReadFile(file)
+	source, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("Could not read file %s: %v", file, err)
 	}

--- a/internal/jsre/jsre_test.go
+++ b/internal/jsre/jsre_test.go
@@ -17,7 +17,6 @@
 package jsre
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -41,12 +40,12 @@ func (no *testNativeObjectBinding) TestMethod(call goja.FunctionCall) goja.Value
 }
 
 func newWithTestJS(t *testing.T, testjs string) (*JSRE, string) {
-	dir, err := ioutil.TempDir("", "jsre-test")
+	dir, err := os.MkdirTemp("", "jsre-test")
 	if err != nil {
 		t.Fatal("cannot create temporary directory:", err)
 	}
 	if testjs != "" {
-		if err := ioutil.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
+		if err := os.WriteFile(path.Join(dir, "test.js"), []byte(testjs), os.ModePerm); err != nil {
 			t.Fatal("cannot create test.js:", err)
 		}
 	}

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 
 	"github.com/XinFinOrg/XDPoSChain/XDCx/tradingstate"
@@ -227,7 +227,7 @@ func (b *LesApiBackend) GetEngine() consensus.Engine {
 func (s *LesApiBackend) GetRewardByHash(hash common.Hash) map[string]map[string]map[string]*big.Int {
 	header := s.eth.blockchain.GetHeaderByHash(hash)
 	if header != nil {
-		data, err := ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()))
+		data, err := os.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.Hash().Hex()))
 		if err == nil {
 			rewards := make(map[string]map[string]map[string]*big.Int)
 			err = json.Unmarshal(data, &rewards)
@@ -235,7 +235,7 @@ func (s *LesApiBackend) GetRewardByHash(hash common.Hash) map[string]map[string]
 				return rewards
 			}
 		} else {
-			data, err = ioutil.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.HashNoValidator().Hex()))
+			data, err = os.ReadFile(filepath.Join(common.StoreRewardFolder, header.Number.String()+"."+header.HashNoValidator().Hex()))
 			if err == nil {
 				rewards := make(map[string]map[string]map[string]*big.Int)
 				err = json.Unmarshal(data, &rewards)

--- a/metrics/librato/client.go
+++ b/metrics/librato/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -93,7 +93,7 @@ func (self *LibratoClient) PostMetrics(batch Batch) (err error) {
 
 	if resp.StatusCode != http.StatusOK {
 		var body []byte
-		if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		if body, err = io.ReadAll(resp.Body); err != nil {
 			body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
 		}
 		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))

--- a/mobile/android_test.go
+++ b/mobile/android_test.go
@@ -17,7 +17,6 @@
 package geth
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -184,7 +183,7 @@ func TestAndroid(t *testing.T) {
 		t.Logf("initialization took %v", time.Since(start))
 	}
 	// Create and switch to a temporary workspace
-	workspace, err := ioutil.TempDir("", "geth-android-")
+	workspace, err := os.MkdirTemp("", "geth-android-")
 	if err != nil {
 		t.Fatalf("failed to create temporary workspace: %v", err)
 	}
@@ -214,14 +213,14 @@ func TestAndroid(t *testing.T) {
 	}
 	build.CopyFile(filepath.Join("libs", "geth.aar"), "geth.aar", os.ModePerm)
 
-	if err = ioutil.WriteFile(filepath.Join("src", "androidTest", "java", "org", "ethereum", "gethtest", "AndroidTest.java"), []byte(androidTestClass), os.ModePerm); err != nil {
+	if err = os.WriteFile(filepath.Join("src", "androidTest", "java", "org", "ethereum", "gethtest", "AndroidTest.java"), []byte(androidTestClass), os.ModePerm); err != nil {
 		t.Fatalf("failed to write Android test class: %v", err)
 	}
 	// Finish creating the project and run the tests via gradle
-	if err = ioutil.WriteFile(filepath.Join("src", "main", "AndroidManifest.xml"), []byte(androidManifest), os.ModePerm); err != nil {
+	if err = os.WriteFile(filepath.Join("src", "main", "AndroidManifest.xml"), []byte(androidManifest), os.ModePerm); err != nil {
 		t.Fatalf("failed to write Android manifest: %v", err)
 	}
-	if err = ioutil.WriteFile("build.gradle", []byte(gradleConfig), os.ModePerm); err != nil {
+	if err = os.WriteFile("build.gradle", []byte(gradleConfig), os.ModePerm); err != nil {
 		t.Fatalf("failed to write gradle build file: %v", err)
 	}
 	if output, err := exec.Command("gradle", "connectedAndroidTest").CombinedOutput(); err != nil {

--- a/node/config.go
+++ b/node/config.go
@@ -19,7 +19,6 @@ package node
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -411,7 +410,7 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 	var ephemeral string
 	if keydir == "" {
 		// There is no datadir.
-		keydir, err = ioutil.TempDir("", "go-ethereum-keystore")
+		keydir, err = os.MkdirTemp("", "go-ethereum-keystore")
 		ephemeral = keydir
 	}
 

--- a/node/config_test.go
+++ b/node/config_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,7 +31,7 @@ import (
 // ones or automatically generated temporary ones.
 func TestDatadirCreation(t *testing.T) {
 	// Create a temporary data dir and check that it can be used by a node
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create manual data dir: %v", err)
 	}
@@ -50,7 +49,7 @@ func TestDatadirCreation(t *testing.T) {
 		t.Fatalf("freshly created datadir not accessible: %v", err)
 	}
 	// Verify that an impossible datadir fails creation
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
@@ -97,7 +96,7 @@ func TestIPCPathResolution(t *testing.T) {
 // ephemeral.
 func TestNodeKeyPersistency(t *testing.T) {
 	// Create a temporary folder and make sure no key is present
-	dir, err := ioutil.TempDir("", "node-test")
+	dir, err := os.MkdirTemp("", "node-test")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}
@@ -125,7 +124,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	if _, err = crypto.LoadECDSA(keyfile); err != nil {
 		t.Fatalf("failed to load freshly persisted node key: %v", err)
 	}
-	blob1, err := ioutil.ReadFile(keyfile)
+	blob1, err := os.ReadFile(keyfile)
 	if err != nil {
 		t.Fatalf("failed to read freshly persisted node key: %v", err)
 	}
@@ -133,7 +132,7 @@ func TestNodeKeyPersistency(t *testing.T) {
 	// Configure a new node and ensure the previously persisted key is loaded
 	config = &Config{Name: "unit-test", DataDir: dir}
 	config.NodeKey()
-	blob2, err := ioutil.ReadFile(filepath.Join(keyfile))
+	blob2, err := os.ReadFile(filepath.Join(keyfile))
 	if err != nil {
 		t.Fatalf("failed to read previously persisted node key: %v", err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -77,7 +76,7 @@ func TestNodeLifeCycle(t *testing.T) {
 // Tests that if the data dir is already in use, an appropriate error is returned.
 func TestNodeUsedDataDir(t *testing.T) {
 	// Create a temporary folder to use as the data directory
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}

--- a/node/service_test.go
+++ b/node/service_test.go
@@ -18,7 +18,6 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 // the configured service context.
 func TestContextDatabases(t *testing.T) {
 	// Create a temporary folder and ensure no database is contained within
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("failed to create temporary data directory: %v", err)
 	}

--- a/p2p/discover/database_test.go
+++ b/p2p/discover/database_test.go
@@ -18,7 +18,6 @@ package discover
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -255,7 +254,7 @@ func TestNodeDBSeedQuery(t *testing.T) {
 }
 
 func TestNodeDBPersistency(t *testing.T) {
-	root, err := ioutil.TempDir("", "nodedb-")
+	root, err := os.MkdirTemp("", "nodedb-")
 	if err != nil {
 		t.Fatalf("failed to create temporary data folder: %v", err)
 	}

--- a/p2p/discv5/database_test.go
+++ b/p2p/discv5/database_test.go
@@ -18,7 +18,6 @@ package discv5
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -255,7 +254,7 @@ func TestNodeDBSeedQuery(t *testing.T) {
 }
 
 func TestNodeDBPersistency(t *testing.T) {
-	root, err := ioutil.TempDir("", "nodedb-")
+	root, err := os.MkdirTemp("", "nodedb-")
 	if err != nil {
 		t.Fatalf("failed to create temporary data folder: %v", err)
 	}

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -100,12 +100,11 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 // SendItems writes an RLP with the given code and data elements.
 // For a call such as:
 //
-//    SendItems(w, code, e1, e2, e3)
+//	SendItems(w, code, e1, e2, e3)
 //
 // the message payload will be an RLP list containing the items:
 //
-//    [e1, e2, e3]
-//
+//	[e1, e2, e3]
 func SendItems(w MsgWriter, msgcode uint64, elems ...interface{}) error {
 	return Send(w, msgcode, elems)
 }
@@ -237,7 +236,7 @@ func ExpectMsg(r MsgReader, code uint64, content interface{}) error {
 		if int(msg.Size) != len(contentEnc) {
 			return fmt.Errorf("message size mismatch: got %d, want %d", msg.Size, len(contentEnc))
 		}
-		actualContent, err := ioutil.ReadAll(msg.Payload)
+		actualContent, err := io.ReadAll(msg.Payload)
 		if err != nil {
 			return err
 		}

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"net"
 	"sync"
@@ -606,7 +605,7 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 		if msg.Size > maxUint24 {
 			return errPlainMessageTooLarge
 		}
-		payload, _ := ioutil.ReadAll(msg.Payload)
+		payload, _ := io.ReadAll(msg.Payload)
 		payload = snappy.Encode(nil, payload)
 
 		msg.Payload = bytes.NewReader(payload)
@@ -700,7 +699,7 @@ func (rw *rlpxFrameRW) ReadMsg() (msg Msg, err error) {
 
 	// if snappy is enabled, verify and decompress message
 	if rw.snappy {
-		payload, err := ioutil.ReadAll(msg.Payload)
+		payload, err := io.ReadAll(msg.Payload)
 		if err != nil {
 			return msg, err
 		}

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"reflect"
 	"strings"
@@ -305,7 +304,7 @@ ba628a4ba590cb43f7848f41c4382885
 	if msg.Code != 8 {
 		t.Errorf("msg code mismatch: got %d, want %d", msg.Code, 8)
 	}
-	payload, _ := ioutil.ReadAll(msg.Payload)
+	payload, _ := io.ReadAll(msg.Payload)
 	wantPayload := unhex("C401020304")
 	if !bytes.Equal(payload, wantPayload) {
 		t.Errorf("msg payload mismatch:\ngot  %x\nwant %x", payload, wantPayload)
@@ -370,7 +369,7 @@ func TestRLPXFrameRW(t *testing.T) {
 		if msg.Code != uint64(i) {
 			t.Fatalf("msg code mismatch: got %d, want %d", msg.Code, i)
 		}
-		payload, _ := ioutil.ReadAll(msg.Payload)
+		payload, _ := io.ReadAll(msg.Payload)
 		wantPayload, _ := rlp.EncodeToBytes(wmsg)
 		if !bytes.Equal(payload, wantPayload) {
 			t.Fatalf("msg payload mismatch:\ngot  %x\nwant %x", payload, wantPayload)

--- a/p2p/simulations/adapters/docker.go
+++ b/p2p/simulations/adapters/docker.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,7 +140,7 @@ const dockerImage = "p2p-node"
 // when executed.
 func buildDockerImage() error {
 	// create a directory to use as the build context
-	dir, err := ioutil.TempDir("", "p2p-docker")
+	dir, err := os.MkdirTemp("", "p2p-docker")
 	if err != nil {
 		return err
 	}
@@ -168,7 +167,7 @@ FROM ubuntu:16.04
 RUN mkdir /data
 ADD self.bin /bin/p2p-node
 	`)
-	if err := ioutil.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0644); err != nil {
 		return err
 	}
 

--- a/p2p/simulations/examples/ping-pong.go
+++ b/p2p/simulations/examples/ping-pong.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -62,7 +62,7 @@ func main() {
 		adapter = adapters.NewSimAdapter(services)
 
 	case "exec":
-		tmpdir, err := ioutil.TempDir("", "p2p-example")
+		tmpdir, err := os.MkdirTemp("", "p2p-example")
 		if err != nil {
 			log.Crit("error creating temp dir", "err", err)
 		}
@@ -170,7 +170,7 @@ func (p *pingPongService) Run(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 				errC <- err
 				return
 			}
-			payload, err := ioutil.ReadAll(msg.Payload)
+			payload, err := io.ReadAll(msg.Payload)
 			if err != nil {
 				errC <- err
 				return

--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -111,7 +110,7 @@ func (c *Client) SubscribeNetwork(events chan *Event, opts SubscribeOpts) (event
 		return nil, err
 	}
 	if res.StatusCode != http.StatusOK {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		res.Body.Close()
 		return nil, fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
@@ -251,7 +250,7 @@ func (c *Client) Send(method, path string, in, out interface{}) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-		response, _ := ioutil.ReadAll(res.Body)
+		response, _ := io.ReadAll(res.Body)
 		return fmt.Errorf("unexpected HTTP status: %s: %s", res.Status, response)
 	}
 	if out != nil {

--- a/p2p/testing/protocoltester.go
+++ b/p2p/testing/protocoltester.go
@@ -27,7 +27,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"sync"
 	"testing"
@@ -220,7 +219,7 @@ func expectMsgs(rw p2p.MsgReadWriter, exps []Expect) error {
 			}
 			return err
 		}
-		actualContent, err := ioutil.ReadAll(msg.Payload)
+		actualContent, err := io.ReadAll(msg.Payload)
 		if err != nil {
 			return err
 		}

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"sync"
 	"testing"
@@ -287,7 +286,7 @@ func TestEncodeToReader(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.ReadAll(r)
+		return io.ReadAll(r)
 	})
 }
 
@@ -328,7 +327,7 @@ func TestEncodeToReaderReturnToPool(t *testing.T) {
 		go func() {
 			for i := 0; i < 1000; i++ {
 				_, r, _ := EncodeToReader("foo")
-				ioutil.ReadAll(r)
+				io.ReadAll(r)
 				r.Read(buf)
 				r.Read(buf)
 				r.Read(buf)

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net"
 	"net/http"
@@ -182,7 +181,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", hc.url, ioutil.NopCloser(bytes.NewReader(body)))
+	req, err := http.NewRequestWithContext(ctx, "POST", hc.url, io.NopCloser(bytes.NewReader(body)))
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -20,8 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -52,7 +52,7 @@ func TestServerRegisterName(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	files, err := ioutil.ReadDir("testdata")
+	files, err := os.ReadDir("testdata")
 	if err != nil {
 		t.Fatal("where'd my testdata go?")
 	}
@@ -70,7 +70,7 @@ func TestServer(t *testing.T) {
 
 func runTestScript(t *testing.T, file string) {
 	server := newTestServer()
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/api_test.go
+++ b/swarm/api/api_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -30,7 +29,7 @@ import (
 )
 
 func testApi(t *testing.T, f func(*Api)) {
-	datadir, err := ioutil.TempDir("", "bzz-test")
+	datadir, err := os.MkdirTemp("", "bzz-test")
 	if err != nil {
 		t.Fatalf("unable to create temp dir: %v", err)
 	}

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -70,7 +69,7 @@ func (c *Client) UploadRaw(r io.Reader, size int64) (string, error) {
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected HTTP status: %s", res.Status)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
@@ -401,7 +400,7 @@ func (c *Client) TarUpload(hash string, uploader Uploader) (string, error) {
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected HTTP status: %s", res.Status)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
@@ -457,7 +456,7 @@ func (c *Client) MultipartUpload(hash string, uploader Uploader) (string, error)
 	if res.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected HTTP status: %s", res.Status)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -18,7 +18,7 @@ package client
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -49,7 +49,7 @@ func TestClientUploadDownloadRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer res.Close()
-	gotData, err := ioutil.ReadAll(res)
+	gotData, err := io.ReadAll(res)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestClientUploadDownloadFiles(t *testing.T) {
 	client := NewClient(srv.URL)
 	upload := func(manifest, path string, data []byte) string {
 		file := &File{
-			ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+			ReadCloser: io.NopCloser(bytes.NewReader(data)),
 			ManifestEntry: api.ManifestEntry{
 				Path:        path,
 				ContentType: "text/plain",
@@ -92,7 +92,7 @@ func TestClientUploadDownloadFiles(t *testing.T) {
 		if file.ContentType != "text/plain" {
 			t.Fatalf("expected downloaded file to have type %q, got %q", "text/plain", file.ContentType)
 		}
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,7 +136,7 @@ var testDirFiles = []string{
 }
 
 func newTestDirectory(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "swarm-client-test")
+	dir, err := os.MkdirTemp("", "swarm-client-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func newTestDirectory(t *testing.T) string {
 			os.RemoveAll(dir)
 			t.Fatalf("error creating dir for %s: %s", path, err)
 		}
-		if err := ioutil.WriteFile(path, []byte(file), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(file), 0644); err != nil {
 			os.RemoveAll(dir)
 			t.Fatalf("error writing file %s: %s", path, err)
 		}
@@ -180,7 +180,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer file.Close()
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -196,7 +196,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 	checkDownloadFile("", []byte(testDirFiles[0]))
 
 	// check we can download the directory
-	tmp, err := ioutil.TempDir("", "swarm-client-test")
+	tmp, err := os.MkdirTemp("", "swarm-client-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, file := range testDirFiles {
-		data, err := ioutil.ReadFile(filepath.Join(tmp, file))
+		data, err := os.ReadFile(filepath.Join(tmp, file))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -283,7 +283,7 @@ func TestClientMultipartUpload(t *testing.T) {
 	uploader := UploaderFunc(func(upload UploadFn) error {
 		for _, name := range testDirFiles {
 			file := &File{
-				ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+				ReadCloser: io.NopCloser(bytes.NewReader(data)),
 				ManifestEntry: api.ManifestEntry{
 					Path:        name,
 					ContentType: "text/plain",
@@ -311,7 +311,7 @@ func TestClientMultipartUpload(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer file.Close()
-		gotData, err := ioutil.ReadAll(file)
+		gotData, err := io.ReadAll(file)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/swarm/api/filesystem_test.go
+++ b/swarm/api/filesystem_test.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -28,7 +27,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/swarm/storage"
 )
 
-var testDownloadDir, _ = ioutil.TempDir(os.TempDir(), "bzz-test")
+var testDownloadDir, _ = os.MkdirTemp(os.TempDir(), "bzz-test")
 
 func testFileSystem(t *testing.T, f func(*FileSystem)) {
 	testApi(t, func(api *Api) {
@@ -38,7 +37,7 @@ func testFileSystem(t *testing.T, f func(*FileSystem)) {
 
 func readPath(t *testing.T, parts ...string) string {
 	file := filepath.Join(parts...)
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading '%v': %v", file, err)
@@ -100,7 +99,7 @@ func TestApiDirUploadModify(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 			return
 		}
-		index, err := ioutil.ReadFile(filepath.Join("testdata", "test0", "index.html"))
+		index, err := os.ReadFile(filepath.Join("testdata", "test0", "index.html"))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			return

--- a/swarm/api/http/error_test.go
+++ b/swarm/api/http/error_test.go
@@ -18,7 +18,7 @@ package http_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -43,7 +43,7 @@ func TestError(t *testing.T) {
 		t.Fatalf("Request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	respbody, err = ioutil.ReadAll(resp.Body)
+	respbody, err = io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 400 && !strings.Contains(string(respbody), "Invalid URI &#34;/this_should_fail_as_no_bzz_protocol_present&#34;: unknown scheme") {
 		t.Fatalf("Response body does not match, expected: %v, to contain: %v; received code %d, expected code: %d", string(respbody), "Invalid bzz URI: unknown scheme", 400, resp.StatusCode)
@@ -69,7 +69,7 @@ func Test404Page(t *testing.T) {
 		t.Fatalf("Request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	respbody, err = ioutil.ReadAll(resp.Body)
+	respbody, err = io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 404 || !strings.Contains(string(respbody), "404") {
 		t.Fatalf("Invalid Status Code received, expected 404, got %d", resp.StatusCode)
@@ -95,7 +95,7 @@ func Test500Page(t *testing.T) {
 		t.Fatalf("Request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	respbody, err = ioutil.ReadAll(resp.Body)
+	respbody, err = io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 404 {
 		t.Fatalf("Invalid Status Code received, expected 404, got %d", resp.StatusCode)
@@ -120,7 +120,7 @@ func Test500PageWith0xHashPrefix(t *testing.T) {
 		t.Fatalf("Request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	respbody, err = ioutil.ReadAll(resp.Body)
+	respbody, err = io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 404 {
 		t.Fatalf("Invalid Status Code received, expected 404, got %d", resp.StatusCode)
@@ -155,7 +155,7 @@ func TestJsonResponse(t *testing.T) {
 	}
 
 	defer resp.Body.Close()
-	respbody, err = ioutil.ReadAll(resp.Body)
+	respbody, err = io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 404 {
 		t.Fatalf("Invalid Status Code received, expected 404, got %d", resp.StatusCode)

--- a/swarm/api/http/roundtripper_test.go
+++ b/swarm/api/http/roundtripper_test.go
@@ -17,7 +17,7 @@
 package http
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -57,7 +57,7 @@ func TestRoundTripper(t *testing.T) {
 		}
 	}()
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 		return

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -43,7 +42,7 @@ import (
 	"github.com/rs/cors"
 )
 
-//setup metrics
+// setup metrics
 var (
 	postRawCount     = metrics.NewRegisteredCounter("api.http.post.raw.count", nil)
 	postRawFail      = metrics.NewRegisteredCounter("api.http.post.raw.fail", nil)
@@ -247,7 +246,7 @@ func (s *Server) handleMultipartUpload(req *Request, boundary string, mw *api.Ma
 			reader = part
 		} else {
 			// copy the part to a tmp file to get its size
-			tmp, err := ioutil.TempFile("", "swarm-multipart")
+			tmp, err := os.CreateTemp("", "swarm-multipart")
 			if err != nil {
 				return err
 			}
@@ -327,10 +326,10 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 }
 
 // HandleGet handles a GET request to
-// - bzz-raw://<key> and responds with the raw content stored at the
-//   given storage key
-// - bzz-hash://<key> and responds with the hash of the content stored
-//   at the given storage key as a text/plain response
+//   - bzz-raw://<key> and responds with the raw content stored at the
+//     given storage key
+//   - bzz-hash://<key> and responds with the hash of the content stored
+//     at the given storage key as a text/plain response
 func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 	getCount.Inc(1)
 	key, err := s.api.Resolve(r.uri)

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -88,7 +88,7 @@ func TestBzzGetPath(t *testing.T) {
 			t.Fatalf("Request failed: %v", err)
 		}
 		defer resp.Body.Close()
-		respbody, err = ioutil.ReadAll(resp.Body)
+		respbody, err = io.ReadAll(resp.Body)
 
 		if string(respbody) != testmanifest[v] {
 			isexpectedfailrequest := false
@@ -117,7 +117,7 @@ func TestBzzGetPath(t *testing.T) {
 			t.Fatalf("Request failed: %v", err)
 		}
 		defer resp.Body.Close()
-		respbody, err = ioutil.ReadAll(resp.Body)
+		respbody, err = io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("Read request body: %v", err)
 		}
@@ -174,7 +174,7 @@ func TestBzzGetPath(t *testing.T) {
 				t.Fatalf("HTTP request: %v", err)
 			}
 			defer resp.Body.Close()
-			respbody, err := ioutil.ReadAll(resp.Body)
+			respbody, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("Read response body: %v", err)
 			}
@@ -204,7 +204,7 @@ func TestBzzGetPath(t *testing.T) {
 				t.Fatalf("HTTP request: %v", err)
 			}
 			defer resp.Body.Close()
-			respbody, err := ioutil.ReadAll(resp.Body)
+			respbody, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatalf("Read response body: %v", err)
 			}
@@ -250,7 +250,7 @@ func TestBzzGetPath(t *testing.T) {
 			t.Fatalf("Request failed: %v", err)
 		}
 		defer resp.Body.Close()
-		respbody, err = ioutil.ReadAll(resp.Body)
+		respbody, err = io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatalf("ReadAll failed: %v", err)
 		}
@@ -272,7 +272,7 @@ func TestBzzRootRedirect(t *testing.T) {
 	client := swarm.NewClient(srv.URL)
 	data := []byte("data")
 	file := &swarm.File{
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+		ReadCloser: io.NopCloser(bytes.NewReader(data)),
 		ManifestEntry: api.ManifestEntry{
 			Path:        "",
 			ContentType: "text/plain",
@@ -310,7 +310,7 @@ func TestBzzRootRedirect(t *testing.T) {
 	if !redirected {
 		t.Fatal("expected GET /bzz:/<hash> to redirect to /bzz:/<hash>/ but it didn't")
 	}
-	gotData, err := ioutil.ReadAll(res.Body)
+	gotData, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build linux || darwin || freebsd
 // +build linux darwin freebsd
 
 package fuse
@@ -22,7 +23,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -136,7 +136,7 @@ func compareGeneratedFileWithFileInMount(t *testing.T, files map[string]fileInfo
 			t.Fatalf("file %v Permission mismatch source (-rwx------) vs destination(%v)", fname, dfinfo.Mode().Perm())
 		}
 
-		fileContents, err := ioutil.ReadFile(filepath.Join(mountDir, fname))
+		fileContents, err := os.ReadFile(filepath.Join(mountDir, fname))
 		if err != nil {
 			t.Fatalf("Could not readfile %v : %v", fname, err)
 		}
@@ -195,8 +195,8 @@ type testAPI struct {
 
 func (ta *testAPI) mountListAndUnmount(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "fuse-source")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "fuse-dest")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "fuse-source")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "fuse-dest")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["2.txt"] = fileInfo{0711, 333, 444, getRandomBtes(10)}
@@ -233,44 +233,44 @@ func (ta *testAPI) mountListAndUnmount(t *testing.T) {
 func (ta *testAPI) maxMounts(t *testing.T) {
 	files := make(map[string]fileInfo)
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir1, _ := ioutil.TempDir(os.TempDir(), "max-upload1")
+	uploadDir1, _ := os.MkdirTemp(os.TempDir(), "max-upload1")
 	bzzHash1 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir1)
-	mount1, _ := ioutil.TempDir(os.TempDir(), "max-mount1")
+	mount1, _ := os.MkdirTemp(os.TempDir(), "max-mount1")
 	swarmfs1 := mountDir(t, ta.api, files, bzzHash1, mount1)
 	defer swarmfs1.Stop()
 
 	files["2.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir2, _ := ioutil.TempDir(os.TempDir(), "max-upload2")
+	uploadDir2, _ := os.MkdirTemp(os.TempDir(), "max-upload2")
 	bzzHash2 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir2)
-	mount2, _ := ioutil.TempDir(os.TempDir(), "max-mount2")
+	mount2, _ := os.MkdirTemp(os.TempDir(), "max-mount2")
 	swarmfs2 := mountDir(t, ta.api, files, bzzHash2, mount2)
 	defer swarmfs2.Stop()
 
 	files["3.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir3, _ := ioutil.TempDir(os.TempDir(), "max-upload3")
+	uploadDir3, _ := os.MkdirTemp(os.TempDir(), "max-upload3")
 	bzzHash3 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir3)
-	mount3, _ := ioutil.TempDir(os.TempDir(), "max-mount3")
+	mount3, _ := os.MkdirTemp(os.TempDir(), "max-mount3")
 	swarmfs3 := mountDir(t, ta.api, files, bzzHash3, mount3)
 	defer swarmfs3.Stop()
 
 	files["4.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir4, _ := ioutil.TempDir(os.TempDir(), "max-upload4")
+	uploadDir4, _ := os.MkdirTemp(os.TempDir(), "max-upload4")
 	bzzHash4 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir4)
-	mount4, _ := ioutil.TempDir(os.TempDir(), "max-mount4")
+	mount4, _ := os.MkdirTemp(os.TempDir(), "max-mount4")
 	swarmfs4 := mountDir(t, ta.api, files, bzzHash4, mount4)
 	defer swarmfs4.Stop()
 
 	files["5.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir5, _ := ioutil.TempDir(os.TempDir(), "max-upload5")
+	uploadDir5, _ := os.MkdirTemp(os.TempDir(), "max-upload5")
 	bzzHash5 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir5)
-	mount5, _ := ioutil.TempDir(os.TempDir(), "max-mount5")
+	mount5, _ := os.MkdirTemp(os.TempDir(), "max-mount5")
 	swarmfs5 := mountDir(t, ta.api, files, bzzHash5, mount5)
 	defer swarmfs5.Stop()
 
 	files["6.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir6, _ := ioutil.TempDir(os.TempDir(), "max-upload6")
+	uploadDir6, _ := os.MkdirTemp(os.TempDir(), "max-upload6")
 	bzzHash6 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir6)
-	mount6, _ := ioutil.TempDir(os.TempDir(), "max-mount6")
+	mount6, _ := os.MkdirTemp(os.TempDir(), "max-mount6")
 
 	os.RemoveAll(mount6)
 	os.MkdirAll(mount6, 0777)
@@ -284,15 +284,15 @@ func (ta *testAPI) maxMounts(t *testing.T) {
 func (ta *testAPI) remount(t *testing.T) {
 	files := make(map[string]fileInfo)
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
-	uploadDir1, _ := ioutil.TempDir(os.TempDir(), "re-upload1")
+	uploadDir1, _ := os.MkdirTemp(os.TempDir(), "re-upload1")
 	bzzHash1 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir1)
-	testMountDir1, _ := ioutil.TempDir(os.TempDir(), "re-mount1")
+	testMountDir1, _ := os.MkdirTemp(os.TempDir(), "re-mount1")
 	swarmfs := mountDir(t, ta.api, files, bzzHash1, testMountDir1)
 	defer swarmfs.Stop()
 
-	uploadDir2, _ := ioutil.TempDir(os.TempDir(), "re-upload2")
+	uploadDir2, _ := os.MkdirTemp(os.TempDir(), "re-upload2")
 	bzzHash2 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir2)
-	testMountDir2, _ := ioutil.TempDir(os.TempDir(), "re-mount2")
+	testMountDir2, _ := os.MkdirTemp(os.TempDir(), "re-mount2")
 
 	// try mounting the same hash second time
 	os.RemoveAll(testMountDir2)
@@ -317,8 +317,8 @@ func (ta *testAPI) remount(t *testing.T) {
 
 func (ta *testAPI) unmount(t *testing.T) {
 	files := make(map[string]fileInfo)
-	uploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
+	uploadDir, _ := os.MkdirTemp(os.TempDir(), "ex-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "ex-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir)
@@ -338,8 +338,8 @@ func (ta *testAPI) unmount(t *testing.T) {
 
 func (ta *testAPI) unmountWhenResourceBusy(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "ex-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "ex-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir)
@@ -367,8 +367,8 @@ func (ta *testAPI) unmountWhenResourceBusy(t *testing.T) {
 
 func (ta *testAPI) seekInMultiChunkFile(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "seek-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "seek-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "seek-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "seek-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10240)}
 	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir)
@@ -394,8 +394,8 @@ func (ta *testAPI) seekInMultiChunkFile(t *testing.T) {
 
 func (ta *testAPI) createNewFile(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "create-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "create-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "create-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "create-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -431,8 +431,8 @@ func (ta *testAPI) createNewFile(t *testing.T) {
 
 func (ta *testAPI) createNewFileInsideDirectory(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "createinsidedir-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "createinsidedir-mount")
 
 	files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir)
@@ -467,8 +467,8 @@ func (ta *testAPI) createNewFileInsideDirectory(t *testing.T) {
 
 func (ta *testAPI) createNewFileInsideNewDirectory(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "createinsidenewdir-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "createinsidenewdir-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir)
@@ -504,8 +504,8 @@ func (ta *testAPI) createNewFileInsideNewDirectory(t *testing.T) {
 
 func (ta *testAPI) removeExistingFile(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "remove-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "remove-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -532,8 +532,8 @@ func (ta *testAPI) removeExistingFile(t *testing.T) {
 
 func (ta *testAPI) removeExistingFileInsideDir(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "remove-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "remove-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["one/five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -561,8 +561,8 @@ func (ta *testAPI) removeExistingFileInsideDir(t *testing.T) {
 func (ta *testAPI) removeNewlyAddedFile(t *testing.T) {
 
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "removenew-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "removenew-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "removenew-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "removenew-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -605,8 +605,8 @@ func (ta *testAPI) removeNewlyAddedFile(t *testing.T) {
 
 func (ta *testAPI) addNewFileAndModifyContents(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "modifyfile-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "modifyfile-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -675,8 +675,8 @@ func (ta *testAPI) addNewFileAndModifyContents(t *testing.T) {
 
 func (ta *testAPI) removeEmptyDir(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "rmdir-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "rmdir-mount")
 
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -699,8 +699,8 @@ func (ta *testAPI) removeEmptyDir(t *testing.T) {
 
 func (ta *testAPI) removeDirWhichHasFiles(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "rmdir-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "rmdir-mount")
 
 	files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["two/five.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -728,8 +728,8 @@ func (ta *testAPI) removeDirWhichHasFiles(t *testing.T) {
 
 func (ta *testAPI) removeDirWhichHasSubDirs(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "rmsubdir-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "rmsubdir-mount")
 
 	files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
 	files["two/three/2.txt"] = fileInfo{0700, 333, 444, getRandomBtes(10)}
@@ -764,8 +764,8 @@ func (ta *testAPI) removeDirWhichHasSubDirs(t *testing.T) {
 
 func (ta *testAPI) appendFileContentsToEnd(t *testing.T) {
 	files := make(map[string]fileInfo)
-	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-upload")
-	testMountDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-mount")
+	testUploadDir, _ := os.MkdirTemp(os.TempDir(), "appendlargefile-upload")
+	testMountDir, _ := os.MkdirTemp(os.TempDir(), "appendlargefile-mount")
 
 	line1 := make([]byte, 10)
 	rand.Read(line1)
@@ -802,7 +802,7 @@ func (ta *testAPI) appendFileContentsToEnd(t *testing.T) {
 }
 
 func TestFUSE(t *testing.T) {
-	datadir, err := ioutil.TempDir("", "fuse")
+	datadir, err := os.MkdirTemp("", "fuse")
 	if err != nil {
 		t.Fatalf("unable to create temp dir: %v", err)
 	}

--- a/swarm/network/kademlia/kaddb.go
+++ b/swarm/network/kademlia/kaddb.go
@@ -19,7 +19,6 @@ package kademlia
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -165,7 +164,6 @@ offline past peer)
 || (proxBin(a) < proxBin(b) && |proxBin(a)| == |proxBin(b)|)
 || (proxBin(a) == proxBin(b) && lastChecked(a) < lastChecked(b))
 
-
 The second argument returned names the first missing slot found
 */
 func (self *KadDb) findBest(maxBinSize int, binSize func(int) int) (node *NodeRecord, need bool, proxLimit int) {
@@ -292,7 +290,7 @@ func (self *KadDb) save(path string, cb func(*NodeRecord, Node)) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(path, data, os.ModePerm)
+	err = os.WriteFile(path, data, os.ModePerm)
 	if err != nil {
 		log.Warn(fmt.Sprintf("unable to save kaddb with %v nodes to %v: %v", n, path, err))
 	} else {
@@ -307,7 +305,7 @@ func (self *KadDb) load(path string, cb func(*NodeRecord, Node) error) (err erro
 	self.lock.Lock()
 
 	var data []byte
-	data, err = ioutil.ReadFile(path)
+	data, err = os.ReadFile(path)
 	if err != nil {
 		return
 	}

--- a/swarm/network/syncdb_test.go
+++ b/swarm/network/syncdb_test.go
@@ -19,7 +19,6 @@ package network
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ type testSyncDb struct {
 
 func newTestSyncDb(priority, bufferSize, batchSize int, dbdir string, t *testing.T) *testSyncDb {
 	if len(dbdir) == 0 {
-		tmp, err := ioutil.TempDir(os.TempDir(), "syncdb-test")
+		tmp, err := os.MkdirTemp(os.TempDir(), "syncdb-test")
 		if err != nil {
 			t.Fatalf("unable to create temporary direcory %v: %v", tmp, err)
 		}

--- a/swarm/storage/dbstore.go
+++ b/swarm/storage/dbstore.go
@@ -29,7 +29,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -39,7 +38,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 )
 
-//metrics variables
+// metrics variables
 var (
 	gcCounter            = metrics.NewRegisteredCounter("storage.db.dbstore.gc.count", nil)
 	dbStoreDeleteCounter = metrics.NewRegisteredCounter("storage.db.dbstore.rm.count", nil)
@@ -338,7 +337,7 @@ func (s *DbStore) Import(in io.Reader) (int64, error) {
 			continue
 		}
 
-		data, err := ioutil.ReadAll(tr)
+		data, err := io.ReadAll(tr)
 		if err != nil {
 			return count, err
 		}
@@ -540,7 +539,8 @@ func (s *DbStore) Close() {
 	s.db.Close()
 }
 
-//  describes a section of the DbStore representing the unsynced
+//	describes a section of the DbStore representing the unsynced
+//
 // domain relevant to a peer
 // Start - Stop designate a continuous area Keys in an address space
 // typically the addresses closer to us than to the peer but not closer

--- a/swarm/storage/dbstore_test.go
+++ b/swarm/storage/dbstore_test.go
@@ -18,14 +18,14 @@ package storage
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 )
 
 func initDbStore(t *testing.T) *DbStore {
-	dir, err := ioutil.TempDir("", "bzz-storage-test")
+	dir, err := os.MkdirTemp("", "bzz-storage-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/storage/dpa_test.go
+++ b/swarm/storage/dpa_test.go
@@ -19,7 +19,6 @@ package storage
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -63,8 +62,8 @@ func TestDPArandom(t *testing.T) {
 	if !bytes.Equal(slice, resultSlice) {
 		t.Errorf("Comparison error.")
 	}
-	ioutil.WriteFile("/tmp/slice.bzz.16M", slice, 0666)
-	ioutil.WriteFile("/tmp/result.bzz.16M", resultSlice, 0666)
+	os.WriteFile("/tmp/slice.bzz.16M", slice, 0666)
+	os.WriteFile("/tmp/result.bzz.16M", resultSlice, 0666)
 	localStore.memStore = NewMemStore(dbStore, defaultCacheCapacity)
 	resultReader = dpa.Retrieve(key)
 	for i := range resultSlice {

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -17,7 +17,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -28,7 +27,7 @@ import (
 )
 
 func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
-	dir, err := ioutil.TempDir("", "swarm-storage-test")
+	dir, err := os.MkdirTemp("", "swarm-storage-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -43,7 +42,7 @@ var (
 )
 
 func readJson(reader io.Reader, value interface{}) error {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("error reading JSON file: %v", err)
 	}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -819,7 +818,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 }
 
 func tempDB() (string, *Database) {
-	dir, err := ioutil.TempDir("", "trie-bench")
+	dir, err := os.MkdirTemp("", "trie-bench")
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}

--- a/whisper/mailserver/server_test.go
+++ b/whisper/mailserver/server_test.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/binary"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -83,7 +83,7 @@ func TestMailServer(t *testing.T) {
 	const password = "password_for_this_test"
 	const dbPath = "whisper-server-test"
 
-	dir, err := ioutil.TempDir("", dbPath)
+	dir, err := os.MkdirTemp("", dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [✅] Not sure (Please specify below)
ioutil library code

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_
- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A


ref:
https://stackoverflow.com/questions/75206234/for-go-ioutil-readall-ioutil-readfile-ioutil-readdir-deprecated
https://pkg.go.dev/io/ioutil