### PR TITLE
core/vm: marshall returnData as hexstring in trace logs

### DIFF
--- a/core/vm/gen_structlog.go
+++ b/core/vm/gen_structlog.go
@@ -6,30 +6,36 @@ import (
 	"encoding/json"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
+	"github.com/XinFinOrg/XDPoSChain/common/math"
 	"github.com/holiman/uint256"
 )
+
+var _ = (*structLogMarshaling)(nil)
 
 // MarshalJSON marshals as JSON.
 func (s StructLog) MarshalJSON() ([]byte, error) {
 	type StructLog struct {
 		Pc            uint64                      `json:"pc"`
 		Op            OpCode                      `json:"op"`
-		Gas           uint64                      `json:"gas"`
-		GasCost       uint64                      `json:"gasCost"`
-		Memory        []byte                      `json:"memory"`
+		Gas           math.HexOrDecimal64         `json:"gas"`
+		GasCost       math.HexOrDecimal64         `json:"gasCost"`
+		Memory        hexutil.Bytes               `json:"memory"`
 		MemorySize    int                         `json:"memSize"`
 		Stack         []uint256.Int               `json:"stack"`
-		ReturnData    []byte                      `json:"returnData"`
+		ReturnData    hexutil.Bytes               `json:"returnData"`
 		Storage       map[common.Hash]common.Hash `json:"-"`
 		Depth         int                         `json:"depth"`
 		RefundCounter uint64                      `json:"refund"`
 		Err           error                       `json:"-"`
+		OpName        string                      `json:"opName"`
+		ErrorString   string                      `json:"error"`
 	}
 	var enc StructLog
 	enc.Pc = s.Pc
 	enc.Op = s.Op
-	enc.Gas = s.Gas
-	enc.GasCost = s.GasCost
+	enc.Gas = math.HexOrDecimal64(s.Gas)
+	enc.GasCost = math.HexOrDecimal64(s.GasCost)
 	enc.Memory = s.Memory
 	enc.MemorySize = s.MemorySize
 	enc.Stack = s.Stack
@@ -38,6 +44,8 @@ func (s StructLog) MarshalJSON() ([]byte, error) {
 	enc.Depth = s.Depth
 	enc.RefundCounter = s.RefundCounter
 	enc.Err = s.Err
+	enc.OpName = s.OpName()
+	enc.ErrorString = s.ErrorString()
 	return json.Marshal(&enc)
 }
 
@@ -46,12 +54,12 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 	type StructLog struct {
 		Pc            *uint64                     `json:"pc"`
 		Op            *OpCode                     `json:"op"`
-		Gas           *uint64                     `json:"gas"`
-		GasCost       *uint64                     `json:"gasCost"`
-		Memory        []byte                      `json:"memory"`
+		Gas           *math.HexOrDecimal64        `json:"gas"`
+		GasCost       *math.HexOrDecimal64        `json:"gasCost"`
+		Memory        *hexutil.Bytes              `json:"memory"`
 		MemorySize    *int                        `json:"memSize"`
 		Stack         []uint256.Int               `json:"stack"`
-		ReturnData    []byte                      `json:"returnData"`
+		ReturnData    *hexutil.Bytes              `json:"returnData"`
 		Storage       map[common.Hash]common.Hash `json:"-"`
 		Depth         *int                        `json:"depth"`
 		RefundCounter *uint64                     `json:"refund"`
@@ -68,13 +76,13 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		s.Op = *dec.Op
 	}
 	if dec.Gas != nil {
-		s.Gas = *dec.Gas
+		s.Gas = uint64(*dec.Gas)
 	}
 	if dec.GasCost != nil {
-		s.GasCost = *dec.GasCost
+		s.GasCost = uint64(*dec.GasCost)
 	}
 	if dec.Memory != nil {
-		s.Memory = dec.Memory
+		s.Memory = *dec.Memory
 	}
 	if dec.MemorySize != nil {
 		s.MemorySize = *dec.MemorySize
@@ -83,7 +91,7 @@ func (s *StructLog) UnmarshalJSON(input []byte) error {
 		s.Stack = dec.Stack
 	}
 	if dec.ReturnData != nil {
-		s.ReturnData = dec.ReturnData
+		s.ReturnData = *dec.ReturnData
 	}
 	if dec.Storage != nil {
 		s.Storage = dec.Storage


### PR DESCRIPTION
# Proposed changes

This PR use `gencodec` to create file `gen_structlog.go`.

```bash
go install github.com/fjl/gencodec@latest
cd XDPoSChain/core/vm
gencodec -type StructLog -field-override structLogMarshaling -out gen_structlog.go
```

Reference: #21715

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
