### PR TITLE
Use PRIVATE_KEY env as start script

### DIFF
--- a/cicd/devnet/start.sh
+++ b/cicd/devnet/start.sh
@@ -1,28 +1,16 @@
 #!/bin/bash
-
-# Update AWS Max Health can resolve below issue, and it's already addressed
-# echo "Preparing to start the XDC chain, it's likely to take up to 1 minute"
-# Sleep for > 30 as we need to wait for the ECS tasks container being killed by fargate. Otherwise it will ended up with two same nodes running on a single /work/xdcchain directory
-# sleep 60
-
 if [ ! -d /work/xdcchain/XDC/chaindata ]
 then
-  # Randomly select a key from environment variable, seperated by ','
-  if test -z "$PRIVATE_KEYS" 
+  if test -z "$PRIVATE_KEY"
   then
-        echo "PRIVATE_KEYS environment variable has not been set. You need to pass at least one PK, or you can pass multiple PK seperated by ',', we will randomly choose one for you"
+        echo "PRIVATE_KEY environment variable has not been set."
         exit 1
   fi
-  IFS=', ' read -r -a private_keys <<< "$PRIVATE_KEYS"
-  private_key=${private_keys[ $RANDOM % ${#private_keys[@]} ]}
-
-  echo "${private_key}" >> /tmp/key
-  echo "Creating a new wallet"
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key |  awk -F '[{}]' '{print $2}')
+  echo $PRIVATE_KEY >> /tmp/key
+  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -v FS="({|})" '{print $2}')
   XDC --datadir /work/xdcchain init /work/genesis.json
 else
-  echo "Wallet already exist, re-use the same one"
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 |  awk -F '[{}]' '{print $2}')
+  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -v FS="({|})" '{print $2}')
 fi
 
 input="/work/bootnodes.list"

--- a/cicd/mainnet/start.sh
+++ b/cicd/mainnet/start.sh
@@ -1,23 +1,16 @@
 #!/bin/bash
-
 if [ ! -d /work/xdcchain/XDC/chaindata ]
 then
-  # Randomly select a key from environment variable, seperated by ','
-  if test -z "$PRIVATE_KEYS"
+  if test -z "$PRIVATE_KEY"
   then
-        echo "PRIVATE_KEYS environment variable has not been set. You need to pass at least one PK, or you can pass multiple PK seperated by ',', we will randomly choose one for you"
+        echo "PRIVATE_KEY environment variable has not been set."
         exit 1
   fi
-  IFS=', ' read -r -a private_keys <<< "$PRIVATE_KEYS"
-  private_key=${private_keys[ $RANDOM % ${#private_keys[@]} ]}
-
-  echo "${private_key}" >> /tmp/key
-  echo "Creating a new wallet"
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
+  echo $PRIVATE_KEY >> /tmp/key
+  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -v FS="({|})" '{print $2}')
   XDC --datadir /work/xdcchain init /work/genesis.json
 else
-  echo "Wallet already exist, re-use the same one"
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
+  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -v FS="({|})" '{print $2}')
 fi
 
 input="/work/bootnodes.list"

--- a/cicd/testnet/start.sh
+++ b/cicd/testnet/start.sh
@@ -2,22 +2,16 @@
 
 if [ ! -d /work/xdcchain/XDC/chaindata ]
 then
-  # Randomly select a key from environment variable, seperated by ','
-  if test -z "$PRIVATE_KEYS"
+  if test -z "$PRIVATE_KEY"
   then
-        echo "PRIVATE_KEYS environment variable has not been set. You need to pass at least one PK, or you can pass multiple PK seperated by ',', we will randomly choose one for you"
+        echo "PRIVATE_KEY environment variable has not been set."
         exit 1
   fi
-  IFS=', ' read -r -a private_keys <<< "$PRIVATE_KEYS"
-  private_key=${private_keys[ $RANDOM % ${#private_keys[@]} ]}
-
-  echo "${private_key}" >> /tmp/key
-  echo "Creating a new wallet"
-  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -F '[{}]' '{print $2}')
+  echo $PRIVATE_KEY >> /tmp/key
+  wallet=$(XDC account import --password .pwd --datadir /work/xdcchain /tmp/key | awk -v FS="({|})" '{print $2}')
   XDC --datadir /work/xdcchain init /work/genesis.json
 else
-  echo "Wallet already exist, re-use the same one"
-  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -F '[{}]' '{print $2}')
+  wallet=$(XDC account list --datadir /work/xdcchain | head -n 1 | awk -v FS="({|})" '{print $2}')
 fi
 
 input="/work/bootnodes.list"


### PR DESCRIPTION
# Proposed changes
Change back to use PRIVATE_KEY as usually node owner put one private key and has their existed start script already.
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
