### PR TITLE
fix sync issue for testnet

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -635,7 +635,7 @@ func (c *ChainConfig) IsTIPXDCXReceiver(num *big.Int) bool {
 }
 
 func (c *ChainConfig) IsXDCxDisable(num *big.Int) bool {
-	return isForked(common.TIPXDCXReceiverDisable, num)
+	return isForked(common.TIPXDCXMinerDisable, num)
 }
 
 func (c *ChainConfig) IsTIPXDCXLending(num *big.Int) bool {


### PR DESCRIPTION
# Proposed changes

The progress is stuck at block number 65533267 when we sync testnet. And the below error appears again and again:

```text
ERROR[09-03|11:12:55]
########## BAD BLOCK #########
Chain config: {"chainId":51,"homesteadBlock":1,"eip150Block":2,"eip150Hash":"0x0000000000000000000000000000000000000000000000000000000000000000","eip155Block":3,"eip158Block":3,"byzantiumBlock":4,"XDPoS":{"period":2,"epoch":900,"reward":5000,"rewardCheckpoint":900,"gap":450,"foudat
ionWalletAddr":"0x746249c61f5832c5eed53172776b460491bdcd5c","SkipV1Validation":false,"v2":{"switchBlock":56828700,"config":{"maxMasternodes":15,"switchRound":0,"minePeriod":2,"timeoutSyncThreshold":3,"timeoutPeriod":20,"certificateThreshold":0.45},"allConfigs":{"0":{"maxMasternodes
":15,"switchRound":0,"minePeriod":2,"timeoutSyncThreshold":3,"timeoutPeriod":20,"certificateThreshold":0.45},"900000":{"maxMasternodes":108,"switchRound":900000,"minePeriod":2,"timeoutSyncThreshold":3,"timeoutPeriod":30,"certificateThreshold":0.667}},"SkipV2Validation":false}}}

Number: 65533267
Hash: 0xc2e6baa3d08c66a30f3c25c33bd5677c244b757fcc19adcc55979f138413d9d2
        receipt{status=0 cgas=23090 bloom=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 logs=[]}


Round: 8758270
Error: invalid receipt root hash (remote: 2fecae86a645f95c7e10f83cd05e497d668a119c5c4851d732af4839ee1673c3 local: 1af8b4fed1f4f654daefc4ace930be9bb2418ddf2178c99557104c45751ced21)
##############################

WARN [09-03|11:12:55] Synchronisation failed, dropping peer    peer=cfd8683cf09bd5bd err="retrieved hash chain is invalid"
```

After debug, we found the reason is caused by [the change](https://github.com/XinFinOrg/XDPoSChain/pull/590/files#diff-10ff00a15ef58da7485fedeca3906c73cb236fde4b143a9d61601c63cbf1ffe8L792-R796) in PR #590.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [X] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
