### PR TITLE
RIN-02 Panic Due to Integer Overflow in Signature Size Calculation

### DIFF
--- a/core/vm/privacy/ringct.go
+++ b/core/vm/privacy/ringct.go
@@ -181,11 +181,11 @@ func computeSignatureSize(numRing int, ringSize int) int {
 		return -1
 	}
 
-	// Calculate each term separately and check for overflow
-	term1 := 8 + 8 + 32 + 32
-	term2 := numRing * ringSize * 65
+	// Calculate term and check for overflow
 
-	if term2 < 0 || term2 > MaxInt-term1 {
+	term := numRing * ringSize * 65
+
+	if term < 0 || term < numRing || term < ringSize {
 		return -1
 	}
 

--- a/core/vm/privacy/ringct.go
+++ b/core/vm/privacy/ringct.go
@@ -183,16 +183,13 @@ func computeSignatureSize(numRing int, ringSize int) int {
 
 	// Calculate each term separately and check for overflow
 	term1 := 8 + 8 + 32 + 32
-	term2 := numRing * ringSize * 32
-	term3 := numRing * ringSize * 33
-	term4 := numRing * 33
+	term2 := numRing * ringSize * 65
 
-	if term2 < 0 || term3 < 0 || term4 < 0 || term2 > MaxInt-term1 || term3 > MaxInt-(term1+term2) || term4 > MaxInt-(term1+term2+term3) {
+	if term2 < 0 || term2 > MaxInt-term1 {
 		return -1
 	}
 
-	result := term1 + term2 + term3 + term4
-	return result
+	return 8 + 8 + 32 + 32 + numRing*ringSize*32 + numRing*ringSize*33 + numRing*33
 }
 
 // deserializes the byteified signature into a RingSignature struct

--- a/core/vm/privacy/ringct_test.go
+++ b/core/vm/privacy/ringct_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSign(t *testing.T) {
@@ -78,7 +80,5 @@ func TestDeserialize(t *testing.T) {
 	sig = append(sig, tail...)
 
 	_, err = Deserialize(sig)
-	if err != nil {
-		t.Error("Failed to Serialize input Ring signature")
-	}
+	assert.EqualError(t, err, "incorrect ring size, len r: 3804, sig.NumRing: 5 sig.Size: 56759212534490939")
 }


### PR DESCRIPTION
# Proposed changes
[Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
](https://skyharbor.certik.com/report/e1b36ec7-b346-4ed9-a193-a72ad2337f68?findingIndex=1705333051226)
Malicious users can create signatures with invalid sizes but with forged numRing and ringSize to bypass the signature size check.

As a result, a panic from a buffer overflow may happen when the implementation tries to deserialize sig.S from the input with a big offset value.
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [x] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
