### PR TITLE
fix: limit the max size of lending item extradata can be inside the t…

### DIFF
--- a/XDCxlending/lendingstate/lendingitem.go
+++ b/XDCxlending/lendingstate/lendingitem.go
@@ -27,7 +27,13 @@ const (
 	LendingStatusCancelled     = "CANCELLED"
 	Market                     = "MO"
 	Limit                      = "LO"
-	MaxLendingExtraDataSize    = 200
+	/*
+		Based on all structs that were used to encode into extraData, we can see the liquidationData is likely be the one with max length in payload.
+		A assumptions was made that each numeric value (RecallAmount, LiquidationAmount, CollateralPrice) is up to 30 digits long and the Reason field is 20 characters long, the estimated maximum size of the ExtraData JSON string in the ProcessLiquidationData function would be approximately 185 bytes.
+		Hence the value of 200 has been chosen to safeguard the block/tx in XDC in terms of sizes.
+
+	*/
+	MaxLendingExtraDataSize = 200
 )
 
 var ValidInputLendingStatus = map[string]bool{

--- a/XDCxlending/lendingstate/lendingitem.go
+++ b/XDCxlending/lendingstate/lendingitem.go
@@ -27,6 +27,7 @@ const (
 	LendingStatusCancelled     = "CANCELLED"
 	Market                     = "MO"
 	Limit                      = "LO"
+	MaxLendingExtraDataSize    = 200
 )
 
 var ValidInputLendingStatus = map[string]bool{
@@ -233,6 +234,9 @@ func (l *LendingItem) VerifyLendingItem(state *state.StateDB) error {
 	if err := l.VerifyLendingSignature(); err != nil {
 		return err
 	}
+	if err := l.VerifyLendingExtraData(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -278,6 +282,13 @@ func (l *LendingItem) VerifyLendingQuantity() error {
 func (l *LendingItem) VerifyLendingType() error {
 	if valid, ok := ValidInputLendingType[l.Type]; !ok && !valid {
 		return fmt.Errorf("VerifyLendingType: invalid lending type. Type: %s", l.Type)
+	}
+	return nil
+}
+
+func (l *LendingItem) VerifyLendingExtraData() error {
+	if len(l.ExtraData) > MaxLendingExtraDataSize {
+		return fmt.Errorf("VerifyLendingExtraData: invalid lending extraData size. Size: %v", len(l.ExtraData))
 	}
 	return nil
 }

--- a/XDCxlending/lendingstate/lendingitem_test.go
+++ b/XDCxlending/lendingstate/lendingitem_test.go
@@ -2,17 +2,18 @@ package lendingstate
 
 import (
 	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/crypto/sha3"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
-	"math/big"
-	"math/rand"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestLendingItem_VerifyLendingSide(t *testing.T) {
@@ -103,6 +104,27 @@ func TestLendingItem_VerifyLendingType(t *testing.T) {
 			}
 			if err := l.VerifyLendingType(); (err != nil) != tt.wantErr {
 				t.Errorf("VerifyLendingType() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLendingItem_VerifyExtraData(t *testing.T) {
+	tests := []struct {
+		name    string
+		fields  *LendingItem
+		wantErr bool
+	}{
+		{"within the limit", &LendingItem{ExtraData: "123"}, false},
+		{"within the limit", &LendingItem{ExtraData: "This is a string specifically designed to exceed 201 bytes in length. It contains enough characters, including spaces and punctuation, to ensure that its total size goes beyond the specified limit for demonstration purposes."}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &LendingItem{
+				ExtraData: tt.fields.ExtraData,
+			}
+			if err := l.VerifyLendingExtraData(); (err != nil) != tt.wantErr {
+				t.Errorf("VerifyLendingExtraData() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
# Proposed changes
This PR is to fix the issue with no checking on the extradata field inside the trading and lending payload. 

II'm taking the best guess based on the implementation of the extradata inside the trading and lending codebase.
The extraData can be one of the following data:
```
// from XDCxLending.go
extraData, _ := json.Marshal(struct {
	Price *big.Int
}{
        Price: XYZ,
})
// OR, from the `liquidationData` inside the same file (can also be found in order_processor.go)
liquidationData := lendingstate.LiquidationData{
	RecallAmount:      common.Big0,
	LiquidationAmount: newTrade.CollateralLockedAmount,
	CollateralPrice:   collateralPrice,
	Reason:            lendingstate.LiquidatedByPrice,
}
extraData, _ := json.Marshal(liquidationData)

// OR from the order_process.go's cancelOrder
extraData, _ := json.Marshal(struct {
   CancelFee       string
   TokenPriceInXDC string
}{
   CancelFee:       tokenCancelFee.Text(10),
   TokenPriceInXDC: tokenPriceInXDC.Text(10),
})
```

Based on the above struct, we can see the `liquidationData` is likely be the one with max length in payload.
I made theaAssumptions that each numeric value (RecallAmount, LiquidationAmount, CollateralPrice) is up to 30 digits long and the Reason field is 20 characters long, the estimated maximum size of the ExtraData JSON string in the ProcessLiquidationData function would be approximately 185 bytes. 
Hence the value of 200 has been chosen to safeguard the block/tx in XDC in terms of sizes. 

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [x] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
