### PR TITLE
PPX-01 rename NextEpochMasterNodes to NextEpochCandidates

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -457,7 +457,7 @@ func (x *XDPoS) GetSnapshot(chain consensus.ChainReader, header *types.Header) (
 		return &utils.PublicApiSnapshot{
 			Number:  sp.Number,
 			Hash:    sp.Hash,
-			Signers: sp.GetMappedMasterNodes(),
+			Signers: sp.GetMappedCandidates(),
 		}, err
 	default: // Default "v1"
 		sp, err := x.EngineV1.GetSnapshot(chain, header)

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -468,7 +468,7 @@ func (x *XDPoS_v2) IsAuthorisedAddress(chain consensus.ChainReader, header *type
 		log.Error("[IsAuthorisedAddress] Can't get snapshot with at ", "number", header.Number, "hash", header.Hash().Hex(), "err", err)
 		return false
 	}
-	for _, mn := range snap.NextEpochMasterNodes {
+	for _, mn := range snap.NextEpochCandidates {
 		if mn == address {
 			return true
 		}
@@ -611,9 +611,9 @@ func (x *XDPoS_v2) VerifyVoteMessage(chain consensus.ChainReader, vote *types.Vo
 	verified, signer, err := x.verifyMsgSignature(types.VoteSigHash(&types.VoteForSign{
 		ProposedBlockInfo: vote.ProposedBlockInfo,
 		GapNumber:         vote.GapNumber,
-	}), vote.Signature, snapshot.NextEpochMasterNodes)
+	}), vote.Signature, snapshot.NextEpochCandidates)
 	if err != nil {
-		for i, mn := range snapshot.NextEpochMasterNodes {
+		for i, mn := range snapshot.NextEpochCandidates {
 			log.Warn("[VerifyVoteMessage] Master node list item", "index", i, "Master node", mn.Hex())
 		}
 		log.Warn("[VerifyVoteMessage] Error while verifying vote message", "votedBlockNum", vote.ProposedBlockInfo.Number.Uint64(), "votedBlockHash", vote.ProposedBlockInfo.Hash.Hex(), "voteHash", vote.Hash(), "error", err.Error())
@@ -649,15 +649,15 @@ func (x *XDPoS_v2) VerifyTimeoutMessage(chain consensus.ChainReader, timeoutMsg 
 		log.Error("[VerifyTimeoutMessage] Fail to get snapshot when verifying timeout message!", "messageGapNumber", timeoutMsg.GapNumber, "err", err)
 		return false, err
 	}
-	if len(snap.NextEpochMasterNodes) == 0 {
-		log.Error("[VerifyTimeoutMessage] cannot find nextEpochMasterNodes from snapshot", "messageGapNumber", timeoutMsg.GapNumber)
+	if len(snap.NextEpochCandidates) == 0 {
+		log.Error("[VerifyTimeoutMessage] cannot find NextEpochCandidates from snapshot", "messageGapNumber", timeoutMsg.GapNumber)
 		return false, fmt.Errorf("Empty master node lists from snapshot")
 	}
 
 	verified, signer, err := x.verifyMsgSignature(types.TimeoutSigHash(&types.TimeoutForSign{
 		Round:     timeoutMsg.Round,
 		GapNumber: timeoutMsg.GapNumber,
-	}), timeoutMsg.Signature, snap.NextEpochMasterNodes)
+	}), timeoutMsg.Signature, snap.NextEpochCandidates)
 
 	if err != nil {
 		log.Warn("[VerifyTimeoutMessage] cannot verify timeout signature", "err", err)
@@ -1005,7 +1005,7 @@ func (x *XDPoS_v2) calcMasternodes(chain consensus.ChainReader, blockNum *big.In
 		log.Error("[calcMasternodes] Adaptor v2 getSnapshot has error", "err", err)
 		return nil, nil, err
 	}
-	candidates := snap.NextEpochMasterNodes
+	candidates := snap.NextEpochCandidates
 
 	if blockNum.Uint64() == x.config.V2.SwitchBlock.Uint64()+1 {
 		log.Info("[calcMasternodes] examing first v2 block")

--- a/consensus/XDPoS/engines/engine_v2/epochSwitch.go
+++ b/consensus/XDPoS/engines/engine_v2/epochSwitch.go
@@ -63,7 +63,7 @@ func (x *XDPoS_v2) getEpochSwitchInfo(chain consensus.ChainReader, header *types
 			return nil, err
 		}
 		penalties := common.ExtractAddressFromBytes(h.Penalties)
-		candidates := snap.NextEpochMasterNodes
+		candidates := snap.NextEpochCandidates
 		standbynodes := []common.Address{}
 		if len(masternodes) != len(candidates) {
 			standbynodes = candidates

--- a/consensus/XDPoS/engines/engine_v2/snapshot.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot.go
@@ -10,22 +10,22 @@ import (
 )
 
 // Snapshot is the state of the smart contract validator list
-// The validator list is used on next epoch master nodes
+// The validator list is used on next epoch candidates nodes
 // If we don't have the snapshot, then we have to trace back the gap block smart contract state which is very costly
 type SnapshotV2 struct {
 	Number uint64      `json:"number"` // Block number where the snapshot was created
 	Hash   common.Hash `json:"hash"`   // Block hash where the snapshot was created
 
-	// MasterNodes will get assigned on updateM1
-	NextEpochMasterNodes []common.Address `json:"masterNodes"` // Set of authorized master nodes at this moment for next epoch
+	// candidates will get assigned on updateM1
+	NextEpochCandidates []common.Address `json:"candidates"` // Set of authorized candidates nodes at this moment for next epoch
 }
 
 // create new snapshot for next epoch to use
-func newSnapshot(number uint64, hash common.Hash, masternodes []common.Address) *SnapshotV2 {
+func newSnapshot(number uint64, hash common.Hash, candidates []common.Address) *SnapshotV2 {
 	snap := &SnapshotV2{
-		Number:               number,
-		Hash:                 hash,
-		NextEpochMasterNodes: masternodes,
+		Number:              number,
+		Hash:                hash,
+		NextEpochCandidates: candidates,
 	}
 	return snap
 }
@@ -53,17 +53,17 @@ func storeSnapshot(s *SnapshotV2, db ethdb.Database) error {
 	return db.Put(append([]byte("XDPoS-V2-"), s.Hash[:]...), blob)
 }
 
-// retrieves master nodes list in map type
-func (s *SnapshotV2) GetMappedMasterNodes() map[common.Address]struct{} {
+// retrieves candidates nodes list in map type
+func (s *SnapshotV2) GetMappedCandidates() map[common.Address]struct{} {
 	ms := make(map[common.Address]struct{})
-	for _, n := range s.NextEpochMasterNodes {
+	for _, n := range s.NextEpochCandidates {
 		ms[n] = struct{}{}
 	}
 	return ms
 }
 
-func (s *SnapshotV2) IsMasterNodes(address common.Address) bool {
-	for _, n := range s.NextEpochMasterNodes {
+func (s *SnapshotV2) IsCandidates(address common.Address) bool {
+	for _, n := range s.NextEpochCandidates {
 		if n.String() == address.String() {
 			return true
 		}

--- a/consensus/XDPoS/engines/engine_v2/snapshot_test.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot_test.go
@@ -15,8 +15,8 @@ func TestGetMasterNodes(t *testing.T) {
 	snap := newSnapshot(1, common.Hash{}, masterNodes)
 
 	for _, address := range masterNodes {
-		if _, ok := snap.GetMappedMasterNodes()[address]; !ok {
-			t.Error("should get master node from map", address.Hex(), snap.GetMappedMasterNodes())
+		if _, ok := snap.GetMappedCandidates()[address]; !ok {
+			t.Error("should get master node from map", address.Hex(), snap.GetMappedCandidates())
 			return
 		}
 	}

--- a/consensus/XDPoS/engines/engine_v2/timeout.go
+++ b/consensus/XDPoS/engines/engine_v2/timeout.go
@@ -97,7 +97,7 @@ func (x *XDPoS_v2) verifyTC(chain consensus.ChainReader, timeoutCert *types.Time
 		log.Error("[verifyTC] Fail to get snapshot when verifying TC!", "TCGapNumber", timeoutCert.GapNumber)
 		return fmt.Errorf("[verifyTC] Unable to get snapshot, %s", err)
 	}
-	if snap == nil || len(snap.NextEpochMasterNodes) == 0 {
+	if snap == nil || len(snap.NextEpochCandidates) == 0 {
 		log.Error("[verifyTC] Something wrong with the snapshot from gapNumber", "messageGapNumber", timeoutCert.GapNumber, "snapshot", snap)
 		return fmt.Errorf("empty master node lists from snapshot")
 	}
@@ -135,7 +135,7 @@ func (x *XDPoS_v2) verifyTC(chain consensus.ChainReader, timeoutCert *types.Time
 	for _, signature := range signatures {
 		go func(sig types.Signature) {
 			defer wg.Done()
-			verified, _, err := x.verifyMsgSignature(signedTimeoutObj, sig, snap.NextEpochMasterNodes)
+			verified, _, err := x.verifyMsgSignature(signedTimeoutObj, sig, snap.NextEpochCandidates)
 			if err != nil || !verified {
 				log.Error("[verifyTC] Error or verification failure", "Signature", sig, "Error", err)
 				mutex.Lock() // Lock before accessing haveError

--- a/consensus/XDPoS/engines/engine_v2/utils.go
+++ b/consensus/XDPoS/engines/engine_v2/utils.go
@@ -164,7 +164,7 @@ func (x *XDPoS_v2) GetSignersFromSnapshot(chain consensus.ChainReader, header *t
 	if err != nil {
 		return nil, err
 	}
-	return snap.NextEpochMasterNodes, err
+	return snap.NextEpochCandidates, err
 }
 
 func (x *XDPoS_v2) CalculateMissingRounds(chain consensus.ChainReader, header *types.Header) (*utils.PublicApiMissedRoundsMetadata, error) {

--- a/consensus/tests/engine_v2_tests/mine_test.go
+++ b/consensus/tests/engine_v2_tests/mine_test.go
@@ -56,7 +56,7 @@ func TestYourTurnInitialV2(t *testing.T) {
 	assert.NotNil(t, snap)
 	masterNodes := adaptor.EngineV1.GetMasternodesFromCheckpointHeader(block900.Header())
 	for i := 0; i < len(masterNodes); i++ {
-		assert.Equal(t, masterNodes[i].Hex(), snap.NextEpochMasterNodes[i].Hex())
+		assert.Equal(t, masterNodes[i].Hex(), snap.NextEpochCandidates[i].Hex())
 	}
 }
 
@@ -136,7 +136,7 @@ func TestUpdateMasterNodes(t *testing.T) {
 	snap, err = x.GetSnapshot(blockchain, parentBlock.Header())
 
 	assert.Nil(t, err)
-	assert.True(t, snap.IsMasterNodes(voterAddr))
+	assert.True(t, snap.IsCandidates(voterAddr))
 	assert.Equal(t, int(snap.Number), 1350)
 }
 
@@ -211,7 +211,7 @@ func TestPrepareHappyPath(t *testing.T) {
 	}
 
 	validators := []byte{}
-	for _, v := range snap.NextEpochMasterNodes {
+	for _, v := range snap.NextEpochCandidates {
 		validators = append(validators, v[:]...)
 	}
 	assert.Equal(t, validators, header901.Validators)
@@ -267,7 +267,7 @@ func TestUpdateMultipleMasterNodes(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.Equal(t, 1350, int(snap.Number))
-			assert.Equal(t, 128, len(snap.NextEpochMasterNodes)) // 128 is all masternode candidates, not limited by MaxMasternodes
+			assert.Equal(t, 128, len(snap.NextEpochCandidates)) // 128 is all masternode candidates, not limited by MaxMasternodes
 		}
 	}
 

--- a/consensus/tests/engine_v2_tests/verify_header_test.go
+++ b/consensus/tests/engine_v2_tests/verify_header_test.go
@@ -286,10 +286,10 @@ func TestConfigSwitchOnDifferentMasternodeCount(t *testing.T) {
 
 	snap, err := x.GetSnapshot(blockchain, currentBlock.Header())
 	assert.Nil(t, err)
-	assert.Equal(t, len(snap.NextEpochMasterNodes), 20)
+	assert.Equal(t, len(snap.NextEpochCandidates), 20)
 	header1800.Validators = []byte{}
 	for i := 0; i < 20; i++ {
-		header1800.Validators = append(header1800.Validators, snap.NextEpochMasterNodes[i].Bytes()...)
+		header1800.Validators = append(header1800.Validators, snap.NextEpochCandidates[i].Bytes()...)
 	}
 
 	round, err := x.GetRoundNumber(header1800)


### PR DESCRIPTION
# Proposed changes
Rename snapshot property name NextEpochCandidates to make more correct meanings, the final masternodes list is calculated at epoch switch block.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
