### PR TITLE
after we use time.Ticker it didn't allow to have 0 time duration

### DIFF
--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -17,8 +17,9 @@
 package eth
 
 import (
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/bitutil"
@@ -44,7 +45,7 @@ const (
 
 	// bloomRetrievalWait is the maximum time to wait for enough bloom bit requests
 	// to accumulate request an entire batch (avoiding hysteresis).
-	bloomRetrievalWait = time.Duration(0)
+	bloomRetrievalWait = time.Microsecond * 100
 )
 
 // startBloomHandlers starts a batch of goroutines to accept bloom bit database

--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -19,12 +19,11 @@ package eth
 import (
 	"time"
 
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/bitutil"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/bloombits"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/params"


### PR DESCRIPTION
# Proposed changes
Related to https://github.com/XinFinOrg/XDPoSChain/pull/400
After we use time.Ticker it didn't allow to have 0 time duration. When we call eth_getLogs it panics and crash the nodes, change to non 0 will resolve this issue

Thanks @gzliudan for finding the root cause.

Error Log:
![2024-03-15 18 54 56](https://github.com/XinFinOrg/XDPoSChain/assets/17850890/00403889-f354-4974-bcae-6b17b4a4e737)


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
Too complicate to write unit test, will do the test on devnet while calling eth_getLogs api.