### PR TITLE
remove legacy testnet validate masternode logic

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/accounts"
 	"github.com/XinFinOrg/XDPoSChain/accounts/keystore"
 	"github.com/XinFinOrg/XDPoSChain/cmd/utils"
-	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
 	"github.com/XinFinOrg/XDPoSChain/console"
 	"github.com/XinFinOrg/XDPoSChain/core"
@@ -319,16 +318,9 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg XDCConfig) {
 			ok := false
 			slaveMode := ctx.GlobalIsSet(utils.XDCSlaveModeFlag.Name)
 			var err error
-			if common.IsTestnet {
-				ok, err = ethereum.ValidateMasternodeTestnet()
-				if err != nil {
-					utils.Fatalf("Can't verify masternode permission: %v", err)
-				}
-			} else {
-				ok, err = ethereum.ValidateMasternode()
-				if err != nil {
-					utils.Fatalf("Can't verify masternode permission: %v", err)
-				}
+			ok, err = ethereum.ValidateMasternode()
+			if err != nil {
+				utils.Fatalf("Can't verify masternode permission: %v", err)
 			}
 			if ok {
 				if slaveMode {
@@ -360,16 +352,10 @@ func startNode(ctx *cli.Context, stack *node.Node, cfg XDCConfig) {
 				log.Info("Update consensus parameters")
 				chain := ethereum.BlockChain()
 				engine.UpdateParams(chain.CurrentHeader())
-				if common.IsTestnet {
-					ok, err = ethereum.ValidateMasternodeTestnet()
-					if err != nil {
-						utils.Fatalf("Can't verify masternode permission: %v", err)
-					}
-				} else {
-					ok, err = ethereum.ValidateMasternode()
-					if err != nil {
-						utils.Fatalf("Can't verify masternode permission: %v", err)
-					}
+
+				ok, err = ethereum.ValidateMasternode()
+				if err != nil {
+					utils.Fatalf("Can't verify masternode permission: %v", err)
 				}
 				if !ok {
 					if started {

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -69,13 +69,13 @@ var RelayerLendingCancelFee = big.NewInt(1000000000000000)            // 0.001
 var BaseLendingInterest = big.NewInt(100000000)                       // 1e8
 
 var MinGasPrice = big.NewInt(DefaultMinGasPrice)
-var RelayerRegistrationSMC = "0x16c63b79f9C8784168103C0b74E6A59EC2de4a02"
+var RelayerRegistrationSMC = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
 var RelayerRegistrationSMCTestnet = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
-var LendingRegistrationSMC = "0x7d761afd7ff65a79e4173897594a194e3c506e57"
+var LendingRegistrationSMC = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
 var LendingRegistrationSMCTestnet = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
 var TRC21IssuerSMCTestNet = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
-var TRC21IssuerSMC = HexToAddress("0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee")
-var XDCXListingSMC = HexToAddress("0xDE34dD0f536170993E8CFF639DdFfCF1A85D3E53")
+var TRC21IssuerSMC = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
+var XDCXListingSMC = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")
 var XDCXListingSMCTestNet = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")
 var TRC21GasPriceBefore = big.NewInt(2500)
 var TRC21GasPrice = big.NewInt(250000000)

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -54,7 +54,7 @@ var ShanghaiBlock = big.NewInt(61290000) // Target 31st March 2024
 var Eip1559Block = big.NewInt(9999999999)
 
 var TIPXDCXTestnet = big.NewInt(23779191)
-var IsTestnet bool = false
+var IsTestnet bool = true
 var Enable0xPrefix bool = true
 var StoreRewardFolder string
 var RollbackHash Hash
@@ -69,13 +69,13 @@ var RelayerLendingCancelFee = big.NewInt(1000000000000000)            // 0.001
 var BaseLendingInterest = big.NewInt(100000000)                       // 1e8
 
 var MinGasPrice = big.NewInt(DefaultMinGasPrice)
-var RelayerRegistrationSMC = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
+var RelayerRegistrationSMC = "0x16c63b79f9C8784168103C0b74E6A59EC2de4a02"
 var RelayerRegistrationSMCTestnet = "0xA1996F69f47ba14Cb7f661010A7C31974277958c"
-var LendingRegistrationSMC = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
+var LendingRegistrationSMC = "0x7d761afd7ff65a79e4173897594a194e3c506e57"
 var LendingRegistrationSMCTestnet = "0x28d7fC2Cf5c18203aaCD7459EFC6Af0643C97bE8"
 var TRC21IssuerSMCTestNet = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
-var TRC21IssuerSMC = HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F")
-var XDCXListingSMC = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")
+var TRC21IssuerSMC = HexToAddress("0x8c0faeb5C6bEd2129b8674F262Fd45c4e9468bee")
+var XDCXListingSMC = HexToAddress("0xDE34dD0f536170993E8CFF639DdFfCF1A85D3E53")
 var XDCXListingSMCTestNet = HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0")
 var TRC21GasPriceBefore = big.NewInt(2500)
 var TRC21GasPrice = big.NewInt(250000000)

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -438,16 +438,6 @@ func (x *XDPoS_v1) YourTurn(chain consensus.ChainReader, parent *types.Header, s
 
 func (x *XDPoS_v1) yourTurn(chain consensus.ChainReader, parent *types.Header, signer common.Address) (int, int, int, bool, error) {
 	masternodes := x.GetMasternodes(chain, parent)
-
-	// if common.IsTestnet {
-	// 	// Only three mns hard code for XDC testnet.
-	// 	masternodes = []common.Address{
-	// 		common.HexToAddress("0x3Ea0A3555f9B1dE983572BfF6444aeb1899eC58C"),
-	// 		common.HexToAddress("0x4F7900282F3d371d585ab1361205B0940aB1789C"),
-	// 		common.HexToAddress("0x942a5885A8844Ee5587C8AC5e371Fc39FFE61896"),
-	// 	}
-	// }
-
 	snap, err := x.GetSnapshot(chain, parent)
 	if err != nil {
 		log.Warn("Failed when trying to commit new work", "err", err)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -486,28 +486,6 @@ func (s *Ethereum) ValidateMasternode() (bool, error) {
 	return true, nil
 }
 
-// ValidateMasternodeTestNet checks if node's address is in set of masternodes in Testnet
-func (s *Ethereum) ValidateMasternodeTestnet() (bool, error) {
-	eb, err := s.Etherbase()
-	if err != nil {
-		return false, err
-	}
-	if s.chainConfig.XDPoS == nil {
-		return false, errors.New("Only verify masternode permission in XDPoS protocol")
-	}
-	masternodes := []common.Address{
-		common.HexToAddress("0x3Ea0A3555f9B1dE983572BfF6444aeb1899eC58C"),
-		common.HexToAddress("0x4F7900282F3d371d585ab1361205B0940aB1789C"),
-		common.HexToAddress("0x942a5885A8844Ee5587C8AC5e371Fc39FFE61896"),
-	}
-	for _, m := range masternodes {
-		if m == eb {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func (s *Ethereum) StartStaking(local bool) error {
 	eb, err := s.Etherbase()
 	if err != nil {


### PR DESCRIPTION
# Proposed changes
Remove Legacy Masternode validate logic on testnet. Bug comes from this PR https://github.com/XinFinOrg/XinFin-Node/pull/137.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
