### PR TITLE
use 0x address scheme by default and add new enable xdc prefix flag

### DIFF
--- a/cicd/devnet/start.sh
+++ b/cicd/devnet/start.sh
@@ -81,5 +81,5 @@ XDC --ethstats ${netstats} --gcmode archive \
 --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd --mine \
 --gasprice "1" --targetgaslimit "420000000" --verbosity ${log_level} \
 --debugdatadir /work/xdcchain \
---enable-0x-prefix --ws --wsaddr=0.0.0.0 --wsport $ws_port \
+--ws --wsaddr=0.0.0.0 --wsport $ws_port \
 --wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/cicd/mainnet/start.sh
+++ b/cicd/mainnet/start.sh
@@ -80,5 +80,5 @@ XDC --ethstats ${netstats} --gcmode archive \
 --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd --mine \
 --gasprice "1" --targetgaslimit "420000000" --verbosity ${log_level} \
 --debugdatadir /work/xdcchain \
---enable-0x-prefix --ws --wsaddr=0.0.0.0 --wsport $ws_port \
+--ws --wsaddr=0.0.0.0 --wsport $ws_port \
 --wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/cicd/testnet/start.sh
+++ b/cicd/testnet/start.sh
@@ -82,5 +82,5 @@ XDC --ethstats ${netstats} --gcmode archive \
 --rpcvhosts "*" --unlock "${wallet}" --password /work/.pwd --mine \
 --gasprice "1" --targetgaslimit "420000000" --verbosity ${log_level} \
 --debugdatadir /work/xdcchain \
---enable-0x-prefix --ws --wsaddr=0.0.0.0 --wsport $ws_port \
+--ws --wsaddr=0.0.0.0 --wsport $ws_port \
 --wsorigins "*" 2>&1 >>/work/xdcchain/xdc.log | tee -a /work/xdcchain/xdc.log

--- a/cmd/XDC/config.go
+++ b/cmd/XDC/config.go
@@ -164,8 +164,8 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, XDCConfig) {
 		common.TIPXDCXCancellationFee = common.TIPXDCXCancellationFeeTestnet
 	}
 
-	if ctx.GlobalBool(utils.Enable0xPrefixFlag.Name) {
-		common.Enable0xPrefix = true
+	if ctx.GlobalBool(utils.EnableXDCPrefixFlag.Name) {
+		common.Enable0xPrefix = false
 	}
 
 	// Rewound

--- a/cmd/XDC/consolecmd_test.go
+++ b/cmd/XDC/consolecmd_test.go
@@ -38,7 +38,7 @@ const (
 // Tests that a node embedded within a console can be started up properly and
 // then terminated by closing the input stream.
 func TestConsoleWelcome(t *testing.T) {
-	coinbase := "xdc8605cdbbdb6d264aa742e77020dcbc58fcdce182"
+	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
 
 	// Start a XDC console, make sure it's cleaned up and terminate the console
 	XDC := runXDC(t,
@@ -75,7 +75,7 @@ at block: 0 ({{niltime}})
 // Tests that a console can be attached to a running node via various means.
 func TestIPCAttachWelcome(t *testing.T) {
 	// Configure the instance for IPC attachement
-	coinbase := "xdc8605cdbbdb6d264aa742e77020dcbc58fcdce182"
+	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
 	var ipc string
 	if runtime.GOOS == "windows" {
 		ipc = `\\.\pipe\XDC` + strconv.Itoa(trulyRandInt(100000, 999999))
@@ -97,7 +97,7 @@ func TestIPCAttachWelcome(t *testing.T) {
 }
 
 func TestHTTPAttachWelcome(t *testing.T) {
-	coinbase := "xdc8605cdbbdb6d264aa742e77020dcbc58fcdce182"
+	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
 	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
 	XDC := runXDC(t,
 		"--XDCx.datadir", tmpdir(t)+"XDCx/"+time.Now().String(),
@@ -112,7 +112,7 @@ func TestHTTPAttachWelcome(t *testing.T) {
 }
 
 func TestWSAttachWelcome(t *testing.T) {
-	coinbase := "xdc8605cdbbdb6d264aa742e77020dcbc58fcdce182"
+	coinbase := "0x8605cdbbdb6d264aa742e77020dcbc58fcdce182"
 	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
 
 	XDC := runXDC(t,

--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -114,6 +114,7 @@ var (
 		//utils.VMEnableDebugFlag,
 		utils.XDCTestnetFlag,
 		utils.Enable0xPrefixFlag,
+		utils.EnableXDCPrefixFlag,
 		utils.RewoundFlag,
 		utils.NetworkIdFlag,
 		utils.RPCCORSDomainFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -117,7 +117,11 @@ var (
 	}
 	Enable0xPrefixFlag = cli.BoolFlag{
 		Name:  "enable-0x-prefix",
-		Usage: "Addres use 0x-prefix (default = false)",
+		Usage: "Addres use 0x-prefix (Deprecated: this is on by default, to use xdc prefix use --enable-xdc-prefix)",
+	}	
+	EnableXDCPrefixFlag = cli.BoolFlag{
+		Name:  "enable-xdc-prefix",
+		Usage: "Addres use xdc-prefix (default = false)",
 	}
 	// General settings
 	AnnounceTxsFlag = cli.BoolFlag{
@@ -786,6 +790,10 @@ func setIPC(ctx *cli.Context, cfg *node.Config) {
 	}
 }
 
+func setPrefix(ctx *cli.Context, cfg *node.Config) {
+	checkExclusive(ctx, Enable0xPrefixFlag, EnableXDCPrefixFlag)
+}
+
 // MakeDatabaseHandles raises out the number of allowed file handles per process
 // for XDC and returns half of the allowance to assign to the database.
 func MakeDatabaseHandles() int {
@@ -933,6 +941,7 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	setHTTP(ctx, cfg)
 	setWS(ctx, cfg)
 	setNodeUserIdent(ctx, cfg)
+	setPrefix(ctx, cfg)
 
 	switch {
 	case ctx.GlobalIsSet(DataDirFlag.Name):

--- a/common/constants.go
+++ b/common/constants.go
@@ -53,7 +53,7 @@ var ShanghaiBlock = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(38383838)
 var IsTestnet bool = false
-var Enable0xPrefix bool = false
+var Enable0xPrefix bool = true
 var StoreRewardFolder string
 var RollbackHash Hash
 var BasePrice = big.NewInt(1000000000000000000)                       // 1

--- a/common/constants/constants.go.devnet
+++ b/common/constants/constants.go.devnet
@@ -53,7 +53,7 @@ var ShanghaiBlock = big.NewInt(16832700)
 
 var TIPXDCXTestnet = big.NewInt(0)
 var IsTestnet bool = false
-var Enable0xPrefix bool = false
+var Enable0xPrefix bool = true
 var StoreRewardFolder string
 var RollbackHash Hash
 var BasePrice = big.NewInt(1000000000000000000)                       // 1

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -53,7 +53,7 @@ var ShanghaiBlock = big.NewInt(61290000) // Target 31st March 2024
 
 var TIPXDCXTestnet = big.NewInt(23779191)
 var IsTestnet bool = false
-var Enable0xPrefix bool = false
+var Enable0xPrefix bool = true
 var StoreRewardFolder string
 var RollbackHash Hash
 var BasePrice = big.NewInt(1000000000000000000)                       // 1


### PR DESCRIPTION
# Proposed changes
As agreed by the developer community to enable 0x prefix as default going forward. This will make sure we have less friction with new partners at later date.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
