### PR TITLE
add flag rpc-gascap and set RPCGasCap to 50M

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -144,6 +144,7 @@ var (
 
 	rpcFlags = []cli.Flag{
 		utils.RPCEnabledFlag,
+		utils.RPCGlobalGasCapFlag,
 		utils.RPCListenAddrFlag,
 		utils.RPCPortFlag,
 		utils.RPCHttpWriteTimeoutFlag,

--- a/cmd/XDC/usage.go
+++ b/cmd/XDC/usage.go
@@ -144,6 +144,7 @@ var AppHelpFlagGroups = []flagGroup{
 		Name: "API AND CONSOLE",
 		Flags: []cli.Flag{
 			utils.RPCEnabledFlag,
+			utils.RPCGlobalGasCapFlag,
 			utils.RPCListenAddrFlag,
 			utils.RPCPortFlag,
 			utils.RPCHttpWriteTimeoutFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -374,7 +374,7 @@ var (
 		Usage: "Record information useful for VM and contract debugging",
 	}
 	RPCGlobalGasCapFlag = cli.Uint64Flag{
-		Name:  "rpc.gascap",
+		Name:  "rpc-gascap",
 		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)",
 		Value: ethconfig.Defaults.RPCGasCap,
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1245,6 +1245,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(RPCGlobalTxFeeCap.Name) {
 		cfg.RPCTxFeeCap = ctx.GlobalFloat64(RPCGlobalTxFeeCap.Name)
 	}
+	if ctx.GlobalIsSet(RPCGlobalGasCapFlag.Name) {
+		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCapFlag.Name)
+	}
 	if ctx.GlobalIsSet(ExtraDataFlag.Name) {
 		cfg.ExtraData = []byte(ctx.GlobalString(ExtraDataFlag.Name))
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -69,7 +69,7 @@ var Defaults = Config{
 	GasPrice:           big.NewInt(0.25 * params.Shannon),
 
 	TxPool:      core.DefaultTxPoolConfig,
-	RPCGasCap:   25000000,
+	RPCGasCap:   50000000,
 	GPO:         FullNodeGPO,
 	RPCTxFeeCap: 1, // 1 ether
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -77,7 +77,7 @@ type peer struct {
 
 	knownVote     mapset.Set // Set of BFT Vote known to be known by this peer
 	knownTimeout  mapset.Set // Set of BFT timeout known to be known by this peer
-	knownSyncInfo mapset.Set // Set of BFT Sync Info known to be known by this peer`
+	knownSyncInfo mapset.Set // Set of BFT Sync Info known to be known by this peer
 }
 
 func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) *peer {


### PR DESCRIPTION
# Proposed changes

This PR:

- increase default value of `RPCGasCap` from `25000000` to `50000000`
- add flag `rpc-gascap` to set `RPCGasCap` when startup node

Reference:

- #19401
- #23028

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [✅] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [✅] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [✅] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
