### PR TITLE
switch to new unused method

### DIFF
--- a/core/vm/privacy/bulletproof.go
+++ b/core/vm/privacy/bulletproof.go
@@ -988,7 +988,7 @@ func MRPProve(values []*big.Int) (MultiRangeProof, error) {
 		return MultiRangeProof{}, errors.New("Value number is not supported - just 1, 2, 4, 8")
 	}
 
-	EC = genECPrimeGroupKey(m * bitsPerValue)
+	EC = NewECPrimeGroupKey(m * bitsPerValue)
 
 	// we concatenate the binary representation of the values
 
@@ -1176,7 +1176,7 @@ Takes in a MultiRangeProof and verifies its correctness
 */
 func MRPVerify(mrp *MultiRangeProof) bool {
 	m := len(mrp.Comms)
-	EC = genECPrimeGroupKey(m * bitsPerValue)
+	EC = NewECPrimeGroupKey(m * bitsPerValue)
 
 	//changes:
 	// check 1 changes since it includes all commitments

--- a/core/vm/privacy/bulletproof_test.go
+++ b/core/vm/privacy/bulletproof_test.go
@@ -525,3 +525,46 @@ func TestMRPGeneration(t *testing.T) {
 		t.Error("failed to verify bulletproof")
 	}
 }
+
+func TestPedersenCommitmentsLen4(t *testing.T) {
+	// EC := genECPrimeGroupKey(4) 	//this is old method, which fails this test
+	EC := NewECPrimeGroupKey(4)
+
+	a1 := make([]*big.Int, 4)
+	a2 := make([]*big.Int, 4)
+	b1 := make([]*big.Int, 4)
+	b2 := make([]*big.Int, 4)
+
+	a1[0] = big.NewInt(0) // vector a1 = [0, 0, 1, 1]
+	a1[1] = big.NewInt(0)
+	a1[2] = big.NewInt(1)
+	a1[3] = big.NewInt(1)
+
+	b1[0] = big.NewInt(0) // vector b1 = [0, 0, 1, 1]
+	b1[1] = big.NewInt(0)
+	b1[2] = big.NewInt(1)
+	b1[3] = big.NewInt(1)
+
+	// second vector
+	a2[0] = big.NewInt(1) // vector a2 = [1, 1, 0, 1], which is different from a1
+	a2[1] = big.NewInt(1)
+	a2[2] = big.NewInt(0)
+	a2[3] = big.NewInt(1)
+
+	b2[0] = big.NewInt(0) // vector b2 = [0, 0, 1, 1]
+	b2[1] = big.NewInt(0)
+	b2[2] = big.NewInt(1)
+	b2[3] = big.NewInt(1)
+
+	P := TwoVectorPCommitWithGens(EC.BPG, EC.BPH, a1, b1)
+	fmt.Printf("P: %x \n", P)
+	P2 := TwoVectorPCommitWithGens(EC.BPG, EC.BPH, a2, b2)
+	fmt.Printf("P2: %x \n", P2)
+
+	if P.X.Cmp(P2.X) == 0 && P.Y.Cmp(P2.Y) == 0 {
+		t.Error("Same Pedersen commitment with different witnesses, this is a security flaw")
+		
+	} else {
+		fmt.Println("Different Pedersen commitments NewECPrimeGroupKey is working correctly")
+	}
+}


### PR DESCRIPTION
# Proposed changes
This change makes the generated Pedersen vector commitments independent from each other. In old setup, vectors generated in a different way can arrive to the same value.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- ✅ Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- ✅ Not sure (Please specify below)
cryptography

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- ✅ This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
