### PR TITLE
Bump txsize configuration 64KB > 128KB

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -50,7 +50,7 @@ const (
 	// non-trivial consequences: larger transactions are significantly harder and
 	// more expensive to propagate; larger transactions also take more resources
 	// to validate whether they fit into the pool or not.
-	txMaxSize = 2 * txSlotSize // 64KB, don't bump without EIP-2464 support
+	txMaxSize = 4 * txSlotSize 
 )
 
 var (


### PR DESCRIPTION
only merge after EIP2464 is implemented https://github.com/XinFinOrg/XDPoSChain/pull/550 