### PR TITLE
use rlock instead of lock in v1 consensus engine

### DIFF
--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -958,9 +958,9 @@ func (x *XDPoS_v1) Seal(chain consensus.ChainReader, block *types.Block, stop <-
 // that a new block should have based on the previous blocks in the chain and the
 // current signer.
 func (x *XDPoS_v1) CalcDifficulty(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
-	x.lock.Lock()
+	x.lock.RLock()
 	signer := x.signer
-	x.lock.Unlock()
+	x.lock.RUnlock()
 	return x.calcDifficulty(chain, parent, signer)
 }
 


### PR DESCRIPTION
# Proposed changes
Following up on this comment https://github.com/XinFinOrg/XDPoSChain/pull/445/files#r1510519857 to use rlock instead of the lock for better performance

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [x] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
