### PR TITLE
add http.TimeoutHandler for rpc http server

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -237,11 +237,12 @@ func NewHTTPServer(cors []string, vhosts []string, srv *Server, writeTimeout tim
 	// Wrap the CORS-handler within a host-handler
 	handler := newCorsHandler(srv, cors)
 	handler = newVHostHandler(vhosts, handler)
+	handler = http.TimeoutHandler(handler, writeTimeout, `{"error":"http server timeout"}`)
 	log.Info("NewHTTPServer", "writeTimeout", writeTimeout)
 	return &http.Server{
 		Handler:      handler,
 		ReadTimeout:  5 * time.Second,
-		WriteTimeout: writeTimeout,
+		WriteTimeout: writeTimeout + time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 }


### PR DESCRIPTION
# Proposed changes

The PR #363 only add parameter `WriteTimeout` for http server. But there are potential issues when timeout:

- the connection is closed and server return empty reply
- the request Context is not canceled

This PR set `http.TimeoutHandler` for http server in package rpc when timeout:

- return with http code 503 and static body message: `{"error":"http server timeout"}`
- the request Context is canceled

background information:

- https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
- https://blog.dharnitski.com/2021/03/14/timeout-vs-handler/
- https://www.sobyte.net/post/2022-01/go-http-server-timeout/
- https://taoshu.in/go/go-http-server-timeout.html

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
