### PR TITLE
feat: GetEpochNumbersBetween API

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -552,15 +552,11 @@ func (x *XDPoS) GetCachedSigningTxs(hash common.Hash) (interface{}, bool) {
 }
 
 func (x *XDPoS) GetEpochSwitchInfoBetween(chain consensus.ChainReader, begin, end *types.Header) ([]*types.EpochSwitchInfo, error) {
-	switch x.config.BlockConsensusVersion(begin.Number, begin.Extra, ExtraFieldCheck) {
-	case params.ConsensusEngineVersion2:
-		switch x.config.BlockConsensusVersion(end.Number, end.Extra, ExtraFieldCheck) {
-		case params.ConsensusEngineVersion2:
-			return x.EngineV2.GetEpochSwitchInfoBetween(chain, begin, end)
-		default: // Default "v1"
-			return nil, errors.New("not supported in the v1 consensus")
-		}
-	default: // Default "v1"
-		return nil, errors.New("not supported in the v1 consensus")
+	beginBlockVersion := x.config.BlockConsensusVersion(begin.Number, begin.Extra, ExtraFieldCheck)
+	endBlockVersion := x.config.BlockConsensusVersion(end.Number, end.Extra, ExtraFieldCheck)
+	if beginBlockVersion == params.ConsensusEngineVersion2 && endBlockVersion == params.ConsensusEngineVersion2 {
+		return x.EngineV2.GetEpochSwitchInfoBetween(chain, begin, end)
 	}
+	// Default "v1"
+	return nil, errors.New("not supported in the v1 consensus")
 }

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -550,3 +550,17 @@ func (x *XDPoS) CacheSigningTxs(hash common.Hash, txs []*types.Transaction) []*t
 func (x *XDPoS) GetCachedSigningTxs(hash common.Hash) (interface{}, bool) {
 	return x.signingTxsCache.Get(hash)
 }
+
+func (x *XDPoS) GetEpochSwitchInfoBetween(chain consensus.ChainReader, begin, end *types.Header) ([]*types.EpochSwitchInfo, error) {
+	switch x.config.BlockConsensusVersion(begin.Number, begin.Extra, ExtraFieldCheck) {
+	case params.ConsensusEngineVersion2:
+		switch x.config.BlockConsensusVersion(end.Number, end.Extra, ExtraFieldCheck) {
+		case params.ConsensusEngineVersion2:
+			return x.EngineV2.GetEpochSwitchInfoBetween(chain, begin, end)
+		default: // Default "v1"
+			return nil, errors.New("not supported in the v1 consensus")
+		}
+	default: // Default "v1"
+		return nil, errors.New("not supported in the v1 consensus")
+	}
+}

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -331,6 +331,9 @@ func (api *API) GetEpochNumbersBetween(begin, end *rpc.BlockNumber) ([]uint64, e
 	if endHeader == nil {
 		return nil, errors.New("illegal end block number")
 	}
+	if beginHeader.Number.Cmp(endHeader.Number) > 0 {
+		return nil, errors.New("illegal begin and end block number, begin > end")
+	}
 	epochSwitchInfos, err := api.XDPoS.GetEpochSwitchInfoBetween(api.chain, beginHeader, endHeader)
 	if err != nil {
 		return nil, err

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -17,6 +17,7 @@ package XDPoS
 
 import (
 	"encoding/base64"
+	"errors"
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -319,4 +320,24 @@ func calculateSigners(message map[string]SignerTypes, pool map[string]map[common
 			MissingSigners: missingSigners,
 		}
 	}
+}
+
+func (api *API) GetEpochNumbersBetween(begin, end *rpc.BlockNumber) ([]uint64, error) {
+	beginHeader := api.getHeaderFromApiBlockNum(begin)
+	if beginHeader == nil {
+		return nil, errors.New("illegal begin block number")
+	}
+	endHeader := api.getHeaderFromApiBlockNum(end)
+	if endHeader == nil {
+		return nil, errors.New("illegal end block number")
+	}
+	epochSwitchInfos, err := api.XDPoS.GetEpochSwitchInfoBetween(api.chain, beginHeader, endHeader)
+	if err != nil {
+		return nil, err
+	}
+	epochSwitchNumbers := make([]uint64, len(epochSwitchInfos))
+	for i, info := range epochSwitchInfos {
+		epochSwitchNumbers[i] = info.EpochSwitchBlockInfo.Number.Uint64()
+	}
+	return epochSwitchNumbers, nil
 }

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -162,6 +162,12 @@ web3._extend({
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'getEpochNumbersBetween',
+			call: 'XDPoS_getEpochNumbersBetween',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
# Proposed changes
GetEpochNumbersBetween API.
Give two numbers, begin and end number. Return all epoch block numbers in between.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [x] External components
- [ ] Not sure (Please specify below)
- [x] API

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
