### PR TITLE
store reward when block number is a multiple of 900

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -372,13 +372,10 @@ func (x *XDPoS_v2) Prepare(chain consensus.ChainReader, header *types.Header) er
 // rewards given, and returns the final block.
 func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, parentState *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// set block reward
+	number := header.Number.Uint64()
+	rCheckpoint := chain.Config().XDPoS.RewardCheckpoint
 
-	isEpochSwitch, _, err := x.IsEpochSwitch(header)
-	if err != nil {
-		log.Error("[Finalize] IsEpochSwitch bug!", "err", err)
-		return nil, err
-	}
-	if x.HookReward != nil && isEpochSwitch {
+	if x.HookReward != nil && number%rCheckpoint == 0 {
 		rewards, err := x.HookReward(chain, state, parentState, header)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Proposed changes

This PR saves rewards when block number is multiple of 900 for v2.0.0.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
