### PR TITLE
Fix getCandidateStatus API

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -427,11 +427,11 @@ func (b *EthApiBackend) GetVotersRewards(masternodeAddr common.Address) map[comm
 	// calculate for 2 epochs ago
 	currentCheckpointNumber, _, err := engine.GetCurrentEpochSwitchBlock(chain, block.Number())
 	if err != nil {
-		log.Error("[GetVotersRewards] Fail to get GetCurrentEpochSwitchBlock for current checkpoint block", "block", block)
+		log.Error("[GetVotersRewards] Fail to get GetCurrentEpochSwitchBlock for current checkpoint block", "block", block.Number(), "err", err)
 	}
 	lastCheckpointNumber, _, err := engine.GetCurrentEpochSwitchBlock(chain, big.NewInt(int64(currentCheckpointNumber-1)))
 	if err != nil {
-		log.Error("[GetVotersRewards] Fail to get GetCurrentEpochSwitchBlock for last checkpoint block", "block", block)
+		log.Error("[GetVotersRewards] Fail to get GetCurrentEpochSwitchBlock for last checkpoint block", "block", block.Number(), "err", err)
 	}
 
 	lastCheckpointBlock := chain.GetBlockByNumber(lastCheckpointNumber)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1174,19 +1174,25 @@ func (s *PublicBlockChainAPI) GetPreviousCheckpointFromEpoch(ctx context.Context
 	epoch := s.b.ChainConfig().XDPoS.Epoch
 
 	if epochNum == rpc.LatestEpochNumber {
-		blockNumer := s.b.CurrentBlock().Number().Uint64()
-		diff := blockNumer % epoch
-		// checkpoint number
-		checkpointNumber = blockNumer - diff
-		epochNum = rpc.EpochNumber(checkpointNumber / epoch)
-		if diff > 0 {
-			epochNum += 1
+		blockNumer := s.b.CurrentBlock().Number()
+		if engine, ok := s.b.GetEngine().(*XDPoS.XDPoS); ok {
+			var err error
+			var currentEpoch uint64
+			checkpointNumber, currentEpoch, err = engine.GetCurrentEpochSwitchBlock(s.chainReader, blockNumer)
+			if err != nil {
+				log.Error("[GetPreviousCheckpointFromEpoch] Fail to get GetCurrentEpochSwitchBlock for current checkpoint block", "block", blockNumer, "err", err)
+				return 0, epochNum
+			}
+
+			epochNum = rpc.EpochNumber(currentEpoch)
 		}
 	} else if epochNum < 2 {
 		checkpointNumber = 0
 	} else {
+		// TODO this checkpointNumber needs to be recalculated for v2 blocks
 		checkpointNumber = epoch * (uint64(epochNum) - 1)
 	}
+
 	return rpc.BlockNumber(checkpointNumber), epochNum
 }
 


### PR DESCRIPTION
# Proposed changes

Fix getCandidateStatus api, it's broken for consensus v2. The epoch number calculation has different way and it's not simple to just mod 900.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
