### PR TITLE
Bul 09

### DIFF
--- a/core/vm/privacy/bulletproof.go
+++ b/core/vm/privacy/bulletproof.go
@@ -801,7 +801,6 @@ func (ipp *InnerProdArg) Serialize() []byte {
 }
 
 func (ipp *InnerProdArg) Deserialize(proof []byte, numChallenges int) error {
-	//check L, R points on curve, then check A,B is scalar in field
 	if len(proof) <= 12 {
 		return errors.New("proof data too short")
 	}

--- a/core/vm/privacy/bulletproof.go
+++ b/core/vm/privacy/bulletproof.go
@@ -837,14 +837,14 @@ func (ipp *InnerProdArg) Deserialize(proof []byte, numChallenges int) error {
 	}
 
 	A := new(big.Int).SetBytes(proof[offset : offset+32])
-	if A.Cmp(big.NewInt(0)) == 0 || A.CmpAbs(curve.Params().N) != 1 {
+	if A.Cmp(big.NewInt(0)) == 0 || A.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	ipp.A = A
 	offset += 32
 
 	B := new(big.Int).SetBytes(proof[offset : offset+32])
-	if B.Cmp(big.NewInt(0)) == 0 || B.CmpAbs(curve.Params().N) != 1 {
+	if B.Cmp(big.NewInt(0)) == 0 || B.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	ipp.B = B
@@ -970,21 +970,21 @@ func (mrp *MultiRangeProof) Deserialize(proof []byte) error {
 	mrp.T2 = T2
 
 	Tau := new(big.Int).SetBytes(proof[offset : offset+32])
-	if Tau.Cmp(big.NewInt(0)) == 0 || Tau.CmpAbs(curve.Params().N) != 1 {
+	if Tau.Cmp(big.NewInt(0)) == 0 || Tau.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	mrp.Tau = Tau
 	offset += 32
 
 	Th := new(big.Int).SetBytes(proof[offset : offset+32])
-	if Th.Cmp(big.NewInt(0)) == 0 || Th.CmpAbs(curve.Params().N) != 1 {
+	if Th.Cmp(big.NewInt(0)) == 0 || Th.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	mrp.Th = Th
 	offset += 32
 
 	Mu := new(big.Int).SetBytes(proof[offset : offset+32])
-	if Mu.Cmp(big.NewInt(0)) == 0 || Mu.CmpAbs(curve.Params().N) != 1 {
+	if Mu.Cmp(big.NewInt(0)) == 0 || Mu.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	mrp.Mu = Mu
@@ -995,21 +995,21 @@ func (mrp *MultiRangeProof) Deserialize(proof []byte) error {
 	offset += len(mrp.IPP.L)*33 + len(mrp.IPP.R)*33 + len(mrp.IPP.Challenges)*32 + 2*32
 
 	Cy := new(big.Int).SetBytes(proof[offset : offset+32])
-	if Cy.Cmp(big.NewInt(0)) == 0 || Cy.CmpAbs(curve.Params().N) != 1 {
+	if Cy.Cmp(big.NewInt(0)) == 0 || Cy.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	mrp.Cy = Cy
 	offset += 32
 
 	Cz := new(big.Int).SetBytes(proof[offset : offset+32])
-	if Cz.Cmp(big.NewInt(0)) == 0 || Cz.CmpAbs(curve.Params().N) != 1 {
+	if Cz.Cmp(big.NewInt(0)) == 0 || Cz.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	mrp.Cz = Cz
 	offset += 32
 
 	Cx := new(big.Int).SetBytes(proof[offset : offset+32])
-	if Cx.Cmp(big.NewInt(0)) == 0 || Cx.CmpAbs(curve.Params().N) != 1 {
+	if Cx.Cmp(big.NewInt(0)) == 0 || Cx.CmpAbs(curve.Params().N) == 1 {
 		return errScalarOutOfRange
 	}
 	mrp.Cx = Cx

--- a/core/vm/privacy/bulletproof.go
+++ b/core/vm/privacy/bulletproof.go
@@ -1454,8 +1454,7 @@ func genECPrimeGroupKey(n int) CryptoParams {
 }
 
 func (Point *ECPoint) isZeroPoint() bool {
-	zero := big.NewInt(0)
-	return Point.X.Cmp(zero) == 0 && Point.Y.Cmp(zero) == 0
+	return Point.X.Cmp(common.Big0) == 0 && Point.Y.Cmp(common.Big0) == 0
 }
 
 func init() {

--- a/core/vm/privacy/bulletproof_test.go
+++ b/core/vm/privacy/bulletproof_test.go
@@ -508,6 +508,7 @@ func TestMRPGeneration(t *testing.T) {
 	values[1] = big.NewInt(100000)
 	mrp, err := MRPProve(values)
 	if err != nil {
+		fmt.Println(err)
 		t.Error("failed to generate bulletproof")
 	}
 
@@ -515,7 +516,9 @@ func TestMRPGeneration(t *testing.T) {
 	serilizedBp := mrp.Serialize()
 
 	newMRP := new(MultiRangeProof)
-	if newMRP.Deserialize(serilizedBp) != nil {
+	err = newMRP.Deserialize(serilizedBp)
+	if err != nil {
+		fmt.Println(err)
 		t.Error("failed to deserialized bulletproof")
 	}
 


### PR DESCRIPTION
# Proposed changes
Implement checks for Points-on-Curve and Range of Scalar Field during Deserialization

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [✅] Not sure (Please specify below)
cryptography

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
