### PR TITLE
Missing `json` Field Tags in Marshalled Struct

### DIFF
--- a/core/types/consensus_v2.go
+++ b/core/types/consensus_v2.go
@@ -14,17 +14,17 @@ type Signature []byte
 
 // Block Info struct in XDPoS 2.0, used for vote message, etc.
 type BlockInfo struct {
-	Hash   common.Hash
-	Round  Round
-	Number *big.Int
+	Hash   common.Hash `json:"hash"`
+	Round  Round       `json:"round"`
+	Number *big.Int    `json:"number"`
 }
 
 // Vote message in XDPoS 2.0
 type Vote struct {
-	signer            common.Address
-	ProposedBlockInfo *BlockInfo
-	Signature         Signature
-	GapNumber         uint64
+	signer            common.Address	//field not exported 
+	ProposedBlockInfo *BlockInfo     `json:"proposedBlockInfo"`
+	Signature         Signature      `json:"signature"`
+	GapNumber         uint64         `json:"gapNumber"`
 }
 
 func (v *Vote) Hash() common.Hash {
@@ -81,9 +81,9 @@ func (s *SyncInfo) Hash() common.Hash {
 
 // Quorum Certificate struct in XDPoS 2.0
 type QuorumCert struct {
-	ProposedBlockInfo *BlockInfo
-	Signatures        []Signature
-	GapNumber         uint64
+	ProposedBlockInfo *BlockInfo `json:"proposedBlockInfo"`
+	Signatures        []Signature `json:"signatures"`
+	GapNumber         uint64 `json:"gapNumber"`
 }
 
 // Timeout Certificate struct in XDPoS 2.0


### PR DESCRIPTION
# Proposed changes
There are several structs passed into json.Marshal without json tags. It may bring unexpected errors when renaming fields. 
This change is advised by the auditing team.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
