### PR TITLE
fix race conditions in txpool

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -21,6 +21,8 @@ import (
 	"math"
 	"math/big"
 	"sort"
+	"sync"
+	"sync/atomic"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
@@ -450,9 +452,10 @@ func (h *priceHeap) Pop() interface{} {
 // in txpool but only interested in the remote part. It means only remote transactions
 // will be considered for tracking, sorting, eviction, etc.
 type txPricedList struct {
-	all     *txLookup  // Pointer to the map of all transactions
-	remotes *priceHeap // Heap of prices of all the stored **remote** transactions
-	stales  int        // Number of stale price points to (re-heap trigger)
+	all      *txLookup  // Pointer to the map of all transactions
+	remotes  *priceHeap // Heap of prices of all the stored **remote** transactions
+	stales   int64      // Number of stale price points to (re-heap trigger)
+	reheapMu sync.Mutex // Mutex asserts that only one routine is reheaping the list
 }
 
 // newTxPricedList creates a new price-sorted transaction heap.
@@ -476,8 +479,8 @@ func (l *txPricedList) Put(tx *types.Transaction, local bool) {
 // the heap if a large enough ratio of transactions go stale.
 func (l *txPricedList) Removed(count int) {
 	// Bump the stale counter, but exit if still too low (< 25%)
-	l.stales += count
-	if l.stales <= len(*l.remotes)/4 {
+	stales := atomic.AddInt64(&l.stales, int64(count))
+	if int(stales) <= len(*l.remotes)/4 {
 		return
 	}
 	// Seems we've reached a critical number of stale transactions, reheap
@@ -515,7 +518,7 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 	for len(*l.remotes) > 0 {
 		head := []*types.Transaction(*l.remotes)[0]
 		if l.all.GetRemote(head.Hash()) == nil { // Removed or migrated
-			l.stales--
+			atomic.AddInt64(&l.stales, -1)
 			heap.Pop(l.remotes)
 			continue
 		}
@@ -541,7 +544,7 @@ func (l *txPricedList) Discard(slots int, force bool) (types.Transactions, bool)
 		// Discard stale transactions if found during cleanup
 		tx := heap.Pop(l.remotes).(*types.Transaction)
 		if l.all.GetRemote(tx.Hash()) == nil { // Removed or migrated
-			l.stales--
+			atomic.AddInt64(&l.stales, -1)
 			continue
 		}
 		// Non stale transaction found, discard it
@@ -560,9 +563,12 @@ func (l *txPricedList) Discard(slots int, force bool) (types.Transactions, bool)
 
 // Reheap forcibly rebuilds the heap based on the current remote transaction set.
 func (l *txPricedList) Reheap() {
+	l.reheapMu.Lock()
+	defer l.reheapMu.Unlock()
 	reheap := make(priceHeap, 0, l.all.RemoteCount())
 
-	l.stales, l.remotes = 0, &reheap
+	atomic.StoreInt64(&l.stales, 0)
+	l.remotes = &reheap
 	l.all.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
 		*l.remotes = append(*l.remotes, tx)
 		return true

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -282,6 +283,7 @@ type TxPool struct {
 	reorgDoneCh     chan chan struct{}
 	reorgShutdownCh chan struct{}  // requests shutdown of scheduleReorgLoop
 	wg              sync.WaitGroup // tracks loop, scheduleReorgLoop
+	initDoneCh      chan struct{}  // is closed once the pool is initialized (for tests)
 
 	eip2718          bool // Fork indicator whether we are using EIP-2718 type transactions.
 	IsSigner         func(address common.Address) bool
@@ -314,6 +316,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		queueTxEventCh:   make(chan *types.Transaction),
 		reorgDoneCh:      make(chan chan struct{}),
 		reorgShutdownCh:  make(chan struct{}),
+		initDoneCh:       make(chan struct{}),
 		gasPrice:         new(big.Int).SetUint64(config.PriceLimit),
 		trc21FeeCapacity: map[common.Address]*big.Int{},
 	}
@@ -368,6 +371,8 @@ func (pool *TxPool) loop() {
 	defer evict.Stop()
 	defer journal.Stop()
 
+	// Notify tests that the init phase is done
+	close(pool.initDoneCh)
 	for {
 		select {
 		// Handle ChainHeadEvent
@@ -386,8 +391,8 @@ func (pool *TxPool) loop() {
 		case <-report.C:
 			pool.mu.RLock()
 			pending, queued := pool.stats()
-			stales := pool.priced.stales
 			pool.mu.RUnlock()
+			stales := int(atomic.LoadInt64(&pool.priced.stales))
 
 			if pending != prevPending || queued != prevQueued || stales != prevStales {
 				log.Debug("Transaction pool status report", "executable", pending, "queued", queued, "stales", stales)


### PR DESCRIPTION
# Proposed changes

This PR fixes several race conditions in the txpool:

- A race between txlist.Removed() and txlist.Reheap() on who is allowed to reheap the list
- A race between several methods in txList on updating the txlist.stales counter
- A race during testing between the txpool.loop() and reseting the txpool's blockchain between tests
- A race during testing when updating txpool.chain.gaslimit from within a test

Reference: #23474

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
