### PR TITLE
drop peer if received bad block data which does not include the valid…

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/verifyHeader.go
+++ b/consensus/XDPoS/engines/engine_v2/verifyHeader.go
@@ -36,7 +36,8 @@ func (x *XDPoS_v2) verifyHeader(chain consensus.ChainReader, header *types.Heade
 	}
 
 	if len(header.Validator) == 0 {
-		return consensus.ErrNoValidatorSignature
+		// This should never happen, if it does, then it means the peer is sending us invalid data.
+		return consensus.ErrNoValidatorSignatureV2
 	}
 
 	if fullVerify {

--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -39,6 +39,8 @@ var (
 
 	ErrNoValidatorSignature = errors.New("no validator in header")
 
+	ErrNoValidatorSignatureV2 = errors.New("no validator in v2 header")
+
 	ErrNotReadyToPropose = errors.New("not ready to propose, QC is not ready")
 
 	ErrNotReadyToMine = errors.New("Not ready to mine, it's not your turn")

--- a/consensus/tests/engine_v2_tests/verify_header_test.go
+++ b/consensus/tests/engine_v2_tests/verify_header_test.go
@@ -50,7 +50,7 @@ func TestShouldVerifyBlock(t *testing.T) {
 	noValidatorBlock := blockchain.GetBlockByNumber(902).Header()
 	noValidatorBlock.Validator = []byte{}
 	err = adaptor.VerifyHeader(blockchain, noValidatorBlock, true)
-	assert.Equal(t, consensus.ErrNoValidatorSignature, err)
+	assert.Equal(t, consensus.ErrNoValidatorSignatureV2, err)
 
 	blockFromFuture := blockchain.GetBlockByNumber(902).Header()
 	blockFromFuture.Time = big.NewInt(time.Now().Unix() + 10000)


### PR DESCRIPTION
# Proposed changes
Fix the bug where v2 is not handling the `ErrNoValidatorSignature` consensus error correctly. In v2, we will never reach the state where a block does not contain validator field. If it does, then the node should drop the peer who sent it. It's invalid block

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [x] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
