### PR TITLE
all: replace uses of ioutil with io and os

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts"
@@ -80,7 +79,7 @@ func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 // NewTransactorWithChainID is a utility method to easily create a transaction signer from
 // an encrypted json key stream and the associated passphrase.
 func NewTransactorWithChainID(keyin io.Reader, passphrase string, chainID *big.Int) (*TransactOpts, error) {
-	json, err := ioutil.ReadAll(keyin)
+	json, err := io.ReadAll(keyin)
 	if err != nil {
 		return nil, err
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -19,8 +19,8 @@ package rawdb
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -214,7 +214,7 @@ func TestDeriveLogFields(t *testing.T) {
 
 func BenchmarkDecodeRLPLogs(b *testing.B) {
 	// Encoded receipts from block 0x14ee094309fbe8f70b65f45ebcc08fb33f126942d97464aad5eb91cfd1e2d269
-	buf, err := ioutil.ReadFile("testdata/stored_receipts.bin")
+	buf, err := os.ReadFile("testdata/stored_receipts.bin")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"os"
 
@@ -250,7 +249,7 @@ func checkKeyFileEnd(r *bufio.Reader) error {
 // restrictive permissions. The key data is saved hex-encoded.
 func SaveECDSA(file string, key *ecdsa.PrivateKey) error {
 	k := hex.EncodeToString(FromECDSA(key))
-	return ioutil.WriteFile(file, []byte(k), 0600)
+	return os.WriteFile(file, []byte(k), 0600)
 }
 
 // GenerateKey generates a new private key.

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"reflect"
@@ -175,7 +174,7 @@ func TestLoadECDSA(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		f, err := ioutil.TempFile("", "loadecdsa_test.*.txt")
+		f, err := os.CreateTemp("", "loadecdsa_test.*.txt")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -196,7 +195,7 @@ func TestLoadECDSA(t *testing.T) {
 }
 
 func TestSaveECDSA(t *testing.T) {
-	f, err := ioutil.TempFile("", "saveecdsa_test.*.txt")
+	f, err := os.CreateTemp("", "saveecdsa_test.*.txt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/tracers/internal/tracers/assets.go
+++ b/eth/tracers/internal/tracers/assets.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -474,7 +473,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/eth/tracers/testing/calltrace_test.go
+++ b/eth/tracers/testing/calltrace_test.go
@@ -2,8 +2,8 @@ package testing
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -66,7 +66,7 @@ func TestCallTracer(t *testing.T) {
 }
 
 func testCallTracer(tracerName string, dirPath string, t *testing.T) {
-	files, err := ioutil.ReadDir(filepath.Join("..", "testdata", dirPath))
+	files, err := os.ReadDir(filepath.Join("..", "testdata", dirPath))
 	if err != nil {
 		t.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}
@@ -83,7 +83,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 				tx   = new(types.Transaction)
 			)
 			// Call tracer test found, read if from disk
-			if blob, err := ioutil.ReadFile(filepath.Join("..", "testdata", dirPath, file.Name())); err != nil {
+			if blob, err := os.ReadFile(filepath.Join("..", "testdata", dirPath, file.Name())); err != nil {
 				t.Fatalf("failed to read testcase: %v", err)
 			} else if err := json.Unmarshal(blob, test); err != nil {
 				t.Fatalf("failed to parse testcase: %v", err)
@@ -171,7 +171,7 @@ func camel(str string) string {
 	return strings.Join(pieces, "")
 }
 func BenchmarkTracers(b *testing.B) {
-	files, err := ioutil.ReadDir(filepath.Join("..", "testdata", "call_tracer"))
+	files, err := os.ReadDir(filepath.Join("..", "testdata", "call_tracer"))
 	if err != nil {
 		b.Fatalf("failed to retrieve tracer test suite: %v", err)
 	}
@@ -181,7 +181,7 @@ func BenchmarkTracers(b *testing.B) {
 		}
 		file := file // capture range variable
 		b.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(b *testing.B) {
-			blob, err := ioutil.ReadFile(filepath.Join("..", "testdata", "call_tracer", file.Name()))
+			blob, err := os.ReadFile(filepath.Join("..", "testdata", "call_tracer", file.Name()))
 			if err != nil {
 				b.Fatalf("failed to read testcase: %v", err)
 			}


### PR DESCRIPTION
# Proposed changes
The `ioutil` package has been deprecated as of Go 1.16, and its functionality has been merged into the `io` and `os` packages.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
