### PR TITLE
implement EIP-1898

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2459,6 +2459,11 @@ func (bc *BlockChain) HasHeader(hash common.Hash, number uint64) bool {
 	return bc.hc.HasHeader(hash, number)
 }
 
+// GetCanonicalHash returns the canonical hash for a given block number
+func (bc *BlockChain) GetCanonicalHash(number uint64) common.Hash {
+	return bc.hc.GetCanonicalHash(number)
+}
+
 // GetBlockHashesFromHash retrieves a number of block hashes starting at a given
 // hash, fetching towards the genesis block.
 func (bc *BlockChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -32,7 +32,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 const (
@@ -380,6 +380,11 @@ func (hc *HeaderChain) GetHeaderByNumber(number uint64) *types.Header {
 		return nil
 	}
 	return hc.GetHeader(hash, number)
+}
+
+func (hc *HeaderChain) GetCanonicalHash(number uint64) common.Hash {
+	// TODO: return rawdb.ReadCanonicalHash(hc.chainDb, number)
+	return GetCanonicalHash(hc.chainDb, number)
 }
 
 // CurrentHeader retrieves the current head header of the canonical chain. The

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -99,7 +99,11 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 			return nil, errors.New("PoS V1 does not support confirmed block lookup")
 		}
 	}
-	return b.eth.blockchain.GetHeaderByNumber(uint64(blockNr)), nil
+	header := b.eth.blockchain.GetHeaderByNumber(uint64(blockNr))
+	if header == nil {
+		return nil, errors.New("header for number not found")
+	}
+	return header, nil
 }
 
 func (b *EthApiBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -102,6 +102,27 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	return b.eth.blockchain.GetHeaderByNumber(uint64(blockNr)), nil
 }
 
+func (b *EthApiBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.HeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		return header, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
+func (b *EthApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	return b.eth.blockchain.GetHeaderByHash(hash), nil
+}
+
 func (b *EthApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error) {
 	// Pending block is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
@@ -130,6 +151,31 @@ func (b *EthApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	return b.eth.blockchain.GetBlockByNumber(uint64(blockNr)), nil
 }
 
+func (b *EthApiBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	return b.eth.blockchain.GetBlockByHash(hash), nil
+}
+
+func (b *EthApiBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.BlockByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		block := b.eth.blockchain.GetBlock(hash, header.Number.Uint64())
+		if block == nil {
+			return nil, errors.New("header found, but block body is missing")
+		}
+		return block, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
 func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	// Pending state is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
@@ -142,6 +188,30 @@ func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
 	return stateDb, header, err
+}
+
+func (b *EthApiBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.StateAndHeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header, err := b.HeaderByHash(ctx, hash)
+		if err != nil {
+			return nil, nil, err
+		}
+		if header == nil {
+			return nil, nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, nil, errors.New("hash is not currently canonical")
+		}
+		stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+		if err != nil {
+			return nil, nil, err
+		}
+		return stateDb, header, nil
+	}
+	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
 func (b *EthApiBackend) GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -187,6 +187,9 @@ func (b *EthApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.
 		return nil, nil, err
 	}
 	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+	if err != nil {
+		return nil, nil, err
+	}
 	return stateDb, header, err
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -57,8 +57,13 @@ type Backend interface {
 	// BlockChain API
 	SetHead(number uint64)
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
+	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
+	HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error)
 	BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error)
+	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
+	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error)
+	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error)
 	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
 	GetTd(blockHash common.Hash) *big.Int

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -74,6 +74,30 @@ func (b *LesApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	return b.eth.blockchain.GetHeaderByNumberOdr(ctx, uint64(blockNr))
 }
 
+func (b *LesApiBackend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.HeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header, err := b.HeaderByHash(ctx, hash)
+		if err != nil {
+			return nil, err
+		}
+		if header == nil {
+			return nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		return header, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
+func (b *LesApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	return b.eth.blockchain.GetHeaderByHash(hash), nil
+}
+
 func (b *LesApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Block, error) {
 	header, err := b.HeaderByNumber(ctx, blockNr)
 	if header == nil || err != nil {
@@ -82,12 +106,53 @@ func (b *LesApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	return b.GetBlock(ctx, header.Hash())
 }
 
+func (b *LesApiBackend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	return b.eth.blockchain.GetBlockByHash(ctx, hash)
+}
+
+func (b *LesApiBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.BlockByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		block, err := b.BlockByHash(ctx, hash)
+		if err != nil {
+			return nil, err
+		}
+		if block == nil {
+			return nil, errors.New("header found, but block body is missing")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(block.NumberU64()) != hash {
+			return nil, errors.New("hash is not currently canonical")
+		}
+		return block, nil
+	}
+	return nil, errors.New("invalid arguments; neither block nor hash specified")
+}
+
 func (b *LesApiBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	header, err := b.HeaderByNumber(ctx, blockNr)
 	if header == nil || err != nil {
 		return nil, nil, err
 	}
 	return light.NewState(ctx, header, b.eth.odr), header, nil
+}
+
+func (b *LesApiBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
+	if blockNr, ok := blockNrOrHash.Number(); ok {
+		return b.StateAndHeaderByNumber(ctx, blockNr)
+	}
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		header := b.eth.blockchain.GetHeaderByHash(hash)
+		if header == nil {
+			return nil, nil, errors.New("header for hash not found")
+		}
+		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
+			return nil, nil, errors.New("hash is not currently canonical")
+		}
+		return light.NewState(ctx, header, b.eth.odr), header, nil
+	}
+	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
 func (b *LesApiBackend) GetBlock(ctx context.Context, blockHash common.Hash) (*types.Block, error) {

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -420,6 +420,11 @@ func (bc *LightChain) HasHeader(hash common.Hash, number uint64) bool {
 	return bc.hc.HasHeader(hash, number)
 }
 
+// GetCanonicalHash returns the canonical hash for a given block number
+func (bc *LightChain) GetCanonicalHash(number uint64) common.Hash {
+	return bc.hc.GetCanonicalHash(number)
+}
+
 // GetBlockHashesFromHash retrieves a number of block hashes starting at a given
 // hash, fetching towards the genesis block.
 func (self *LightChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {


### PR DESCRIPTION
# Proposed changes

This PR support for EIP-1898.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A


## Test

```bash
MY_ADDRESS="0xD4CE02705041F04135f1949Bc835c1Fe0885513c"
XDCValidator="0x0000000000000000000000000000000000000088"

HASH0=$(curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 4003,
  "method": "eth_getBlockByNumber",
  "params": [
    "0x0",
    false
  ]
}' | jq -r '.result.hash')

HASH1=$(curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 4003,
  "method": "eth_getBlockByNumber",
  "params": [
    "0x1",
    false
  ]
}' | jq -r '.result.hash')

echo "HASH0 = ${HASH0}"
echo "HASH1 = ${HASH1}"
```

### eth_call

test: function ownerCount() => 0x0db02622

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": null,
  "error": {
    "code": -32700,
    "message": "parse error"
  }
}
```

---

request:

```bash
# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "0x0"
  ]
}' | jq

# block number earliest
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "earliest"
  ]
}' | jq

# genesis hash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockHash": "'"${HASH0}"'"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "recovery failed"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "latest"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq

```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "'"${XDCValidator}"'",
      "data": "0x0db02622"
    },
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
}
```

### eth_estimateGas

test: function ownerCount() => 0x0db02622

---

request:

```bash
curl -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": null,
  "error": {
    "code": -32700,
    "message": "parse error"
  }
}
```

---

request:

```bash
# block number 0
curl -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "0x0"
  ]
}' | jq

# block number earliest
curl -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "earliest"
  ]
}' | jq

# genesis hash
curl -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 1234,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockHash": "'"${HASH0}"'"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "recovery failed"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x5208"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "latest"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x5208"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x5208"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x5208"
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": "0xD4CE02705041F04135f1949Bc835c1Fe0885513c",
      "to": "0x85f33E1242d87a875301312BD4EbaEe8876517BA",
      "value": "0x12345678"
    },
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x5208"
}
```

### eth_getAccountInfo

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32602,
    "message": "missing value for required argument 1"
  }
}
```

---

request:

```bash
# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "0x0"
  ]
}' | jq

# block number earliest
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "earliest"
  ]
}' | jq

# genesis hash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "'"${HASH0}"'"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "latest"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getAccountInfo",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": {
    "address": "0x0000000000000000000000000000000000000088",
    "balance": "0x1fc3842bd1f071c00000",
    "codeHash": "0x43e5b04f4015a9345835af4980fea519f1a1f499cbfddd624696cca4dcd43657",
    "codeSize": 14452,
    "nonce": 0,
    "storageHash": "0x69fc7cb82b5837876debf26719e7057afa53678154477a9a8376f371caef86b8"
  }
}
```

### eth_getBalance

ADDRESS="${MY_ADDRESS}"
ADDRESS="${XDCValidator}"

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32602,
    "message": "missing value for required argument 1"
  }
}
```

---

request:

```bash
# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "0x0"
  ]
}' | jq

# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "0xffffffff"
  ]
}' | jq

# block number earliest
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "earliest"
  ]
}' | jq

# genesis hash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "'"${HASH0}"'"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x1fc3842bd1f071c00000"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x1fc3842bd1f071c00000"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "latest"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x1fc3842bd1f071c00000"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x1fc3842bd1f071c00000"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x1fc3842bd1f071c00000"
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getBalance",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x1fc3842bd1f071c00000"
}
```

### eth_getCode

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32602,
    "message": "missing value for required argument 1"
  }
}
```

---

request:

```bash
# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "0x0"
  ]
}' | jq

# block number earliest
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "earliest"
  ]
}' | jq

# genesis hash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "'"${HASH0}"'"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "latest"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getCode",
  "params": [
    "'"${XDCValidator}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```

### eth_getStorageAt

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32602,
    "message": "missing value for required argument 2"
  }
}
```

---

request:

```bash
# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "0x0"
  ]
}' | jq

# block number earliest
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "earliest"
  ]
}' | jq

# genesis hash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "'"${HASH0}"'"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000003"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000003"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "latest"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000003"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000003"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000003"
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getStorageAt",
  "params": [
    "'"${XDCValidator}"'",
    "0x8",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0000000000000000000000000000000000000000000000000000000000000003"
}
```

### eth_getTransactionCount

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32602,
    "message": "missing value for required argument 1"
  }
}
```

---

request:

```bash
# block number 0
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "0x0"
  ]
}' | jq

# block number earliest
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "earliest"
  ]
}' | jq

# genesis hash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "'"${HASH0}"'"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "0x1"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "latest"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "pending"
  ]
}' | jq
```

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0"
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "committed"
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "PoS V1 does not support confirmed block lookup"
  }
}
```

---

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockNumber": "0x1"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x0"
}
```

---

nonexistent block number

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    "0xffffffffffff"
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockNumber": "0xffffffffffff"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for number not found"
  }
}
```

---

nonexistent hash

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "header for hash not found"
  }
}
```

---

test blockHash of block number 1:

request:

```bash
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "'"${HASH1}"'"
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": true 
    }
  ]
}' | jq

curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_getTransactionCount",
  "params": [
    "'"${ADDRESS}"'",
    {
        "blockHash": "'"${HASH1}"'",
        "requireCanonical": false 
    }
  ]
}' | jq
```

response:

```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x......"
}
```
