### PR TITLE
lower the devnet cert to recover devnet again

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -94,9 +94,9 @@ var (
 			TimeoutPeriod:        30,
 			MinePeriod:           2,
 		},
-		13625858: { // 2024.07.29 RPC call and reorg sync issue
+		13625855: { // 2024.07.29 RPC call and reorg sync issue
 			MaxMasternodes:       108,
-			SwitchRound:          13625858,
+			SwitchRound:          13625855,
 			CertThreshold:        0.4,
 			TimeoutSyncThreshold: 3,
 			TimeoutPeriod:        30,


### PR DESCRIPTION
# Proposed changes
Matching the current round number from the block, not the timeout round number, timeout round number will be delete after all the nodes gets reverted.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
