### PR TITLE
remove ecs rpc node as we have ec2 ones

### DIFF
--- a/cicd/terraform/main.tf
+++ b/cicd/terraform/main.tf
@@ -19,64 +19,6 @@ provider "aws" {
   region  = "ap-southeast-1"
 }
 
-module "devnet-rpc" {
-  source = "./module/region"
-  region = "ap-southeast-1"
-  nodeKeys = local.rpcDevnetNodeKeys
-  enableFixedIp = true
-  logLevel = local.logLevel
-  xdc_ecs_tasks_execution_role_arn = aws_iam_role.xdc_ecs_tasks_execution_role.arn
-
-  cpu = 1024 
-  memory = 4096
-
-  network = "devnet"
-  vpc_cidr = "10.0.0.0/16"
-  subnet_cidr = "10.0.0.0/20"
-  providers = {
-    aws = aws.ap-southeast-1
-  }
-}
-
-module "testnet-rpc" {
-  source = "./module/region"
-  region = "ap-southeast-1"
-  nodeKeys = local.rpcTestnetNodeKeys
-  enableFixedIp = true
-  logLevel = local.logLevel
-  xdc_ecs_tasks_execution_role_arn = aws_iam_role.xdc_ecs_tasks_execution_role.arn
-
-  cpu = 1024
-  memory = 4096
-
-  network = "testnet"
-  vpc_cidr = "10.1.0.0/16"
-  subnet_cidr = "10.1.0.0/20"
-  providers = {
-    aws = aws.ap-southeast-1
-  }
-}
-
-module "mainnet-rpc" {
-  source = "./module/region"
-  region = "ap-southeast-1"
-  nodeKeys = local.rpcMainnetNodeKeys
-  enableFixedIp = true
-  logLevel = local.logLevel
-  xdc_ecs_tasks_execution_role_arn = aws_iam_role.xdc_ecs_tasks_execution_role.arn
-
-  cpu = 1024
-  memory = 4096
-
-  network = "mainnet"
-  vpc_cidr = "10.2.0.0/16"
-  subnet_cidr = "10.2.0.0/20"
-  providers = {
-    aws = aws.ap-southeast-1
-  }
-}
-
-
 module "devnet_rpc" {
   source = "./module/ec2_rpc"
   network = "devnet"


### PR DESCRIPTION
# Proposed changes
remove ecs rpc as we migrate to ec2 ones

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [x] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
