### PR TITLE
fix: replace all time.after with the time.newtimer

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -1088,8 +1088,10 @@ func (x *XDPoS_v2) allowedToSend(chain consensus.ChainReader, blockHeader *types
 // Periodlly execution(Attached to engine initialisation during "new"). Used for pool cleaning etc
 func (x *XDPoS_v2) periodicJob() {
 	go func() {
+		ticker := time.NewTicker(utils.PeriodicJobPeriod * time.Second)
+		defer ticker.Stop()
 		for {
-			<-time.After(utils.PeriodicJobPeriod * time.Second)
+			<-ticker.C
 			x.hygieneVotePool()
 			x.hygieneTimeoutPool()
 		}

--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -156,12 +156,16 @@ func generateCache(dest []uint32, epoch uint64, seed []byte) {
 	defer close(done)
 
 	go func() {
+		waitDuration := 3 * time.Second
+		timer := time.NewTimer(waitDuration)
+		defer timer.Stop()
 		for {
 			select {
 			case <-done:
 				return
-			case <-time.After(3 * time.Second):
+			case <-timer.C:
 				logger.Info("Generating ethash verification cache", "percentage", atomic.LoadUint32(&progress)*100/uint32(rows)/4, "elapsed", common.PrettyDuration(time.Since(start)))
+				timer.Reset(waitDuration)
 			}
 		}
 	}()

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -606,6 +606,9 @@ func (s *MatcherSession) DeliverSections(bit uint, sections []uint64, bitsets []
 // of the session, any request in-flight need to be responded to! Empty responses
 // are fine though in that case.
 func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan *Retrieval) {
+	ticker := time.NewTicker(wait)
+	defer ticker.Stop()
+
 	for {
 		// Allocate a new bloom bit index to retrieve data for, stopping when done
 		bit, ok := s.AllocateRetrieval()
@@ -621,7 +624,7 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 				s.DeliverSections(bit, []uint64{}, [][]byte{})
 				return
 
-			case <-time.After(wait):
+			case <-ticker.C:
 				// Throttling up, fetch whatever's available
 			}
 		}


### PR DESCRIPTION
# Proposed changes
Replace all the time.after with time.newTimer to avoid memory leak

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [x] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [x] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
