### PR TITLE
make MasternodeVotingSMC tx never timeout

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1399,7 +1399,12 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
 		blockNrOrHash = &latest
 	}
-	result, _, failed, err, vmErr := DoCall(ctx, s.b, args, *blockNrOrHash, overrides, vm.Config{}, 5*time.Second, s.b.RPCGasCap())
+	timeout := 5 * time.Second
+	MasternodeVotingSMCBinary := common.Address{19: 0x88} // xdc0000000000000000000000000000000000000088
+	if args.To != nil && *args.To == MasternodeVotingSMCBinary {
+		timeout = 0
+	}
+	result, _, failed, err, vmErr := DoCall(ctx, s.b, args, *blockNrOrHash, overrides, vm.Config{}, timeout, s.b.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Proposed changes

The value of timeout for a single call is 5 seconds now.

```go
func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Bytes, error) {
        // ......
	result, _, failed, err, vmErr := DoCall(ctx, s.b, args, *blockNrOrHash, overrides, vm.Config{}, 5*time.Second, s.b.RPCGasCap())
	if err != nil {
		return nil, err
	}
	// ......
}
```

When the system is extremely slow, such as the CPU is exhausted, the function `Call` will return `err="execution aborted (timeout = 5s)"`. This is OK for normal transactions. But when we call the function `UpdateM1`:

```go
// in function WriteBlockWithState
err := bc.UpdateM1()
if err != nil {
    log.Crit("Error when update masternodes set. Stopping node", "err", err, "blockNum", block.NumberU64())
}

// in function reorg
err := bc.UpdateM1()
if err != nil {
    log.Crit("Error when update masternodes set. Stopping node", "err", err, "blockNumber", newChain[i].NumberU64())
}
```

if `UpdateM1` returns timeout error, then the node will exit by `log.Crit`. The function `UpdateM1` calls the function of contract MasternodeVotingSMC(xdc0000000000000000000000000000000000000088). So this PR change the timeout value for the transactions of `MasternodeVotingSMC` to zero which means infinite.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
