### PR TITLE
use Keccak instead of HashToScalar

### DIFF
--- a/core/vm/privacy/bulletproof.go
+++ b/core/vm/privacy/bulletproof.go
@@ -233,7 +233,14 @@ func HashPointsToBytes(points []ECPoint) []byte {
 		input = append(input, pointInByte...)
 	}
 
-	return crypto.Keccak256(input)
+	hashedInt, err := HashToScalar(input, curve)
+	if err != nil {
+		check(err)
+	}
+
+	hashedBytes := hashedInt.Bytes()
+
+	return hashedBytes
 }
 
 /*

--- a/core/vm/privacy/hash.go
+++ b/core/vm/privacy/hash.go
@@ -1,0 +1,225 @@
+//
+// Copyright Coinbase, Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// This file is slightly modified from https://github.com/coinbase/kryptology/blob/master/pkg/core/hash.go
+// The implementation we require is the HashToScalar() function
+package privacy
+
+import (
+	"bytes"
+	"crypto/elliptic"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"math"
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec"
+)
+
+type HashField struct {
+	// F_p^k
+	Order           *big.Int // p^k
+	Characteristic  *big.Int // p
+	ExtensionDegree *big.Int // k
+}
+
+type Params struct {
+	F                 *HashField
+	SecurityParameter int
+	Hash              func() hash.Hash
+	L                 int
+}
+
+func getParams(curve elliptic.Curve) (*Params, error) {
+	switch curve.Params().Name {
+	case btcec.S256().Name, elliptic.P256().Params().Name:
+		return &Params{
+			F: &HashField{
+				Order:           curve.Params().P,
+				Characteristic:  curve.Params().P,
+				ExtensionDegree: new(big.Int).SetInt64(1),
+			},
+			SecurityParameter: 128,
+			Hash:              sha256.New,
+			L:                 48,
+		}, nil
+	case "Bls12381G1":
+		return &Params{
+			F: &HashField{
+				Order:           curve.Params().P,
+				Characteristic:  curve.Params().P,
+				ExtensionDegree: new(big.Int).SetInt64(1),
+			},
+			SecurityParameter: 128,
+			Hash:              sha256.New,
+			L:                 48,
+		}, nil
+	case "ed25519":
+		return &Params{
+			F: &HashField{
+				Order:           curve.Params().P,
+				Characteristic:  curve.Params().P,
+				ExtensionDegree: new(big.Int).SetInt64(1),
+			},
+			SecurityParameter: 128,
+			Hash:              sha256.New,
+			L:                 48,
+		}, nil
+	default:
+		return nil, fmt.Errorf("Not implemented: %s", curve.Params().Name)
+	}
+}
+
+func I2OSP(b, n int) []byte {
+	os := new(big.Int).SetInt64(int64(b)).Bytes()
+	if n > len(os) {
+		var buf bytes.Buffer
+		buf.Write(make([]byte, n-len(os)))
+		buf.Write(os)
+		return buf.Bytes()
+	}
+	return os[:n]
+}
+
+func OS2IP(os []byte) *big.Int {
+	return new(big.Int).SetBytes(os)
+}
+
+func hashThis(f func() hash.Hash, this []byte) ([]byte, error) {
+	h := f()
+	w, err := h.Write(this)
+	if w != len(this) {
+		return nil, fmt.Errorf("bytes written to hash doesn't match expected")
+	} else if err != nil {
+		return nil, err
+	}
+	v := h.Sum(nil)
+	return v, nil
+}
+
+func concat(xs ...[]byte) []byte {
+	var result []byte
+	for _, x := range xs {
+		result = append(result, x...)
+	}
+	return result
+}
+
+func xor(b1, b2 []byte) []byte {
+	// b1 and b2 must be same length
+	result := make([]byte, len(b1))
+	for i := range b1 {
+		result[i] = b1[i] ^ b2[i]
+	}
+
+	return result
+}
+
+func ExpandMessageXmd(f func() hash.Hash, msg, DST []byte, lenInBytes int) ([]byte, error) {
+	// https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-10#section-5.4.1
+
+	// step 1
+	ell := int(math.Ceil(float64(lenInBytes) / float64(f().Size())))
+
+	//step 2
+	if ell > 255 {
+		return nil, fmt.Errorf("ell > 255")
+	}
+
+	// step 3
+	dstPrime := append(DST, I2OSP(len(DST), 1)...)
+
+	// step 4
+	zPad := I2OSP(0, f().BlockSize())
+
+	// step 5 & 6
+	msgPrime := concat(zPad, msg, I2OSP(lenInBytes, 2), I2OSP(0, 1), dstPrime)
+
+	var err error
+
+	b := make([][]byte, ell+1)
+
+	// step 7
+	b[0], err = hashThis(f, msgPrime)
+	if err != nil {
+		return nil, err
+	}
+
+	// step 8
+	b[1], err = hashThis(f, concat(b[0], I2OSP(1, 1), dstPrime))
+	if err != nil {
+		return nil, err
+	}
+
+	// step 9
+	for i := 2; i <= ell; i++ {
+		// step 10
+		b[i], err = hashThis(f, concat(xor(b[0], b[i-1]), I2OSP(i, 1), dstPrime))
+		if err != nil {
+			return nil, err
+		}
+	}
+	// step 11
+	uniformBytes := concat(b[1:]...)
+
+	// step 12
+	return uniformBytes[:lenInBytes], nil
+}
+
+func hashToField(msg []byte, count int, curve elliptic.Curve) ([][]*big.Int, error) {
+	// https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-10#section-5.3
+
+	parameters, err := getParams(curve)
+	if err != nil {
+		return nil, err
+	}
+
+	f := parameters.Hash
+
+	DST := []byte("Coinbase_tECDSA")
+
+	m := int(parameters.F.ExtensionDegree.Int64())
+	L := parameters.L
+
+	// step 1
+	lenInBytes := count * m * L
+
+	// step 2
+	uniformBytes, err := ExpandMessageXmd(f, msg, DST, lenInBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	u := make([][]*big.Int, count)
+
+	// step 3
+	for i := 0; i < count; i++ {
+		e := make([]*big.Int, m)
+		// step 4
+		for j := 0; j < m; j++ {
+			// step 5
+			elmOffset := L * (j + i*m)
+			// step 6
+			tv := uniformBytes[elmOffset : elmOffset+L]
+			// step 7
+			e[j] = new(big.Int).Mod(OS2IP(tv), parameters.F.Characteristic)
+
+		}
+		// step 8
+		u[i] = e
+	}
+	// step 9
+	return u, nil
+}
+
+func HashToScalar(msg []byte, curve elliptic.Curve) (*big.Int, error) {
+	u, err := hashToField(msg, 1, curve)
+	if err != nil {
+		return nil, err
+	}
+	return u[0][0], nil
+}

--- a/core/vm/privacy/ringct.go
+++ b/core/vm/privacy/ringct.go
@@ -438,7 +438,6 @@ func Sign(m [32]byte, rings []Ring, privkeys []*ecdsa.PrivateKey, s int) (*RingS
 	}
 
 	// concatenate m and u*G and calculate c[s+1] = H(m, L_s, R_s)
-	// C_j := crypto.Keccak256(append(m[:], l...))
 	C_j, err := HashToScalar(append(m[:], l...), curve)
 	if err != nil{
 		return nil, err
@@ -448,10 +447,8 @@ func Sign(m [32]byte, rings []Ring, privkeys []*ecdsa.PrivateKey, s int) (*RingS
 		idx = 0
 	}
 	if idx == 0 {
-		// C[0] = new(big.Int).SetBytes(C_j[:])
 		C[0] = C_j
 	} else {
-		// C[idx] = new(big.Int).SetBytes(C_j[:])
 		C[idx] = C_j
 	}
 	for idx != s {
@@ -492,12 +489,10 @@ func Sign(m [32]byte, rings []Ring, privkeys []*ecdsa.PrivateKey, s int) (*RingS
 		} else {
 			ciIdx = idx
 		}
-		// cSha := crypto.Keccak256(append(PadTo32Bytes(m[:]), l...))
 		cSha, err := HashToScalar(append(PadTo32Bytes(m[:]), l...), curve)
 		if err != nil {
 			return nil, err
 		}
-		// C[ciIdx] = new(big.Int).SetBytes(cSha[:])
 		C[ciIdx] = cSha
 	}
 
@@ -590,9 +585,6 @@ func Verify(sig *RingSignature, verifyMes bool) bool {
 
 		// calculate c[i+1] = H(m, L_i, R_i)
 		//cj_mes := append(PadTo32Bytes(sig.M[:]), l...)
-		
-
-		// C_j := crypto.Keccak256(append(PadTo32Bytes(sig.M[:]), l...))
 		C_j, err := HashToScalar(append(PadTo32Bytes(sig.M[:]), l...), curve)
 		if err != nil{
 			return false //or handle the error as required
@@ -604,12 +596,7 @@ func Verify(sig *RingSignature, verifyMes bool) bool {
 		/*if j == ringsize-1 {
 			C[0] = new(big.Int).SetBytes(C_j[:])
 		} else {*/
-		
-
-		// C[j+1] = new(big.Int).SetBytes(C_j[:])
 		C[j+1] = C_j
-
-
 		//log.Info("C", "j", j + 1, "C", common.Bytes2Hex(C[j + 1].Bytes()))
 		//}
 	}

--- a/core/vm/privacy/ringct_test.go
+++ b/core/vm/privacy/ringct_test.go
@@ -322,3 +322,19 @@ func TestNilPointerDereferencePanic(t *testing.T) {
 	// Should failed to verify Ring signature as the signature is invalid
 	assert.EqualError(t, err, "failed to deserialize, invalid ring signature")
 }
+
+func TestCustom(t *testing.T){
+	sample := "just a string"
+	sample_b := []byte(sample)
+	fmt.Println(sample_b)
+	h := crypto.Keccak256(sample_b)
+	fmt.Println(h)
+	fmt.Println(len(h))
+	fmt.Println(curve.Params().N)
+	h_scalar, err := HashToScalar(sample_b, curve)
+	if err != nil{
+		fmt.Println(err)
+		t.Error("")
+	}
+	fmt.Println(h_scalar)
+}

--- a/core/vm/privacy/ringct_test.go
+++ b/core/vm/privacy/ringct_test.go
@@ -322,19 +322,3 @@ func TestNilPointerDereferencePanic(t *testing.T) {
 	// Should failed to verify Ring signature as the signature is invalid
 	assert.EqualError(t, err, "failed to deserialize, invalid ring signature")
 }
-
-func TestCustom(t *testing.T){
-	sample := "just a string"
-	sample_b := []byte(sample)
-	fmt.Println(sample_b)
-	h := crypto.Keccak256(sample_b)
-	fmt.Println(h)
-	fmt.Println(len(h))
-	fmt.Println(curve.Params().N)
-	h_scalar, err := HashToScalar(sample_b, curve)
-	if err != nil{
-		fmt.Println(err)
-		t.Error("")
-	}
-	fmt.Println(h_scalar)
-}


### PR DESCRIPTION
# Proposed changes
crypto.Keccak256() Hash method could return invalid point on curve. Replace it with coinbase kryptology HashToScalar function.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [✅] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [✅] Not sure (Please specify below)
Cryptography

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [✅] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
