### PR TITLE
improve the method eth_estimateGas

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1251,7 +1251,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, bl
 
 		res, _, failed, err, vmErr := s.doCall(ctx, args, rpc.LatestBlockNumber, vm.Config{}, 0)
 		if err != nil {
-			if errors.Is(err, core.ErrIntrinsicGas) {
+			if errors.Is(err, vm.ErrOutOfGas) || errors.Is(err, core.ErrIntrinsicGas) {
 				return false, nil, nil, nil // Special case, raise gas limit
 			}
 			return false, nil, err, nil // Bail out


### PR DESCRIPTION
# Proposed changes

This PR improve the method eth_estimateGas:
-  return the right result for the tx which to is EOA and includes arbitrary data (fix issue #340)
- short circuit estimation and directly try 21000 if the tx is a plain value transfer

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A

## Test cases

```bash
curl ${RPC} -X POST -H "Content-Type: application/json" -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "data": "0x01234567"
    },
    "latest"
  ]
}'

curl ${RPC} -X POST -H "Content-Type: application/json" -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "data": "0x012345670123456789012345678901234567890123456789012345678901234567890123"
    },
    "latest"
  ]
}'

curl ${RPC} -X POST -H "Content-Type: application/json" -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "data": "0x0123456701234567890123456789012345678901234567890123456789012345678901230123456789012345678901234567890123456789012345678901234567890123"
    },
    "latest"
  ]
}'

curl ${RPC} -X POST -H "Content-Type: application/json" -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x1234",
      "data": ""
    },
    "latest"
  ]
}'

curl ${RPC} -X POST -H "Content-Type: application/json" -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x1234"
    },
    "latest"
  ]
}'

```
