### PR TITLE
all: improve EstimateGas API 

### DIFF
--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -19,6 +19,7 @@ package abi
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -712,4 +713,35 @@ func TestABI_MethodById(t *testing.T) {
 		}
 	}
 
+}
+
+func TestUnpackRevert(t *testing.T) {
+	t.Parallel()
+
+	var cases = []struct {
+		input     string
+		expect    string
+		expectErr error
+	}{
+		{"", "", errors.New("invalid data for unpacking")},
+		{"08c379a1", "", errors.New("invalid data for unpacking")},
+		{"08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d72657665727420726561736f6e00000000000000000000000000000000000000", "revert reason", nil},
+	}
+	for index, c := range cases {
+		t.Run(fmt.Sprintf("case %d", index), func(t *testing.T) {
+			got, err := UnpackRevert(common.Hex2Bytes(c.input))
+			if c.expectErr != nil {
+				if err == nil {
+					t.Fatalf("Expected non-nil error")
+				}
+				if err.Error() != c.expectErr.Error() {
+					t.Fatalf("Expected error mismatch, want %v, got %v", c.expectErr, err)
+				}
+				return
+			}
+			if c.expect != got {
+				t.Fatalf("Output mismatch, want %v, got %v", c.expect, got)
+			}
+		})
+	}
 }

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -1,0 +1,154 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package backends
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain"
+	"github.com/XinFinOrg/XDPoSChain/accounts/abi"
+	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind"
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+func TestSimulatedBackend_EstimateGas(t *testing.T) {
+	/*
+		pragma solidity ^0.6.4;
+		contract GasEstimation {
+		    function PureRevert() public { revert(); }
+		    function Revert() public { revert("revert reason");}
+		    function OOG() public { for (uint i = 0; ; i++) {}}
+		    function Assert() public { assert(false);}
+		    function Valid() public {}
+		}*/
+	const contractAbi = "[{\"inputs\":[],\"name\":\"Assert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"OOG\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PureRevert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Revert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Valid\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+	const contractBin = "0x60806040523480156100115760006000fd5b50610017565b61016e806100266000396000f3fe60806040523480156100115760006000fd5b506004361061005c5760003560e01c806350f6fe3414610062578063aa8b1d301461006c578063b9b046f914610076578063d8b9839114610080578063e09fface1461008a5761005c565b60006000fd5b61006a610094565b005b6100746100ad565b005b61007e6100b5565b005b6100886100c2565b005b610092610135565b005b6000600090505b5b808060010191505061009b565b505b565b60006000fd5b565b600015156100bf57fe5b5b565b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600d8152602001807f72657665727420726561736f6e0000000000000000000000000000000000000081526020015060200191505060405180910390fd5b565b5b56fea2646970667358221220345bbcbb1a5ecf22b53a78eaebf95f8ee0eceff6d10d4b9643495084d2ec934a64736f6c63430006040033"
+
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	opts := bind.NewKeyedTransactor(key)
+
+	sim := NewXDCSimulatedBackend(core.GenesisAlloc{addr: {Balance: big.NewInt(params.Ether)}}, 10000000, &params.ChainConfig{
+		ConstantinopleBlock: big.NewInt(0),
+		XDPoS: &params.XDPoSConfig{
+			Epoch:            900,
+			SkipV1Validation: true,
+			V2: &params.V2{
+				SwitchBlock:   big.NewInt(900),
+				CurrentConfig: params.UnitTestV2Configs[0],
+			},
+		},
+	})
+
+	defer sim.Close()
+
+	parsed, _ := abi.JSON(strings.NewReader(contractAbi))
+	contractAddr, _, _, _ := bind.DeployContract(opts, parsed, common.FromHex(contractBin), sim)
+	sim.Commit()
+
+	var cases = []struct {
+		name        string
+		message     XDPoSChain.CallMsg
+		expect      uint64
+		expectError error
+	}{
+		{"plain transfer(valid)", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &addr,
+			Gas:      0,
+			GasPrice: big.NewInt(0),
+			Value:    big.NewInt(1),
+			Data:     nil,
+		}, params.TxGas, nil},
+
+		{"plain transfer(invalid)", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      0,
+			GasPrice: big.NewInt(0),
+			Value:    big.NewInt(1),
+			Data:     nil,
+		}, 0, errors.New("always failing transaction (execution reverted)")},
+
+		{"Revert", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      0,
+			GasPrice: big.NewInt(0),
+			Value:    nil,
+			Data:     common.Hex2Bytes("d8b98391"),
+		}, 0, errors.New("always failing transaction (execution reverted) (revert reason)")},
+
+		{"PureRevert", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      0,
+			GasPrice: big.NewInt(0),
+			Value:    nil,
+			Data:     common.Hex2Bytes("aa8b1d30"),
+		}, 0, errors.New("always failing transaction (execution reverted)")},
+
+		{"OOG", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      100000,
+			GasPrice: big.NewInt(0),
+			Value:    nil,
+			Data:     common.Hex2Bytes("50f6fe34"),
+		}, 0, errors.New("gas required exceeds allowance (100000)")},
+
+		{"Assert", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      100000,
+			GasPrice: big.NewInt(0),
+			Value:    nil,
+			Data:     common.Hex2Bytes("b9b046f9"),
+		}, 0, errors.New("always failing transaction (invalid opcode: INVALID)")},
+
+		{"Valid", XDPoSChain.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      100000,
+			GasPrice: big.NewInt(0),
+			Value:    nil,
+			Data:     common.Hex2Bytes("e09fface"),
+		}, 21483, nil},
+	}
+	for _, c := range cases {
+		got, err := sim.EstimateGas(context.Background(), c.message)
+		if c.expectError != nil {
+			if err == nil {
+				t.Fatalf("Expect error, got nil")
+			}
+			if c.expectError.Error() != err.Error() {
+				t.Fatalf("Expect error, want %v, got %v", c.expectError, err)
+			}
+			continue
+		}
+		if got != c.expect {
+			t.Fatalf("Gas estimation mismatch, want %d, got %d", c.expect, got)
+		}
+	}
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -82,8 +82,6 @@ var (
 	blockReorgDropMeter = metrics.NewRegisteredMeter("chain/reorg/drop", nil)
 
 	CheckpointCh = make(chan int)
-
-	ErrNoGenesis = errors.New("Genesis not found in chain")
 )
 
 const (

--- a/core/error.go
+++ b/core/error.go
@@ -29,6 +29,18 @@ var (
 	// ErrBlacklistedHash is returned if a block to import is on the blacklist.
 	ErrBlacklistedHash = errors.New("blacklisted hash")
 
+	// ErrNoGenesis is returned when there is no Genesis Block.
+	ErrNoGenesis = errors.New("genesis not found in chain")
+)
+
+// List of evm-call-message pre-checking errors. All state transtion messages will
+// be pre-checked before execution. If any invalidation detected, the corresponding
+// error should be returned which is defined here.
+//
+// - If the pre-checking happens in the miner, then the transaction won't be packed.
+// - If the pre-checking happens in the block processing procedure, then a "BAD BLOCk"
+// error should be emitted.
+var (
 	// ErrNonceTooLow is returned if the nonce of a transaction is lower than the
 	// one present in the local chain.
 	ErrNonceTooLow = errors.New("nonce too low")
@@ -44,6 +56,10 @@ var (
 	// ErrGasLimitReached is returned by the gas pool if the amount of gas required
 	// by a transaction is higher than what's left in the block.
 	ErrGasLimitReached = errors.New("gas limit reached")
+
+	// ErrInsufficientFundsForTransfer is returned if the transaction sender doesn't
+	// have enough funds for transfer(topmost call only).
+	ErrInsufficientFundsForTransfer = errors.New("insufficient funds for transfer")
 
 	// ErrMaxInitCodeSizeExceeded is returned if creation transaction provides the init code bigger
 	// than init code size limit.

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -117,11 +117,11 @@ func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, 
 	vmenv := vm.NewEVM(evmContext, txContext, statedb, nil, chain.Config(), vm.Config{})
 	gaspool := new(GasPool).AddGas(1000000)
 	owner := common.Address{}
-	rval, _, _, err, _ := NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
+	result, err, _ := NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
 	if err != nil {
 		return nil, err
 	}
-	return rval, err
+	return result.Return(), err
 }
 
 // make sure that balance of token is at slot 0

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
-	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/holiman/uint256"
 )
 

--- a/eth/tracers/testing/calltrace_test.go
+++ b/eth/tracers/testing/calltrace_test.go
@@ -120,7 +120,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
 			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-			if _, _, _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+			if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}
 			// Retrieve the trace result and compare against the etalon
@@ -231,7 +231,7 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		evm := vm.NewEVM(context, txContext, statedb, nil, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
 		snap := statedb.Snapshot()
 		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-		if _, _, _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+		if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
 			b.Fatalf("failed to execute transaction: %v", err)
 		}
 		if _, err = tracer.GetResult(); err != nil {

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -158,7 +158,7 @@ func TestZeroValueToNotExitCall(t *testing.T) {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
 	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-	if _, _, _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+	if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
 	// Retrieve the trace result and compare against the etalon
@@ -244,7 +244,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
 	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-	if _, _, _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+	if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
 	// Retrieve the trace result and compare against the etalon
@@ -346,7 +346,7 @@ func BenchmarkTransactionTrace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		snap := statedb.Snapshot()
 		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-		_, _, _, err, _ = st.TransitionDb(common.Address{})
+		_, err, _ = st.TransitionDb(common.Address{})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -142,8 +142,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
 				owner := common.Address{}
-				ret, _, _, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
-				res = append(res, ret...)
+				result, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+				res = append(res, result.Return()...)
 			}
 		} else {
 			header := lc.GetHeaderByHash(bhash)
@@ -160,9 +160,9 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			vmenv := vm.NewEVM(context, txContext, statedb, nil, config, vm.Config{NoBaseFee: true})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
 			owner := common.Address{}
-			ret, _, _, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+			result, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
 			if statedb.Error() == nil {
-				res = append(res, ret...)
+				res = append(res, result.Return()...)
 			}
 		}
 	}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -191,8 +191,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		vmenv := vm.NewEVM(context, txContext, st, nil, config, vm.Config{NoBaseFee: true})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		owner := common.Address{}
-		ret, _, _, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
-		res = append(res, ret...)
+		result, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+		res = append(res, result.Return()...)
 		if st.Error() != nil {
 			return res, st.Error()
 		}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -166,7 +166,7 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	gaspool.AddGas(block.GasLimit())
 
 	coinbase := &t.json.Env.Coinbase
-	if _, _, _, err, _ := core.ApplyMessage(evm, msg, gaspool, *coinbase); err != nil {
+	if _, err, _ := core.ApplyMessage(evm, msg, gaspool, *coinbase); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
 	if logs := rlpHash(statedb.Logs()); logs != common.Hash(post.Logs) {


### PR DESCRIPTION
# Proposed changes
this PR separate consensus errors and EVM Internal errors
### Test
test contract is following:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.19;

contract TestRevert {
    function revertLogic(address payable recipient)
        external
        payable
        returns (uint256)
    {
        recipient.transfer(msg.value);
        require(msg.value > 10, "Transfer amount must be greater than ten");

        return msg.value;
    }

    // Function to allow contract to send ETH to another account
    function sendXDC(address payable recipient, uint256 amount) external returns (uint256){
        // Transfer the specified amount to the recipient
        recipient.transfer(amount* 1 ether);

        return amount;
        
    }

    receive() external payable {
    }

    fallback() external payable {
    }
}


```
#### Gas Consumption Comparison
**eth_estimateGas**
The `curl` command I used:
- address with balance  : `0x873C36f9Fd02e0C57a393aFE80D14f244fE04378`
- address without balance: `0xFb51679CeF4CF53152B531e6E437C727aDfF533e`
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "eth_estimateGas",
  "params": [
    {
      "from": <wallet address>,  
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "value":"0xc8",
      "data": "0x8a73d3ab000000000000000000000000eb14f05e78bdb995a55aac7d2b2d26d2215f22fd"
    },
    "latest"
  ]}' 
```
and their response:

| Balance | PR are applied | Response                                      |
| ------- | -------------- | --------------------------------------------- |
| Yes     | Yes            | {"jsonrpc":"2.0","id":1002,"result":"0x8066"} |
| Yes     | No             | {"jsonrpc":"2.0","id":1002,"result":"0x8066"} |
| No      | Yes            | {"jsonrpc":"2.0","id":1002,"result":"0x8066"} |
| No      | No             | {"jsonrpc":"2.0","id":1002,"result":"0x8066"} |

---
**eth_call**
The `curl` command I used:
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "eth_call",
  "params": [
    {
      "from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",  
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "data": "0x1afd35fe000000000000000000000000885c1e1b9c24758b56b6a36c13a94efdb4e4e3b10000000000000000000000000000000000000000000000000000000000000001"
    },
    "latest"
  ]}'
  ```
and their response:

| PR are applied | Response                                                                                                      |
| -------------- | ------------------------------------------------------------------------------------------------------------- |
| Yes            | {"jsonrpc":"2.0","id":1002,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}<br> |
| No             | {"jsonrpc":"2.0","id":1002,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}<br> |


#### Other cases
##### Request（The balance is 100, and an internal transaction attempts to transfer 200 to the address`0x873C36f9Fd02e0C57a393aFE80D14f244fE04378`）
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "eth_call",
  "params": [
    {            
      "from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "data": "0x1afd35fe000000000000000000000000885c1e1b9c24758b56b6a36c13a94efdb4e4e3b100000000000000000000000000000000000000000000000000000000000000c8",
    },
  ]}' | jq
```
##### Response
```bash
{
    "jsonrpc": "2.0",
    "id": 1002,
    "error": {
        "code": -32000,
        "message": "execution reverted"
    }
}
```
##### Request（gas exceeds the gasLimit）
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "eth_call",
  "params": [
    {            
      "from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "gas": "0x10",
      "data": "0x1afd35fe000000000000000000000000885c1e1b9c24758b56b6a36c13a94efdb4e4e3b10000000000000000000000000000000000000000000000000000000000000008",
    },
  ]}' | jq
```
##### Response
```bash
{
    "jsonrpc": "2.0",
    "id": 1002,
    "error": {
        "code": -32000,
        "message": "err: intrinsic gas too low: have 16, want 22680 (supplied gas 16)"
    }
}
```
##### Request(revert caused by business logic)
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "eth_estimateGas",
    "params": [
        {
		"from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",
		"to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
		"value":"0x3",
		"data": "0x8a73d3ab000000000000000000000000eb14f05e78bdb995a55aac7d2b2d26d2215f22fd"
        }
    ]}' | jq
```

##### Response
```bash
{
    "jsonrpc": "2.0",
    "id": 1002,
    "error": {
        "code": -32000,
        "message": "always failing transaction (execution reverted) (Transfer amount must be greater than ten)"
    }
}
```
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement
- [x] N/A
## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A




## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement
- [x] N/A
## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A



## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement
- [x] N/A
## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A

