### PR TITLE
support both input and data in eth_call, eth_estimateGas, personal_sendTransaction

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -778,3 +778,8 @@ func (m Message) CheckNonce() bool          { return m.checkNonce }
 func (m Message) AccessList() AccessList    { return m.accessList }
 
 func (m *Message) SetNonce(nonce uint64) { m.nonce = nonce }
+
+func (m *Message) SetBalanceTokenFeeForCall() {
+	m.balanceTokenFee = new(big.Int).SetUint64(m.gasLimit)
+	m.balanceTokenFee.Mul(m.balanceTokenFee, m.gasPrice)
+}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -652,7 +652,7 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Ha
 // created during the execution of EVM if the given transaction was added on
 // top of the provided block and returns them as a JSON object.
 // You can provide -2 as a block number to trace on top of the pending block.
-func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
+func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
 	// Try to retrieve the specified block
 	var (
 		err   error

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1249,7 +1249,6 @@ type CallArgs struct {
 }
 
 // ToMessage converts CallArgs to the Message type used by the core evm
-// TODO: set balanceTokenFee
 func (args *CallArgs) ToMessage(b Backend, number *big.Int, globalGasCap uint64) types.Message {
 	// Set sender address or use a default if none specified
 	var addr common.Address
@@ -1298,11 +1297,7 @@ func (args *CallArgs) ToMessage(b Backend, number *big.Int, globalGasCap uint64)
 		accessList = *args.AccessList
 	}
 
-	balanceTokenFee := big.NewInt(0).SetUint64(gas)
-	balanceTokenFee = balanceTokenFee.Mul(balanceTokenFee, gasPrice)
-
-	// Create new call message
-	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, accessList, false, balanceTokenFee, number)
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, accessList, false, nil, number)
 	return msg
 }
 
@@ -1321,6 +1316,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	}
 
 	msg := args.ToMessage(b, header.Number, globalGasCap)
+	msg.SetBalanceTokenFeeForCall()
 
 	// Setup context so it may be cancelled the call has completed
 	// or, in case of unmetered gas, setup a context with a timeout.

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -1,0 +1,197 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
+	"github.com/XinFinOrg/XDPoSChain/common/math"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/rpc"
+)
+
+// TransactionArgs represents the arguments to construct a new transaction
+// or a message call.
+type TransactionArgs struct {
+	From     *common.Address `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      *hexutil.Uint64 `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Value    *hexutil.Big    `json:"value"`
+	Nonce    *hexutil.Uint64 `json:"nonce"`
+
+	// We accept "data" and "input" for backwards-compatibility reasons.
+	// "input" is the newer name and should be preferred by clients.
+	// Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
+	Data  *hexutil.Bytes `json:"data"`
+	Input *hexutil.Bytes `json:"input"`
+
+	// For non-legacy transactions
+	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+}
+
+// from retrieves the transaction sender address.
+func (arg *TransactionArgs) from() common.Address {
+	if arg.From == nil {
+		return common.Address{}
+	}
+	return *arg.From
+}
+
+// data retrieves the transaction calldata. Input field is preferred.
+func (arg *TransactionArgs) data() []byte {
+	if arg.Input != nil {
+		return *arg.Input
+	}
+	if arg.Data != nil {
+		return *arg.Data
+	}
+	return nil
+}
+
+// setDefaults fills in default values for unspecified tx fields.
+func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
+	if args.GasPrice == nil {
+		price, err := b.SuggestPrice(ctx)
+		if err != nil {
+			return err
+		}
+		args.GasPrice = (*hexutil.Big)(price)
+	}
+	if args.Value == nil {
+		args.Value = new(hexutil.Big)
+	}
+	if args.Nonce == nil {
+		nonce, err := b.GetPoolNonce(ctx, args.from())
+		if err != nil {
+			return err
+		}
+		args.Nonce = (*hexutil.Uint64)(&nonce)
+	}
+	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
+		return errors.New(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
+	}
+	if args.To == nil && len(args.data()) == 0 {
+		return errors.New(`contract creation without any data provided`)
+	}
+	// Estimate the gas usage if necessary.
+	if args.Gas == nil {
+		// These fields are immutable during the estimation, safe to
+		// pass the pointer directly.
+		callArgs := TransactionArgs{
+			From:       args.From,
+			To:         args.To,
+			GasPrice:   args.GasPrice,
+			Value:      args.Value,
+			Data:       args.Data,
+			AccessList: args.AccessList,
+		}
+		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+		estimated, err := DoEstimateGas(ctx, b, callArgs, pendingBlockNr, nil, b.RPCGasCap())
+		if err != nil {
+			return err
+		}
+		args.Gas = &estimated
+		log.Trace("Estimate gas usage automatically", "gas", args.Gas)
+	}
+	if args.ChainID == nil {
+		id := (*hexutil.Big)(b.ChainConfig().ChainId)
+		args.ChainID = id
+	}
+	return nil
+}
+
+// ToMessage converts TransactionArgs to the Message type used by the core evm
+func (args *TransactionArgs) ToMessage(b Backend, number *big.Int, globalGasCap uint64) types.Message {
+	// Set sender address or use zero address if none specified.
+	addr := args.from()
+	if addr == (common.Address{}) {
+		if wallets := b.AccountManager().Wallets(); len(wallets) > 0 {
+			if accounts := wallets[0].Accounts(); len(accounts) > 0 {
+				addr = accounts[0].Address
+			}
+		}
+	}
+
+	// Set default gas & gas price if none were set
+	gas := globalGasCap
+	if args.Gas != nil {
+		gas = uint64(*args.Gas)
+	}
+	if gas == 0 {
+		gas = math.MaxUint64 / 2
+	}
+	if globalGasCap != 0 && globalGasCap < gas {
+		log.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
+		gas = globalGasCap
+	}
+	gasPrice := new(big.Int)
+	if args.GasPrice != nil {
+		gasPrice = args.GasPrice.ToInt()
+	}
+	if gasPrice.Sign() <= 0 {
+		gasPrice = new(big.Int).SetUint64(defaultGasPrice)
+	}
+	value := new(big.Int)
+	if args.Value != nil {
+		value = args.Value.ToInt()
+	}
+	data := args.data()
+	var accessList types.AccessList
+	if args.AccessList != nil {
+		accessList = *args.AccessList
+	}
+
+	// Create new call message
+	msg := types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, accessList, false, nil, number)
+	return msg
+}
+
+// toTransaction converts the arguments to a transaction.
+// This assumes that setDefaults has been called.
+func (args *TransactionArgs) toTransaction() *types.Transaction {
+	var data types.TxData
+	if args.AccessList == nil {
+		data = &types.LegacyTx{
+			To:       args.To,
+			Nonce:    uint64(*args.Nonce),
+			Gas:      uint64(*args.Gas),
+			GasPrice: (*big.Int)(args.GasPrice),
+			Value:    (*big.Int)(args.Value),
+			Data:     args.data(),
+		}
+	} else {
+		data = &types.AccessListTx{
+			To:         args.To,
+			ChainID:    (*big.Int)(args.ChainID),
+			Nonce:      uint64(*args.Nonce),
+			Gas:        uint64(*args.Gas),
+			GasPrice:   (*big.Int)(args.GasPrice),
+			Value:      (*big.Int)(args.Value),
+			Data:       args.data(),
+			AccessList: *args.AccessList,
+		}
+	}
+	return types.NewTx(data)
+}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -99,12 +99,13 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.Gas == nil {
 		// These fields are immutable during the estimation, safe to
 		// pass the pointer directly.
+		data := args.data()
 		callArgs := TransactionArgs{
 			From:       args.From,
 			To:         args.To,
 			GasPrice:   args.GasPrice,
 			Value:      args.Value,
-			Data:       args.Data,
+			Data:       (*hexutil.Bytes)(&data),
 			AccessList: args.AccessList,
 		}
 		pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)


### PR DESCRIPTION
# Proposed changes
A user reported a bug in [here](https://www.xdc.dev/steven_lin_1581b1cdfd98a6/wip-ethestimategas-rpc-method-on-apothem-with-erc20-transfer-always-return-execution-reverted-error-5fgl) when using the Go-Ethereum client to call JSON-RPC. The issue arises because the parameter field 'data' has been renamed to 'input' from version 1.13 onwards.

This PR adds support of "input" field in `eth_call`,`eth_estimateGas` . Field "data" will be still supported
### Test
When this PR is not merged:
- For RPC="http://127.0.0.1:8545", the changes from this PR are applied.
- For RPC="https://arpc.apothem.network/", the changes from this PR are not applied.
#### eth_call
- `data` field

Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "data": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x000000000000000000000000000000000000000000000000000000000000000b"
}
```
- `input` field

Request:
```shell
RPC="https://arpc.apothem.network/"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "execution reverted"
  }
}
```
---
Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x000000000000000000000000000000000000000000000000000000000000000b"
}
```
- Requests that include both an `input` field and a `data` field, and these fields have the same value.

Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622",
      "data": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x000000000000000000000000000000000000000000000000000000000000000b"
}
```
- Requests that include both an `input` field and a `data` field, but these fields have different values.

Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_call",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622",
      "data": "0x12345678"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x000000000000000000000000000000000000000000000000000000000000000b"
}
```
#### eth_estimateGas
- `data` field

Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "data": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x574a"
}
```
- `input` field

Request:
```shell
RPC="https://arpc.apothem.network/"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622"
    },
    "latest"]}' | jq
```
Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "error": {
    "code": -32000,
    "message": "execution reverted"
  }
}
```

---
Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x574a"
}
```
- Requests that include both an `input` field and a `data` field, and these fields have the same value.

Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622",
      "data": "0x0db02622"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x574a"
}
```
- Requests that include both an `input` field and a `data` field, but these fields have different values.

Request:
```shell
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 8001,
  "method": "eth_estimateGas",
  "params": [
    {
      "to": "0x0000000000000000000000000000000000000088",
      "input": "0x0db02622",
      "data": "0x12345678"
    },
    "latest"]}' | jq
```

Response:
```json
{
  "jsonrpc": "2.0",
  "id": 8001,
  "result": "0x574a"
}
```
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement
- [x] N/A

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [x] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
