### PR TITLE
fix v2.0.0 sync problem for mainnet

### DIFF
--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -154,7 +154,6 @@ func (x *XDPoS_v1) verifyHeaderWithCache(chain consensus.ChainReader, header *ty
 // looking those up from the database. This is useful for concurrently verifying
 // a batch of new headers.
 func (x *XDPoS_v1) verifyHeader(chain consensus.ChainReader, header *types.Header, parents []*types.Header, fullVerify bool) error {
-	fullVerify = false
 	// If we're running a engine faking, accept any block as valid
 	if x.config.SkipV1Validation {
 		return nil


### PR DESCRIPTION
# Proposed changes

This PR fix v2.0.0 sync problem for mainet by revert commit #531. When we sync mainnet with [old v2.0.0](https://github.com/XinFinOrg/XDPoSChain/commit/3ae6f752bda4865664fdb3914b2a119eaaee1ffb), each block reported `Reorg` and `Chain split detected` WARN messages after catch up the latest height, such as:

```text
INFO [07-18|11:02:55] Imported new chain segment               blocks=1 txs=4   mgas=0.414   elapsed=35.412ms  mgasps=11.691  number=77335639 hash=88c610…c7db38 cache=0.00B
INFO [07-18|11:02:56] Imported new chain segment               blocks=1 txs=4   mgas=0.414   elapsed=26.552ms  mgasps=15.592  number=77335639 hash=790a6f…f48b2f cache=0.00B
WARN [07-18|11:02:57] Reorg                                    oldBlock hash=0x88c610f8f05ae42d34eea4a8f60260658a6373c02686de4862e5688cd7c7db38 number=77335639 newBlock hash=0x15e1d39c60de3862b2f70f6e583f9025e1781854f496d16d84e7dd1fb712b5aa number=77335640
WARN [07-18|11:02:57] Chain split detected                     number=77335638 hash=7ec1da…0e2128 drop=1 dropfrom=88c610…c7db38 add=2 addfrom=15e1d3…12b5aa
INFO [07-18|11:02:57] Imported new chain segment               blocks=1 txs=3   mgas=0.295   elapsed=26.230ms  mgasps=11.253  number=77335640 hash=15e1d3…12b5aa cache=0.00B
INFO [07-18|11:02:58] Imported new chain segment               blocks=1 txs=3   mgas=0.295   elapsed=23.732ms  mgasps=12.438  number=77335640 hash=0aa7d0…0647cf cache=0.00B
WARN [07-18|11:02:59] Reorg                                    oldBlock hash=0x15e1d39c60de3862b2f70f6e583f9025e1781854f496d16d84e7dd1fb712b5aa number=77335640 newBlock hash=0xd5993a3805f94f47423780a02a61018cff698b503e2df51fa6b8e42cc4b9466a number=77335641
WARN [07-18|11:02:59] Chain split detected                     number=77335639 hash=790a6f…f48b2f drop=1 dropfrom=15e1d3…12b5aa add=2 addfrom=d5993a…b9466a
INFO [07-18|11:02:59] Imported new chain segment               blocks=1 txs=4   mgas=0.414   elapsed=26.021ms  mgasps=15.913  number=77335641 hash=d5993a…b9466a cache=0.00B
INFO [07-18|11:03:00] Imported new chain segment               blocks=1 txs=4   mgas=0.414   elapsed=21.459ms  mgasps=19.295  number=77335641 hash=e166c3…f048b4 cache=0.00B
WARN [07-18|11:03:01] Reorg                                    oldBlock hash=0xd5993a3805f94f47423780a02a61018cff698b503e2df51fa6b8e42cc4b9466a number=77335641 newBlock hash=0x84ac59222c5890837bf2d9b29c893458eff9302191476c09087b8df08d86818c number=77335642
WARN [07-18|11:03:01] Chain split detected                     number=77335640 hash=0aa7d0…0647cf drop=1 dropfrom=d5993a…b9466a add=2 addfrom=84ac59…86818c
INFO [07-18|11:03:01] Imported new chain segment               blocks=1 txs=4   mgas=0.425   elapsed=32.295ms  mgasps=13.173  number=77335642 hash=84ac59…86818c cache=0.00B
INFO [07-18|11:03:02] Imported new chain segment               blocks=1 txs=4   mgas=0.425   elapsed=30.304ms  mgasps=14.039  number=77335642 hash=54153e…b0406e cache=0.00B
WARN [07-18|11:03:03] Reorg                                    oldBlock hash=0x84ac59222c5890837bf2d9b29c893458eff9302191476c09087b8df08d86818c number=77335642 newBlock hash=0x1bf851c8e8128c691f2c091ca7e524e942ac14a0a820d190d985dc600d168e9a number=77335643
WARN [07-18|11:03:03] Chain split detected                     number=77335641 hash=e166c3…f048b4 drop=1 dropfrom=84ac59…86818c add=2 addfrom=1bf851…168e9a
INFO [07-18|11:03:03] Imported new chain segment               blocks=1 txs=4   mgas=0.414   elapsed=33.259ms  mgasps=12.438  number=77335643 hash=1bf851…168e9a cache=0.00B
INFO [07-18|11:03:04] Imported new chain segment               blocks=1 txs=4   mgas=0.414   elapsed=27.531ms  mgasps=15.026  number=77335643 hash=294f60…d87438 cache=0.00B
WARN [07-18|11:03:05] Reorg                                    oldBlock hash=0x1bf851c8e8128c691f2c091ca7e524e942ac14a0a820d190d985dc600d168e9a number=77335643 newBlock hash=0x04e4a12c02d615010076b279057fcc8bdce4b2cd89460d5e03b50d0704e84760 number=77335644
WARN [07-18|11:03:05] Chain split detected                     number=77335642 hash=54153e…b0406e drop=1 dropfrom=1bf851…168e9a add=2 addfrom=04e4a1…e84760
INFO [07-18|11:03:05] Imported new chain segment               blocks=1 txs=4   mgas=0.413   elapsed=33.305ms  mgasps=12.415  number=77335644 hash=04e4a1…e84760 cache=0.00B
INFO [07-18|11:03:06] Imported new chain segment               blocks=1 txs=4   mgas=0.413   elapsed=21.299ms  mgasps=19.413  number=77335644 hash=dc34fe…fbba77 cache=0.00B
WARN [07-18|11:03:07] Reorg                                    oldBlock hash=0x04e4a12c02d615010076b279057fcc8bdce4b2cd89460d5e03b50d0704e84760 number=77335644 newBlock hash=0x5521e65ddeb4552e7861ef7cd5a30d002c9624edd6c652b7bf50ea8186194a9a number=77335645
WARN [07-18|11:03:07] Chain split detected                     number=77335643 hash=294f60…d87438 drop=1 dropfrom=04e4a1…e84760 add=2 addfrom=5521e6…194a9a
INFO [07-18|11:03:07] Imported new chain segment               blocks=1 txs=3   mgas=0.295   elapsed=28.081ms  mgasps=10.512  number=77335645 hash=5521e6…194a9a cache=0.00B
INFO [07-18|11:03:08] Imported new chain segment               blocks=1 txs=3   mgas=0.295   elapsed=21.080ms  mgasps=14.002  number=77335645 hash=0d23f2…28ea0f cache=0.00B
WARN [07-18|11:03:09] Reorg                                    oldBlock hash=0x5521e65ddeb4552e7861ef7cd5a30d002c9624edd6c652b7bf50ea8186194a9a number=77335645 newBlock hash=0x7b09ca9b35c1b068ba993d01301ec2d528504e9cf4d3362ca7d8df582d7d14ef number=77335646
WARN [07-18|11:03:09] Chain split detected                     number=77335644 hash=dc34fe…fbba77 drop=1 dropfrom=5521e6…194a9a add=2 addfrom=7b09ca…7d14ef
INFO [07-18|11:03:09] Imported new chain segment               blocks=1 txs=5   mgas=0.502   elapsed=184.209ms mgasps=2.724   number=77335646 hash=7b09ca…7d14ef cache=0.00B
INFO [07-18|11:03:10] Imported new chain segment               blocks=1 txs=5   mgas=0.502   elapsed=25.485ms  mgasps=19.687  number=77335646 hash=a1727d…e64efa cache=0.00B
WARN [07-18|11:03:11] Reorg                                    oldBlock hash=0x7b09ca9b35c1b068ba993d01301ec2d528504e9cf4d3362ca7d8df582d7d14ef number=77335646 newBlock hash=0xc47ebcf55ec0b7a86689c5fa5009d9fa8d6ef0c87e860e190c28e6396a78782f number=77335647
WARN [07-18|11:03:11] Chain split detected                     number=77335645 hash=0d23f2…28ea0f drop=1 dropfrom=7b09ca…7d14ef add=2 addfrom=c47ebc…78782f
INFO [07-18|11:03:11] Imported new chain segment               blocks=1 txs=3   mgas=0.295   elapsed=23.721ms  mgasps=12.444  number=77335647 hash=c47ebc…78782f cache=0.00B
INFO [07-18|11:03:12] Imported new chain segment               blocks=1 txs=3   mgas=0.295   elapsed=21.698ms  mgasps=13.604  number=77335647 hash=b2d980…d7255a cache=0.00B
WARN [07-18|11:03:13] Reorg                                    oldBlock hash=0xc47ebcf55ec0b7a86689c5fa5009d9fa8d6ef0c87e860e190c28e6396a78782f number=77335647 newBlock hash=0x97bd3f4c3cb50711c67db5404ceaae6076a8032e4726d6dc25fa5bfcc3efd273 number=77335648
WARN [07-18|11:03:13] Chain split detected                     number=77335646 hash=a1727d…e64efa drop=1 dropfrom=c47ebc…78782f add=2 addfrom=97bd3f…efd273
INFO [07-18|11:03:13] Imported new chain segment               blocks=1 txs=5   mgas=0.546   elapsed=26.870ms  mgasps=20.306  number=77335648 hash=97bd3f…efd273 cache=0.00B
INFO [07-18|11:03:14] Imported new chain segment               blocks=1 txs=5   mgas=0.546   elapsed=26.914ms  mgasps=20.273  number=77335648 hash=3eec6a…d26d47 cache=0.00B
WARN [07-18|11:03:15] Reorg                                    oldBlock hash=0x97bd3f4c3cb50711c67db5404ceaae6076a8032e4726d6dc25fa5bfcc3efd273 number=77335648 newBlock hash=0xd4cf73305789dc9a53a1d02eebb9db3e9b023483617afa3086c36d97a01c7827 number=77335649
WARN [07-18|11:03:15] Chain split detected                     number=77335647 hash=b2d980…d7255a drop=1 dropfrom=97bd3f…efd273 add=2 addfrom=d4cf73…1c7827
INFO [07-18|11:03:15] Imported new chain segment               blocks=1 txs=4   mgas=0.383   elapsed=52.763ms  mgasps=7.263   number=77335649 hash=d4cf73…1c7827 cache=0.00B
INFO [07-18|11:03:15] Imported new chain segment               blocks=1 txs=4   mgas=0.383   elapsed=21.426ms  mgasps=17.885  number=77335649 hash=cf443c…a0d22b cache=0.00B
INFO [07-18|11:03:16] Imported new chain segment               blocks=1 txs=4   mgas=0.383   elapsed=29.003ms  mgasps=13.213  number=77335649 hash=784aab…1faec1 cache=0.00B
INFO [07-18|11:03:16] Imported new chain segment               blocks=1 txs=4   mgas=0.383   elapsed=32.905ms  mgasps=11.646  number=77335649 hash=36ab5a…59423a cache=0.00B
WARN [07-18|11:03:17] Reorg                                    oldBlock hash=0xd4cf73305789dc9a53a1d02eebb9db3e9b023483617afa3086c36d97a01c7827 number=77335649 newBlock hash=0x2951fef200085429fcd585865a2b3c4237e7cebf1731a1eca09d2751e98afd08 number=77335650
WARN [07-18|11:03:17] Chain split detected                     number=77335648 hash=3eec6a…d26d47 drop=1 dropfrom=d4cf73…1c7827 add=2 addfrom=2951fe…8afd08
INFO [07-18|11:03:17] It's time to update new set of masternodes for the next epoch...
ERROR[07-18|11:03:18] RPC method eth_call crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 140130 [running]:
github.com/XinFinOrg/XDPoSChain/rpc.(*callback).call.func1()
        /home/me/XDPoSChain/rpc/service.go:200 +0x85
panic({0x112f780?, 0x1d640b0?})
        /home/me/govm/golang/go-1.21.12/src/runtime/panic.go:914 +0x21f
github.com/XinFinOrg/XDPoSChain/core/types.(*Block).Header(...)
        /home/me/XDPoSChain/core/types/block.go:348
github.com/XinFinOrg/XDPoSChain/internal/ethapi.DoCall({0x15e3f40, 0xc03fb25680}, {0x15f4808, 0xc02aba0348}, {0xc03eed3f38, 0xc03eed3f50, 0xc0425b50b0, 0xc04b6ce540, 0x0, 0xc03fb67c50, ...}, ...)
        /home/me/XDPoSChain/internal/ethapi/api.go:1326 +0x38c
github.com/XinFinOrg/XDPoSChain/internal/ethapi.(*PublicBlockChainAPI).Call(0xc01bbf9fc0, {0x15e3f40, 0xc03fb25680}, {0xc03eed3f38, 0xc03eed3f50, 0xc0425b50b0, 0xc04b6ce540, 0x0, 0xc03fb67c50, 0x0}, ...)
        /home/me/XDPoSChain/internal/ethapi/api.go:1402 +0x14c
reflect.Value.call({0xc01c1d9180?, 0xc01c3493e8?, 0x7f63d3709bb8?}, {0x129f056, 0x4}, {0xc00e9b6b00, 0x5, 0x426d12?})
        /home/me/govm/golang/go-1.21.12/src/reflect/value.go:596 +0xce7
reflect.Value.Call({0xc01c1d9180?, 0xc01c3493e8?, 0x58aee5?}, {0xc00e9b6b00?, 0x3?, 0x16?})
        /home/me/govm/golang/go-1.21.12/src/reflect/value.go:380 +0xb9
github.com/XinFinOrg/XDPoSChain/rpc.(*callback).call(0xc01c372fc0, {0x15e3f40?, 0xc03fb25680}, {0xc0425b4e78, 0x8}, {0xc03fb256d0, 0x3, 0x4e192f?})
        /home/me/XDPoSChain/rpc/service.go:206 +0x379
github.com/XinFinOrg/XDPoSChain/rpc.(*handler).runMethod(0xc033a3b3b0?, {0x15e3f40?, 0xc03fb25680?}, 0xc03c968230, 0x3?, {0xc03fb256d0?, 0x11d6140?, 0xc029a6be08?})
        /home/me/XDPoSChain/rpc/handler.go:388 +0x3c
github.com/XinFinOrg/XDPoSChain/rpc.(*handler).handleCall(0xc04c461b90, 0xc050a31650, 0xc03c968230)
        /home/me/XDPoSChain/rpc/handler.go:336 +0x22f
github.com/XinFinOrg/XDPoSChain/rpc.(*handler).handleCallMsg(0xc04c461b90, 0x30?, 0xc03c968230)
        /home/me/XDPoSChain/rpc/handler.go:297 +0xbd
github.com/XinFinOrg/XDPoSChain/rpc.(*handler).handleMsg.func1(0xc050a31650)
        /home/me/XDPoSChain/rpc/handler.go:138 +0x2f
github.com/XinFinOrg/XDPoSChain/rpc.(*handler).startCallProc.func1()
        /home/me/XDPoSChain/rpc/handler.go:225 +0xbe
created by github.com/XinFinOrg/XDPoSChain/rpc.(*handler).startCallProc in goroutine 139868
        /home/me/XDPoSChain/rpc/handler.go:221 +0x79

WARN [07-18|11:03:18] Served eth_call                          reqid=1 t=1.729175ms err="method handler crashed"
CRIT [07-18|11:03:18] Error when update masternodes set. Stopping node err="method handler crashed"                      blockNumber=77335650
```

At last when reach the gap block (77335650 % 900 == 450), the function `UpdateM1()` is called in the function `reorg`, but `UpdateM1()` raised panic because of the gap block is not exist in statedb:

```go
if bc.chainConfig.XDPoS != nil && ((newChain[i].NumberU64() % bc.chainConfig.XDPoS.Epoch) == (bc.chainConfig.XDPoS.Epoch - bc.chainConfig.XDPoS.Gap)) {
	err := bc.UpdateM1()
	if err != nil {
		log.Crit("Error when update masternodes set. Stopping node", "err", err, "blockNumber", newChain[i].NumberU64())
	}
}
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
