### PR TITLE
Ensure DB is close before client exit

### DIFF
--- a/cmd/XDC/chaincmd.go
+++ b/cmd/XDC/chaincmd.go
@@ -319,7 +319,8 @@ func exportChain(ctx *cli.Context) error {
 		utils.Fatalf("This command requires an argument.")
 	}
 	stack, _ := makeFullNode(ctx)
-	chain, _ := utils.MakeChain(ctx, stack)
+	chain, db := utils.MakeChain(ctx, stack)
+	defer db.Close()
 	start := time.Now()
 
 	var err error
@@ -353,6 +354,7 @@ func importPreimages(ctx *cli.Context) error {
 	}
 	stack, _ := makeFullNode(ctx)
 	diskdb := utils.MakeChainDatabase(ctx, stack)
+	defer diskdb.Close()
 
 	start := time.Now()
 	if err := utils.ImportPreimages(diskdb, ctx.Args().First()); err != nil {
@@ -369,6 +371,7 @@ func exportPreimages(ctx *cli.Context) error {
 	}
 	stack, _ := makeFullNode(ctx)
 	diskdb := utils.MakeChainDatabase(ctx, stack)
+	defer diskdb.Close()
 
 	start := time.Now()
 	if err := utils.ExportPreimages(diskdb, ctx.Args().First()); err != nil {
@@ -386,6 +389,7 @@ func copyDb(ctx *cli.Context) error {
 	// Initialize a new chain for the running node to sync into
 	stack, _ := makeFullNode(ctx)
 	chain, chainDb := utils.MakeChain(ctx, stack)
+	defer chainDb.Close()
 
 	syncmode := *utils.GlobalTextMarshaler(ctx, utils.SyncModeFlag.Name).(*downloader.SyncMode)
 	dl := downloader.New(syncmode, chainDb, new(event.TypeMux), chain, nil, nil, nil)
@@ -458,6 +462,8 @@ func removeDB(ctx *cli.Context) error {
 func dump(ctx *cli.Context) error {
 	stack, _ := makeFullNode(ctx)
 	chain, chainDb := utils.MakeChain(ctx, stack)
+	defer chainDb.Close()
+	
 	for _, arg := range ctx.Args() {
 		var block *types.Block
 		if hashish(arg) {
@@ -477,7 +483,6 @@ func dump(ctx *cli.Context) error {
 			fmt.Printf("%s\n", state.Dump())
 		}
 	}
-	chainDb.Close()
 	return nil
 }
 


### PR DESCRIPTION
# Proposed changes
Before exiting the XDC application using command lines, close the database to prevent any potential storage collisions.
This change is advised by the auditing team.

ref previous PR which was closed to combine changes into 1 commit:  https://github.com/XinFinOrg/XDPoSChain/pull/476

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)
CMD

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
