### PR TITLE
fix: GenNewKeyRing should return out of bound error if s and ring siz…

### DIFF
--- a/core/vm/privacy/ringct.go
+++ b/core/vm/privacy/ringct.go
@@ -8,8 +8,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/common"
 	"math/big"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
 
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -28,18 +29,18 @@ const (
 	pubkeyHybrid       byte = 0x6 // y_bit + x coord + y coord
 )
 
-//The proof contains pretty much stuffs
-//The proof contains pretty much stuffs
-//Ring size rs: 1 byte => proof[0]
-//num input: number of real inputs: 1 byte => proof[1]
-//List of inputs/UTXO index typed uint64 => total size = rs * numInput * 8 = proof[0]*proof[1]*8
-//List of key images: total size = numInput * 33 = proof[1] * 33
-//number of output n: 1 byte
-//List of output => n * 130 bytes
-//transaction fee: uint256 => 32 byte
-//ringCT proof size ctSize: uint16 => 2 byte
-//ringCT proof: ctSize bytes
-//bulletproofs: bp
+// The proof contains pretty much stuffs
+// The proof contains pretty much stuffs
+// Ring size rs: 1 byte => proof[0]
+// num input: number of real inputs: 1 byte => proof[1]
+// List of inputs/UTXO index typed uint64 => total size = rs * numInput * 8 = proof[0]*proof[1]*8
+// List of key images: total size = numInput * 33 = proof[1] * 33
+// number of output n: 1 byte
+// List of output => n * 130 bytes
+// transaction fee: uint256 => 32 byte
+// ringCT proof size ctSize: uint16 => 2 byte
+// ringCT proof: ctSize bytes
+// bulletproofs: bp
 type PrivateSendVerifier struct {
 	proof []byte
 	//ringCT 	RingCT
@@ -273,7 +274,7 @@ func GenNewKeyRing(size int, privkey *ecdsa.PrivateKey, s int) ([]*ecdsa.PublicK
 	ring := make([]*ecdsa.PublicKey, size)
 	pubkey := privkey.Public().(*ecdsa.PublicKey)
 
-	if s > len(ring) {
+	if s >= len(ring) {
 		return nil, errors.New("index s out of bounds")
 	}
 
@@ -545,7 +546,7 @@ func Link(sig_a *RingSignature, sig_b *RingSignature) bool {
 	return false
 }
 
-//function returns(mutiple rings, private keys, message, error)
+// function returns(mutiple rings, private keys, message, error)
 func GenerateMultiRingParams(numRing int, ringSize int, s int) (rings []Ring, privkeys []*ecdsa.PrivateKey, m [32]byte, err error) {
 	for i := 0; i < numRing; i++ {
 		privkey, err := crypto.GenerateKey()


### PR DESCRIPTION
# Proposed changes
Make sure we cover the case where s and len(ring) would be the same for out of bound error.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
