### PR TITLE
add method `eth_getAccountInfo`

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -393,6 +393,10 @@ func (self *stateObject) Nonce() uint64 {
 	return self.data.Nonce
 }
 
+func (self *stateObject) Root() common.Hash {
+	return self.data.Root
+}
+
 // Never called, but must be present to allow stateObject to be used
 // as a vm.Account interface that also satisfies the vm.ContractRef
 // interface. Interfaces are awesome.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -221,6 +221,16 @@ func (self *StateDB) GetNonce(addr common.Address) uint64 {
 	return 0
 }
 
+// GetStorageRoot retrieves the storage root from the given address or empty
+// if object not found.
+func (self *StateDB) GetStorageRoot(addr common.Address) common.Hash {
+	stateObject := self.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.Root()
+	}
+	return common.Hash{}
+}
+
 func (self *StateDB) GetCode(addr common.Address) []byte {
 	stateObject := self.getStateObject(addr)
 	if stateObject != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -83,6 +83,14 @@ type StateDB struct {
 	lock sync.Mutex
 }
 
+type AccountInfo struct {
+	CodeSize    int
+	Nonce       uint64
+	Balance     *big.Int
+	CodeHash    common.Hash
+	StorageHash common.Hash
+}
+
 func (self *StateDB) SubRefund(gas uint64) {
 	self.journal = append(self.journal, refundChange{
 		prev: self.refund})
@@ -260,6 +268,28 @@ func (self *StateDB) GetCodeHash(addr common.Address) common.Hash {
 		return common.Hash{}
 	}
 	return common.BytesToHash(stateObject.CodeHash())
+}
+
+func (self *StateDB) GetAccountInfo(addr common.Address) *AccountInfo {
+	result := AccountInfo{}
+
+	stateObject := self.getStateObject(addr)
+	if stateObject == nil {
+		result.Balance = common.Big0
+		return &result
+	}
+
+	if stateObject.code != nil {
+		result.CodeSize = len(stateObject.code)
+	} else {
+		result.CodeSize, _ = self.db.ContractCodeSize(stateObject.addrHash, common.BytesToHash(stateObject.CodeHash()))
+	}
+	result.Nonce = stateObject.Nonce()
+	result.Balance = stateObject.Balance()
+	result.CodeHash = common.BytesToHash(stateObject.CodeHash())
+	result.StorageHash = stateObject.Root()
+
+	return &result
 }
 
 func (self *StateDB) GetState(addr common.Address, bhash common.Hash) common.Hash {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -623,6 +623,24 @@ func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Addres
 	return code, state.Error()
 }
 
+// GetAccountInfo returns the information at the given address in the state for the given block number.
+func (s *PublicBlockChainAPI) GetAccountInfo(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (map[string]interface{}, error) {
+	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	info := state.GetAccountInfo(address)
+	result := map[string]interface{}{
+		"address":     address,
+		"balance":     (*hexutil.Big)(info.Balance),
+		"codeSize":    info.CodeSize,
+		"codeHash":    info.CodeHash,
+		"nonce":       info.Nonce,
+		"storageHash": info.StorageHash,
+	}
+	return result, nil
+}
+
 // GetStorageAt returns the storage from the state at the given address, key and
 // block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
 // numbers are also allowed.

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -5329,6 +5329,13 @@ var methods = function () {
         inputFormatter: [formatters.inputAddressFormatter, formatters.inputDefaultBlockNumberFormatter]
     });
 
+    var getAccountInfo = new Method({
+        name: 'getAccountInfo',
+        call: 'eth_getAccountInfo',
+        params: 2,
+        inputFormatter: [formatters.inputAddressFormatter, formatters.inputDefaultBlockNumberFormatter]
+    });
+
     var getBlock = new Method({
         name: 'getBlock',
         call: blockCall,
@@ -5513,6 +5520,7 @@ var methods = function () {
         getBalance,
         getStorageAt,
         getCode,
+        getAccountInfo,
         getBlock,
         getBlockSigners,
         getStakerROI,


### PR DESCRIPTION
# Proposed changes

Add method `eth_getAccountInfo` which returns below properties for an account:

- address
- balance
- code hash
  - for contract: Keccak256(code)
  - for exist EOA: Keccak256(nil) = `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
  - for inexistent account: `0x0000000000000000000000000000000000000000000000000000000000000000`
- code size
- nonce
- storage hash

## Test 

### 1. system contract

**request**

```bash
 curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "0x0000000000000000000000000000000000000088",
    "latest"
  ]
}' | jq
```

**response**

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

### 2. exist EOA

`0xD4CE02705041F04135f1949Bc835c1Fe0885513c` is my test account which is exist on chain when I test.

**request**

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8002,
  "method": "eth_getAccountInfo",
  "params": [
    "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
    "latest"
  ]
}' | jq
```

**response**

```json
{
  "jsonrpc": "2.0",
  "id": 8002,
  "result": {
    "address": "0xd4ce02705041f04135f1949bc835c1fe0885513c",
    "balance": "0x200000000000000000000000000000000000000000000000000000000000000",
    "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
    "codeSize": 0,
    "nonce": 0,
    "storageHash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
  }
}
```

### 3. inexistent account

**request*

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8003,
  "method": "eth_getAccountInfo",
  "params": [
    "0xf756fdbb39E5491AFE9FDab2B69E48e408e84888",
    "latest"
  ]
}' | jq
```

**response**

```json
{
  "jsonrpc": "2.0",
  "id": 8003,
  "result": {
    "address": "0xf756fdbb39e5491afe9fdab2b69e48e408e84888",
    "balance": "0x0",
    "codeHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "codeSize": 0,
    "nonce": 0,
    "storageHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
  }
}
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [X] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
