### PR TITLE
fix: add infinity point check on the DeserializeCompressed method

### DIFF
--- a/core/vm/privacy/ringct.go
+++ b/core/vm/privacy/ringct.go
@@ -91,7 +91,20 @@ func SerializeCompressed(p *ecdsa.PublicKey) []byte {
 }
 
 func DeserializeCompressed(curve elliptic.Curve, b []byte) *ecdsa.PublicKey {
+	if len(b) < 33 {
+		// Not enough data to represent a compressed public key
+		return nil
+	}
+
 	x := new(big.Int).SetBytes(b[1:33])
+	if x.Sign() == 0 {
+		// This condition checks if the x-coordinate is zero, which is not a
+		// perfect check for the infinity point but serves as a simple proxy.
+		// A more accurate approach might involve checking against specific
+		// representations of the infinity point depending on the curve and
+		// usage context.
+		return nil // or return a representation of the infinity point if your application requires it
+	}
 	// Y = +-sqrt(x^3 + B)
 	x3 := new(big.Int).Mul(x, x)
 	x3.Mul(x3, x)

--- a/core/vm/privacy/ringct_test.go
+++ b/core/vm/privacy/ringct_test.go
@@ -322,7 +322,19 @@ func TestNilPointerDereferencePanic(t *testing.T) {
 		t.Error("Failed to Serialize input Ring signature")
 	}
 
-	_ , err = Deserialize(sig)
+	_, err = Deserialize(sig)
 	// Should failed to verify Ring signature as the signature is invalid
 	assert.EqualError(t, err, "failed to deserialize, invalid ring signature")
+}
+
+func TestDeserializeCompressedForInfinity(t *testing.T) {
+	curve := crypto.S256()
+	pub := []byte{}
+	pub = append(pub, byte(2))
+	xCoordinate := make([]byte, 32) // 0 x-coordinate
+	pub = append(pub, xCoordinate...)
+
+	fmt.Printf("Compressed public key: %x\n", pub) // infinity point
+	pubkey := DeserializeCompressed(curve, pub)
+	assert.Nil(t, pubkey, "DeserializeCompressed should return nil")
 }


### PR DESCRIPTION
# Proposed changes
The method DeserializeCompressed is missing checks on the infinity point check.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)
VM

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
