### PR TITLE
implement EIP-4399, PREVRANDAO opcode

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -47,6 +47,7 @@ var TIPXDCXCancellationFee = big.NewInt(38383838)
 var TIPXDCXCancellationFeeTestnet = big.NewInt(38383838)
 var BerlinBlock = big.NewInt(9999999999)
 var LondonBlock = big.NewInt(9999999999)
+var MergeBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(38383838)
 var IsTestnet bool = false

--- a/common/constants/constants.go.devnet
+++ b/common/constants/constants.go.devnet
@@ -47,6 +47,7 @@ var TIPXDCXCancellationFee = big.NewInt(225000)
 var TIPXDCXCancellationFeeTestnet = big.NewInt(225000)
 var BerlinBlock = big.NewInt(9999999999)
 var LondonBlock = big.NewInt(9999999999)
+var MergeBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(0)
 var IsTestnet bool = false

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -47,6 +47,7 @@ var TIPXDCXCancellationFee = big.NewInt(23779191)
 var TIPXDCXCancellationFeeTestnet = big.NewInt(23779191)
 var BerlinBlock = big.NewInt(9999999999)
 var LondonBlock = big.NewInt(9999999999)
+var MergeBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(23779191)
 var IsTestnet bool = false

--- a/core/evm.go
+++ b/core/evm.go
@@ -23,17 +23,23 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
 )
 
 // NewEVMContext creates a new context for use in the EVM.
 func NewEVMContext(msg Message, header *types.Header, chain consensus.ChainContext, author *common.Address) vm.Context {
 	// If we don't have an explicit author (i.e. not mining), extract from the header
-	var beneficiary common.Address
+	var (
+		beneficiary common.Address
+		random      common.Hash
+	)
 	if author == nil {
 		beneficiary, _ = chain.Engine().Author(header) // Ignore error, we're past header validation
 	} else {
 		beneficiary = *author
 	}
+	// since xdpos chain do not use difficulty and mixdigest, we use hash of the block number as random
+	random = crypto.Keccak256Hash(header.Number.Bytes())
 	return vm.Context{
 		CanTransfer: CanTransfer,
 		Transfer:    Transfer,
@@ -45,6 +51,7 @@ func NewEVMContext(msg Message, header *types.Header, chain consensus.ChainConte
 		Difficulty:  new(big.Int).Set(header.Difficulty),
 		GasLimit:    header.GasLimit,
 		GasPrice:    new(big.Int).Set(msg.GasPrice()),
+		Random:      &random,
 	}
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -107,6 +107,7 @@ type Context struct {
 	BlockNumber *big.Int       // Provides information for NUMBER
 	Time        *big.Int       // Provides information for TIME
 	Difficulty  *big.Int       // Provides information for DIFFICULTY
+	Random      *common.Hash   // Provides information for PREVRANDAO
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -477,6 +477,17 @@ func opDifficulty(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx)
 	return nil, nil
 }
 
+func opRandom(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) ([]byte, error) {
+	var v *uint256.Int
+	if interpreter.evm.Context.Random != nil {
+		v = new(uint256.Int).SetBytes((interpreter.evm.Context.Random.Bytes()))
+	} else { // if context random is not set, use emptyCodeHash as default
+		v = new(uint256.Int).SetBytes(emptyCodeHash.Bytes())
+	}
+	callContext.stack.push(v)
+	return nil, nil
+}
+
 func opGasLimit(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) ([]byte, error) {
 	callContext.stack.push(new(uint256.Int).SetUint64(interpreter.evm.GasLimit))
 	return nil, nil

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/big"
 	"os"
 	"testing"
 
@@ -658,6 +659,39 @@ func TestCreate2Addreses(t *testing.T) {
 		expected := common.BytesToAddress(common.FromHex(tt.expected))
 		if !bytes.Equal(expected.Bytes(), address.Bytes()) {
 			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
+		}
+	}
+}
+
+func TestRandom(t *testing.T) {
+	type testcase struct {
+		name   string
+		random common.Hash
+	}
+
+	for _, tt := range []testcase{
+		{name: "empty hash", random: common.Hash{}},
+		{name: "1", random: common.Hash{0}},
+		{name: "emptyCodeHash", random: emptyCodeHash},
+		{name: "hash(0x010203)", random: crypto.Keccak256Hash([]byte{0x01, 0x02, 0x03})},
+	} {
+		var (
+			env            = NewEVM(Context{Random: &tt.random}, nil, nil, params.TestChainConfig, Config{})
+			stack          = newstack()
+			pc             = uint64(0)
+			evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+		)
+		opRandom(&pc, evmInterpreter, &callCtx{nil, stack, nil})
+		if len(stack.data) != 1 {
+			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
+		}
+		actual := stack.pop()
+		expected, overflow := uint256.FromBig(new(big.Int).SetBytes(tt.random.Bytes()))
+		if overflow {
+			t.Errorf("Testcase %v: invalid overflow", tt.name)
+		}
+		if actual.Cmp(expected) != 0 {
+			t.Errorf("Testcase %v: expected  %x, got %x", tt.name, expected, actual)
 		}
 	}
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -93,6 +93,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	if cfg.JumpTable == nil {
 		switch {
+		case evm.chainRules.IsMerge:
+			cfg.JumpTable = &mergeInstructionSet
 		case evm.chainRules.IsLondon:
 			cfg.JumpTable = &londonInstructionSet
 		case evm.chainRules.IsBerlin:
@@ -262,7 +264,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		}
 		pc++
 	}
-	
+
 	if err == errStopToken {
 		err = nil // clear stop token error
 	}

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -52,10 +52,22 @@ var (
 	istanbulInstructionSet         = newIstanbulInstructionSet()
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
+	mergeInstructionSet            = newMergeInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
+
+func newMergeInstructionSet() JumpTable {
+	instructionSet := newLondonInstructionSet()
+	instructionSet[PREVRANDAO] = &operation{
+		execute:     opRandom,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
+	return instructionSet
+}
 
 // newLondonInstructionSet returns the frontier, homestead, byzantium,
 // constantinople, istanbul, petersburg, berlin and london instructions.

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -98,6 +98,8 @@ const (
 	TIMESTAMP   OpCode = 0x42
 	NUMBER      OpCode = 0x43
 	DIFFICULTY  OpCode = 0x44
+	RANDOM      OpCode = 0x44 // Same as DIFFICULTY
+	PREVRANDAO  OpCode = 0x44 // Same as DIFFICULTY
 	GASLIMIT    OpCode = 0x45
 	CHAINID     OpCode = 0x46
 	SELFBALANCE OpCode = 0x47
@@ -277,7 +279,7 @@ var opCodeToString = [256]string{
 	COINBASE:    "COINBASE",
 	TIMESTAMP:   "TIMESTAMP",
 	NUMBER:      "NUMBER",
-	DIFFICULTY:  "DIFFICULTY",
+	DIFFICULTY:  "DIFFICULTY", // TODO rename to PREVRANDAO post merge
 	GASLIMIT:    "GASLIMIT",
 	CHAINID:     "CHAINID",
 	SELFBALANCE: "SELFBALANCE",

--- a/params/config.go
+++ b/params/config.go
@@ -242,19 +242,19 @@ var (
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
 	AllEthashProtocolChanges = &ChainConfig{
-		ChainId: big.NewInt(1337),
-		HomesteadBlock: big.NewInt(0),
-		DAOForkBlock: nil,
-		DAOForkSupport: false,
-		EIP150Block: big.NewInt(0),
-		EIP150Hash: common.Hash{},
-		EIP155Block: big.NewInt(0),
-		EIP158Block: big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
+		ChainId:             big.NewInt(1337),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: nil,
-		Ethash: new(EthashConfig),
-		Clique: nil,
-		XDPoS: nil,
+		Ethash:              new(EthashConfig),
+		Clique:              nil,
+		XDPoS:               nil,
 	}
 
 	// AllXDPoSProtocolChanges contains every protocol change (EIPs) introduced
@@ -262,52 +262,52 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllXDPoSProtocolChanges  = &ChainConfig{
-		ChainId: big.NewInt(89),
-		HomesteadBlock: big.NewInt(0),
-		DAOForkBlock: nil,
-		DAOForkSupport: false,
-		EIP150Block: big.NewInt(0),
-		EIP150Hash: common.Hash{},
-		EIP155Block: big.NewInt(0),
-		EIP158Block: big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
+	AllXDPoSProtocolChanges = &ChainConfig{
+		ChainId:             big.NewInt(89),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: nil,
-		Ethash: nil,
-		Clique: nil,
-		XDPoS: &XDPoSConfig{Period: 0, Epoch: 900},
+		Ethash:              nil,
+		Clique:              nil,
+		XDPoS:               &XDPoSConfig{Period: 0, Epoch: 900},
 	}
 
 	AllCliqueProtocolChanges = &ChainConfig{
-		ChainId: big.NewInt(1337),
-		HomesteadBlock: big.NewInt(0),
-		DAOForkBlock: nil,
-		DAOForkSupport: false,
-		EIP150Block: big.NewInt(0),
-		EIP150Hash: common.Hash{},
-		EIP155Block: big.NewInt(0),
-		EIP158Block: big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
+		ChainId:             big.NewInt(1337),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: nil,
-		Ethash: nil,
-		Clique: &CliqueConfig{Period: 0, Epoch: 900},
-		XDPoS: nil,
+		Ethash:              nil,
+		Clique:              &CliqueConfig{Period: 0, Epoch: 900},
+		XDPoS:               nil,
 	}
 
 	// XDPoS config with v2 engine after block 901
 	TestXDPoSMockChainConfig = &ChainConfig{
-		ChainId: big.NewInt(1337),
-		HomesteadBlock: big.NewInt(0),
-		DAOForkBlock: nil,
-		DAOForkSupport: false,
-		EIP150Block: big.NewInt(0),
-		EIP150Hash: common.Hash{},
-		EIP155Block: big.NewInt(0),
-		EIP158Block: big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
+		ChainId:             big.NewInt(1337),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: nil,
-		Ethash: new(EthashConfig),
-		Clique: nil,
+		Ethash:              new(EthashConfig),
+		Clique:              nil,
 		XDPoS: &XDPoSConfig{
 			Epoch:               900,
 			Gap:                 450,
@@ -323,21 +323,21 @@ var (
 	}
 
 	TestChainConfig = &ChainConfig{
-		ChainId: big.NewInt(1),
-		HomesteadBlock: big.NewInt(0),
-		DAOForkBlock: nil,
-		DAOForkSupport: false,
-		EIP150Block: big.NewInt(0),
-		EIP150Hash: common.Hash{},
-		EIP155Block: big.NewInt(0),
-		EIP158Block: big.NewInt(0),
-		ByzantiumBlock: big.NewInt(0),
+		ChainId:             big.NewInt(1),
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        nil,
+		DAOForkSupport:      false,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.Hash{},
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
 		ConstantinopleBlock: nil,
-		Ethash: new(EthashConfig),
-		Clique: nil,
-		XDPoS: nil,
+		Ethash:              new(EthashConfig),
+		Clique:              nil,
+		XDPoS:               nil,
 	}
-	TestRules       = TestChainConfig.Rules(new(big.Int))
+	TestRules = TestChainConfig.Rules(new(big.Int))
 )
 
 // ChainConfig is the core config which determines the blockchain settings.

--- a/params/config.go
+++ b/params/config.go
@@ -362,8 +362,6 @@ type ChainConfig struct {
 
 	ByzantiumBlock      *big.Int `json:"byzantiumBlock,omitempty"`      // Byzantium switch block (nil = no fork, 0 = already on byzantium)
 	ConstantinopleBlock *big.Int `json:"constantinopleBlock,omitempty"` // Constantinople switch block (nil = no fork, 0 = already activated)
-	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
-	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty"`
@@ -500,7 +498,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v BerlinBlock: %v LondonBlock: %v Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Istanbul: %v  BerlinBlock: %v LondonBlock: %v MergeBlock: %v Engine: %v}",
 		c.ChainId,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -510,8 +508,10 @@ func (c *ChainConfig) String() string {
 		c.EIP158Block,
 		c.ByzantiumBlock,
 		c.ConstantinopleBlock,
-		c.BerlinBlock,
-		c.LondonBlock,
+		common.TIPXDCXCancellationFee,
+		common.BerlinBlock,
+		common.LondonBlock,
+		common.MergeBlock,
 		engine,
 	)
 }
@@ -566,6 +566,12 @@ func (c *ChainConfig) IsBerlin(num *big.Int) bool {
 // IsLondon returns whether num is either equal to the London fork block or greater.
 func (c *ChainConfig) IsLondon(num *big.Int) bool {
 	return isForked(common.LondonBlock, num)
+}
+
+// IsMerge returns whether num is either equal to the Merge fork block or greater.
+// Different from Geth which uses `block.difficulty != nil`
+func (c *ChainConfig) IsMerge(num *big.Int) bool {
+	return isForked(common.MergeBlock, num)
 }
 
 func (c *ChainConfig) IsTIP2019(num *big.Int) bool {
@@ -669,13 +675,6 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.ConstantinopleBlock, newcfg.ConstantinopleBlock, head) {
 		return newCompatError("Constantinople fork block", c.ConstantinopleBlock, newcfg.ConstantinopleBlock)
 	}
-	if isForkIncompatible(c.BerlinBlock, newcfg.BerlinBlock, head) {
-		return newCompatError("Berlin fork block", c.BerlinBlock, newcfg.BerlinBlock)
-	}
-	if isForkIncompatible(c.LondonBlock, newcfg.LondonBlock, head) {
-		return newCompatError("London fork block", c.LondonBlock, newcfg.LondonBlock)
-	}
-
 	return nil
 }
 
@@ -744,6 +743,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
+	IsMerge                                                 bool
 }
 
 func (c *ChainConfig) Rules(num *big.Int) Rules {
@@ -762,6 +762,7 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsPetersburg:     c.IsPetersburg(num),
 		IsIstanbul:       c.IsIstanbul(num),
 		IsBerlin:         c.IsBerlin(num),
-        IsLondon:         c.IsLondon(num),
+		IsLondon:         c.IsLondon(num),
+		IsMerge:          c.IsMerge(num),
 	}
 }


### PR DESCRIPTION
# Proposed changes
Implement EIP-4399, PRERANDAO opcode.
The random value is calculated from block number through keccak hash.

## Test plan
1. Modify common/constants.go `MergeBlock=0` to make this EIP work immediately.
2. Write a contract to print PRERANDAO (0x44). Deploy it.
3. Send tx to the contract in different block numbers. Check the result equals hash of the block number.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)
- [x] EVM

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [x] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
