### PR TITLE
fix: missing validation in unpacklog

### DIFF
--- a/accounts/abi/abi.go
+++ b/accounts/abi/abi.go
@@ -148,7 +148,6 @@ func (abi *ABI) MethodById(sigdata []byte) (*Method, error) {
 	return nil, fmt.Errorf("no method with id: %#x", sigdata[:4])
 }
 
-
 // revertSelector is a special function selector for revert reason unpacking.
 var revertSelector = crypto.Keccak256([]byte("Error(string)"))[:4]
 

--- a/accounts/abi/argument.go
+++ b/accounts/abi/argument.go
@@ -290,7 +290,7 @@ func capitalise(input string) string {
 	return strings.ToUpper(input[:1]) + input[1:]
 }
 
-//unpackStruct extracts each argument into its corresponding struct field
+// unpackStruct extracts each argument into its corresponding struct field
 func unpackStruct(value, reflectValue reflect.Value, arg Argument) error {
 	name := capitalise(arg.Name)
 	typ := value.Type()

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -30,6 +30,10 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/event"
 )
 
+var (
+	errNoEventSignature = errors.New("no event signature")
+)
+
 // SignerFn is a signer function callback when a contract requires a method to
 // sign the transaction before submission.
 type SignerFn func(types.Signer, common.Address, *types.Transaction) (*types.Transaction, error)
@@ -326,6 +330,13 @@ func (c *BoundContract) WatchLogs(opts *WatchOpts, name string, query ...[]inter
 
 // UnpackLog unpacks a retrieved log into the provided output structure.
 func (c *BoundContract) UnpackLog(out interface{}, event string, log types.Log) error {
+	// Anonymous events are not supported.
+	if len(log.Topics) == 0 {
+		return errNoEventSignature
+	}
+	if log.Topics[0] != c.abi.Events[event].Id() {
+		return fmt.Errorf("event signature mismatch")
+	}
 	if len(log.Data) > 0 {
 		if err := c.abi.Unpack(out, event, log.Data); err != nil {
 			return err


### PR DESCRIPTION
# Proposed changes
Add two more if condition to double check the signature is valid in unpacklog method inside the abi

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
