### PR TITLE
Fix crash during reorg for v2.0.0

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1319,7 +1319,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	// this makes sure resources are cleaned up.
 	defer cancel()
 
-	block, err := b.BlockByHash(ctx, header.Hash())
+	block, err := b.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, 0, false, err, nil
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -626,6 +626,10 @@ func (c *ChainConfig) IsTIPXDCXReceiver(num *big.Int) bool {
 	return isForked(common.TIPXDCX, num) && !isForked(common.TIPXDCXReceiverDisable, num)
 }
 
+func (c *ChainConfig) IsXDCxDisable(num *big.Int) bool {
+	return isForked(common.TIPXDCXReceiverDisable, num)
+}
+
 func (c *ChainConfig) IsTIPXDCXLending(num *big.Int) bool {
 	return isForked(common.TIPXDCXLending, num)
 }
@@ -789,7 +793,7 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          c.IsMerge(num),
 		IsShanghai:       c.IsShanghai(num),
-		IsXDCxDisable:    c.IsTIPXDCXReceiver(num),
+		IsXDCxDisable:    c.IsXDCxDisable(num),
 		IsEIP1559:        c.IsEIP1559(num),
 	}
 }


### PR DESCRIPTION
# Proposed changes

### 1. fix crash during reorg

In the function `DoCall`

Old code:

```go
block, err := b.BlockByHash(ctx, header.Hash())
```

New code:

```go
block, err := b.BlockByNumberOrHash(ctx, blockNrOrHash)
```

The function `BlockByHash` returns nil block during reorg, but `BlockByNumberOrHash` returns block which is we want.

### 2. fix `IsXDCxDisable`

In the function `func (c *ChainConfig) Rules(num *big.Int)`:

Old code:

```go
IsXDCxDisable:    c.IsTIPXDCXReceiver(num),
```

`IsTIPXDCXReceiver` means `common.TIPXDCX <= num < common.TIPXDCXReceiverDisable`.

New code:

```go
 IsXDCxDisable:    c.IsXDCxDisable(num),
```

`IsXDCxDisable` means `num >= common.TIPXDCXReceiverDisable`.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
