### PR TITLE
core/vm: implement EIP-3855: PUSH0 instruction.

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -49,6 +49,7 @@ var TIPXDCXDISABLE = big.NewInt(99999999900)
 var BerlinBlock = big.NewInt(9999999999)
 var LondonBlock = big.NewInt(9999999999)
 var MergeBlock = big.NewInt(9999999999)
+var ShanghaiBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(38383838)
 var IsTestnet bool = false

--- a/common/constants/constants.go.devnet
+++ b/common/constants/constants.go.devnet
@@ -49,6 +49,7 @@ var TIPXDCXDISABLE = big.NewInt(15894900)
 var BerlinBlock = big.NewInt(9999999999)
 var LondonBlock = big.NewInt(9999999999)
 var MergeBlock = big.NewInt(9999999999)
+var ShanghaiBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(0)
 var IsTestnet bool = false

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -49,6 +49,7 @@ var TIPXDCXDISABLE = big.NewInt(99999999900)
 var BerlinBlock = big.NewInt(9999999999)
 var LondonBlock = big.NewInt(9999999999)
 var MergeBlock = big.NewInt(9999999999)
+var ShanghaiBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(23779191)
 var IsTestnet bool = false

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -29,7 +29,7 @@ import (
 // defined jump tables are not polluted.
 func EnableEIP(eipNum int, jt *JumpTable) error {
 	switch eipNum {
-	case 3898:
+	case 3198:
 		enable3198(jt)
 	case 2200:
 		enable2200(jt)

--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -29,6 +29,8 @@ import (
 // defined jump tables are not polluted.
 func EnableEIP(eipNum int, jt *JumpTable) error {
 	switch eipNum {
+	case 3855:
+		enable3855(jt)
 	case 3198:
 		enable3198(jt)
 	case 2200:
@@ -110,5 +112,22 @@ func enable3198(jt *JumpTable) {
 func opBaseFee(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) ([]byte, error) {
 	baseFee, _ := uint256.FromBig(common.MinGasPrice50x)
 	callContext.stack.push(baseFee)
+	return nil, nil
+}
+
+// enable3855 applies EIP-3855 (PUSH0 opcode)
+func enable3855(jt *JumpTable) {
+	// New opcode
+	jt[PUSH0] = &operation{
+		execute:     opPush0,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
+}
+
+// opPush0 implements the PUSH0 opcode
+func opPush0(pc *uint64, interpreter *EVMInterpreter, callContext *callCtx) ([]byte, error) {
+	callContext.stack.push(new(uint256.Int))
 	return nil, nil
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -93,6 +93,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	if cfg.JumpTable == nil {
 		switch {
+		case evm.chainRules.IsShanghai:
+			cfg.JumpTable = &shanghaiInstructionSet
 		case evm.chainRules.IsMerge:
 			cfg.JumpTable = &mergeInstructionSet
 		case evm.chainRules.IsLondon:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -53,10 +53,17 @@ var (
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
+	shanghaiInstructionSet         = newShanghaiInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
+
+func newShanghaiInstructionSet() JumpTable {
+	instructionSet := newMergeInstructionSet()
+	enable3855(&instructionSet) // PUSH0 instruction
+	return instructionSet
+}
 
 func newMergeInstructionSet() JumpTable {
 	instructionSet := newLondonInstructionSet()

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -25,11 +25,7 @@ type OpCode byte
 
 // IsPush specifies if an opcode is a PUSH opcode.
 func (op OpCode) IsPush() bool {
-	switch op {
-	case PUSH1, PUSH2, PUSH3, PUSH4, PUSH5, PUSH6, PUSH7, PUSH8, PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16, PUSH17, PUSH18, PUSH19, PUSH20, PUSH21, PUSH22, PUSH23, PUSH24, PUSH25, PUSH26, PUSH27, PUSH28, PUSH29, PUSH30, PUSH31, PUSH32:
-		return true
-	}
-	return false
+	return PUSH0 <= op && op <= PUSH32
 }
 
 // 0x0 range - arithmetic ops.

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -108,18 +108,19 @@ const (
 
 // 0x50 range - 'storage' and execution.
 const (
-	POP OpCode = 0x50 + iota
-	MLOAD
-	MSTORE
-	MSTORE8
-	SLOAD
-	SSTORE
-	JUMP
-	JUMPI
-	PC
-	MSIZE
-	GAS
-	JUMPDEST
+	POP      OpCode = 0x50
+	MLOAD    OpCode = 0x51
+	MSTORE   OpCode = 0x52
+	MSTORE8  OpCode = 0x53
+	SLOAD    OpCode = 0x54
+	SSTORE   OpCode = 0x55
+	JUMP     OpCode = 0x56
+	JUMPI    OpCode = 0x57
+	PC       OpCode = 0x58
+	MSIZE    OpCode = 0x59
+	GAS      OpCode = 0x5a
+	JUMPDEST OpCode = 0x5b
+	PUSH0    OpCode = 0x5f
 )
 
 // 0x60 range - pushes.
@@ -300,6 +301,7 @@ var opCodeToString = [256]string{
 	MSIZE:    "MSIZE",
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
+	PUSH0:    "PUSH0",
 
 	// 0x60 range - push.
 	PUSH1:  "PUSH1",
@@ -462,6 +464,7 @@ var stringToOp = map[string]OpCode{
 	"MSIZE":          MSIZE,
 	"GAS":            GAS,
 	"JUMPDEST":       JUMPDEST,
+	"PUSH0":          PUSH0,
 	"PUSH1":          PUSH1,
 	"PUSH2":          PUSH2,
 	"PUSH3":          PUSH3,

--- a/params/config.go
+++ b/params/config.go
@@ -498,7 +498,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Istanbul: %v  BerlinBlock: %v LondonBlock: %v MergeBlock: %v Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Istanbul: %v  BerlinBlock: %v LondonBlock: %v MergeBlock: %v ShanghaiBlock: %v Engine: %v}",
 		c.ChainId,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -512,6 +512,7 @@ func (c *ChainConfig) String() string {
 		common.BerlinBlock,
 		common.LondonBlock,
 		common.MergeBlock,
+		common.ShanghaiBlock,
 		engine,
 	)
 }
@@ -572,6 +573,11 @@ func (c *ChainConfig) IsLondon(num *big.Int) bool {
 // Different from Geth which uses `block.difficulty != nil`
 func (c *ChainConfig) IsMerge(num *big.Int) bool {
 	return isForked(common.MergeBlock, num)
+}
+
+// IsShanghai returns whether num is either equal to the Shanghai fork block or greater.
+func (c *ChainConfig) IsShanghai(num *big.Int) bool {
+	return isForked(common.ShanghaiBlock, num)
 }
 
 func (c *ChainConfig) IsTIP2019(num *big.Int) bool {
@@ -742,7 +748,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
-	IsMerge                                                 bool
+	IsMerge, IsShanghai                                     bool
 }
 
 func (c *ChainConfig) Rules(num *big.Int) Rules {
@@ -763,5 +769,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          c.IsMerge(num),
+		IsShanghai:       c.IsShanghai(num),
 	}
 }


### PR DESCRIPTION
# Proposed changes
Implement EIP-3855: PUSH0 instruction. With constant ShanghaiBlock.

## Test plan

1. Modify common/constants.go set ShanghaiBlock to a small constant, to make this EIP work quickly.
2. Write a contract to run PUSH0 (0x5f). Deploy it.
3. Send tx to the contract in different block numbers. Check the result after EIP works. Also check the result before EIP works.
 
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)
- [x] EVM

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [x] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
