### PR TITLE
fix nil issues reported by nilness and staticcheck

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -280,7 +280,7 @@ func (c *BoundContract) FilterLogs(opts *FilterOpts, name string, query ...[]int
 	if err != nil {
 		return nil, nil, err
 	}
-	sub, err := event.NewSubscription(func(quit <-chan struct{}) error {
+	sub := event.NewSubscription(func(quit <-chan struct{}) error {
 		for _, log := range buff {
 			select {
 			case logs <- log:
@@ -289,11 +289,8 @@ func (c *BoundContract) FilterLogs(opts *FilterOpts, name string, query ...[]int
 			}
 		}
 		return nil
-	}), nil
+	})
 
-	if err != nil {
-		return nil, nil, err
-	}
 	return logs, sub, nil
 }
 

--- a/cmd/gc/main.go
+++ b/cmd/gc/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/cmd/utils"
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/lru"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
@@ -20,7 +21,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/ethdb/leveldb"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/trie"
-	"github.com/XinFinOrg/XDPoSChain/common/lru"
 )
 
 var (
@@ -170,7 +170,7 @@ func getAllChilds(n StateNode, db *leveldb.Database) ([17]*StateNode, error) {
 				}
 				if err == nil {
 					childs[i] = &StateNode{node: childNode, path: append(n.path, byte(i))}
-				} else if err != nil {
+				} else {
 					_, ok := err.(*trie.MissingNodeError)
 					if !ok {
 						return childs, err
@@ -187,7 +187,7 @@ func getAllChilds(n StateNode, db *leveldb.Database) ([17]*StateNode, error) {
 		}
 		if err == nil {
 			childs[0] = &StateNode{node: childNode, path: append(n.path, node.Key...)}
-		} else if err != nil {
+		} else {
 			_, ok := err.(*trie.MissingNodeError)
 			if !ok {
 				return childs, err

--- a/cmd/puppeth/wizard_netstats.go
+++ b/cmd/puppeth/wizard_netstats.go
@@ -82,7 +82,6 @@ func (w *wizard) gatherStats(server string, pubkey []byte, client *sshClient) *s
 	logger.Info("Starting remote server health-check")
 
 	stat := &serverStat{
-		address:  client.address,
 		services: make(map[string]map[string]string),
 	}
 	if client == nil {
@@ -94,6 +93,8 @@ func (w *wizard) gatherStats(server string, pubkey []byte, client *sshClient) *s
 		}
 		client = conn
 	}
+	stat.address = client.address
+
 	// Client connected one way or another, run health-checks
 	logger.Debug("Checking for nginx availability")
 	if infos, err := checkNginx(client, w.network); err != nil {

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -476,7 +476,7 @@ func (x *XDPoS_v1) snapshot(chain consensus.ChainReader, number uint64, hash com
 		headers []*types.Header
 		snap    *SnapshotV1
 	)
-	for snap == nil {
+	for {
 		// If an in-memory SnapshotV1 was found, use that
 		if s, ok := x.recents.Get(hash); ok {
 			snap = s.(*SnapshotV1)

--- a/consensus/XDPoS/engines/engine_v2/forensics.go
+++ b/consensus/XDPoS/engines/engine_v2/forensics.go
@@ -210,7 +210,7 @@ func (f *Forensics) findAncestorQCs(chain consensus.ChainReader, currentQc types
 		parentHash := quorumCertificate.ProposedBlockInfo.Hash
 		parentHeader := chain.GetHeaderByHash(parentHash)
 		if parentHeader == nil {
-			log.Error("[findAncestorQCs] Forensics findAncestorQCs unable to find its parent block header", "BlockNum", parentHeader.Number.Int64(), "ParentHash", parentHash.Hex())
+			log.Error("[findAncestorQCs] Forensics findAncestorQCs unable to find its parent block header", "ParentHash", parentHash.Hex())
 			return nil, errors.New("unable to find parent block header in forensics")
 		}
 		var decodedExtraField types.ExtraFields_v2

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -390,7 +390,7 @@ func (c *Clique) snapshot(chain consensus.ChainReader, number uint64, hash commo
 		headers []*types.Header
 		snap    *Snapshot
 	)
-	for snap == nil {
+	for {
 		// If an in-memory snapshot was found, use that
 		if s, ok := c.recents.Get(hash); ok {
 			snap = s.(*Snapshot)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1659,7 +1659,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 					}
 				}
 				//check
-				if tradingState != nil && tradingService != nil {
+				if tradingState != nil {
 					gotRoot := tradingState.IntermediateRoot()
 					expectRoot, _ := tradingService.GetTradingStateRoot(block, author)
 					parentRoot, _ := tradingService.GetTradingStateRoot(parent, parentAuthor)
@@ -1938,7 +1938,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 					}
 				}
 			}
-			if tradingState != nil && tradingService != nil {
+			if tradingState != nil {
 				gotRoot := tradingState.IntermediateRoot()
 				expectRoot, _ := tradingService.GetTradingStateRoot(block, author)
 				parentRoot, _ := tradingService.GetTradingStateRoot(parent, parentAuthor)

--- a/core/order_pool_test.go
+++ b/core/order_pool_test.go
@@ -60,10 +60,6 @@ func getNonce(t *testing.T, userAddress common.Address) (uint64, error) {
 		return 0, err
 	}
 	var result interface{}
-	if err != nil {
-
-		return 0, err
-	}
 	err = rpcClient.Call(&result, "XDCx_getOrderCount", userAddress)
 	if err != nil {
 		return 0, err

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -285,9 +285,7 @@ func (pm *ProtocolManager) removePeer(id string) {
 		log.Debug("Peer removal failed", "peer", id, "err", err)
 	}
 	// Hard disconnect at the networking layer
-	if peer != nil {
-		peer.Peer.Disconnect(p2p.DiscUselessPeer)
-	}
+	peer.Peer.Disconnect(p2p.DiscUselessPeer)
 }
 
 func (pm *ProtocolManager) Start(maxPeers int) {

--- a/les/backend.go
+++ b/les/backend.go
@@ -147,7 +147,7 @@ func lesTopic(genesisHash common.Hash, protocolVersion uint) discv5.Topic {
 	case lpv2:
 		name = "LES2"
 	default:
-		panic(nil)
+		panic("lesTopic")
 	}
 	return discv5.Topic(name + "@" + common.Bytes2Hex(genesisHash.Bytes()[0:8]))
 }

--- a/les/odr_requests.go
+++ b/les/odr_requests.go
@@ -196,7 +196,7 @@ func (r *TrieRequest) GetCost(peer *peer) uint64 {
 	case lpv2:
 		return peer.GetRequestCost(GetProofsV2Msg, 1)
 	default:
-		panic(nil)
+		panic("TrieRequest GetCost")
 	}
 }
 
@@ -356,7 +356,7 @@ func (r *ChtRequest) GetCost(peer *peer) uint64 {
 	case lpv2:
 		return peer.GetRequestCost(GetHelperTrieProofsMsg, 1)
 	default:
-		panic(nil)
+		panic("ChtRequest GetCost")
 	}
 }
 

--- a/les/peer.go
+++ b/les/peer.go
@@ -279,7 +279,7 @@ func (p *peer) RequestProofs(reqID, cost uint64, reqs []ProofReq) error {
 	case lpv2:
 		return sendRequest(p.rw, GetProofsV2Msg, reqID, cost, reqs)
 	default:
-		panic(nil)
+		panic("peer RequestProofs")
 	}
 }
 
@@ -301,7 +301,7 @@ func (p *peer) RequestHelperTrieProofs(reqID, cost uint64, reqs []HelperTrieReq)
 	case lpv2:
 		return sendRequest(p.rw, GetHelperTrieProofsMsg, reqID, cost, reqs)
 	default:
-		panic(nil)
+		panic("peer RequestHelperTrieProofs")
 	}
 }
 
@@ -320,7 +320,7 @@ func (p *peer) SendTxs(reqID, cost uint64, txs types.Transactions) error {
 	case lpv2:
 		return sendRequest(p.rw, SendTxV2Msg, reqID, cost, txs)
 	default:
-		panic(nil)
+		panic("peer SendTxs")
 	}
 }
 

--- a/les/randselect.go
+++ b/les/randselect.go
@@ -109,7 +109,7 @@ func (n *wrsNode) insert(item wrsItem, weight int64) int {
 	for n.items[branch] != nil && (n.level == 0 || n.items[branch].(*wrsNode).itemCnt == n.items[branch].(*wrsNode).maxItems) {
 		branch++
 		if branch == wrsBranches {
-			panic(nil)
+			panic("wrsNode insert: branch == wrsBranches")
 		}
 	}
 	n.itemCnt++
@@ -169,5 +169,5 @@ func (n *wrsNode) choose(val int64) (wrsItem, int64) {
 			val -= w
 		}
 	}
-	panic(nil)
+	panic("wrsNode choose")
 }

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -306,7 +306,7 @@ func (r *sentReq) tryRequest() {
 	s, ok := r.sentTo[p]
 	r.lock.RUnlock()
 	if !ok {
-		panic(nil)
+		panic("sentReq tryRequest: !ok")
 	}
 
 	defer func() {

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -22,11 +22,10 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
-
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/bitutil"
 	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -165,7 +164,7 @@ func (c *ChtIndexerBackend) Process(header *types.Header) {
 
 	td := core.GetTd(c.diskdb, hash, num)
 	if td == nil {
-		panic(nil)
+		panic("ChtIndexerBackend Process: td == nil")
 	}
 	var encNumber [8]byte
 	binary.BigEndian.PutUint64(encNumber[:], num)

--- a/mobile/ethereum.go
+++ b/mobile/ethereum.go
@@ -64,11 +64,13 @@ func (msg *CallMsg) SetGas(gas int64)          { msg.msg.Gas = uint64(gas) }
 func (msg *CallMsg) SetGasPrice(price *BigInt) { msg.msg.GasPrice = price.bigint }
 func (msg *CallMsg) SetValue(value *BigInt)    { msg.msg.Value = value.bigint }
 func (msg *CallMsg) SetData(data []byte)       { msg.msg.Data = common.CopyBytes(data) }
+
 func (msg *CallMsg) SetTo(address *Address) {
 	if address == nil {
 		msg.msg.To = nil
+	} else {
+		msg.msg.To = &address.address
 	}
-	msg.msg.To = &address.address
 }
 
 // SyncProgress gives progress indications when the node is synchronising with

--- a/p2p/discv5/ticket.go
+++ b/p2p/discv5/ticket.go
@@ -441,7 +441,7 @@ func (s *ticketStore) removeTicketRef(ref ticketRef) {
 		}
 	}
 	if idx == -1 {
-		panic(nil)
+		panic("ticketStore removeTicketRef: idx == -1")
 	}
 	list = append(list[:idx], list[idx+1:]...)
 	if len(list) != 0 {
@@ -802,7 +802,7 @@ func (r *topicRadius) chooseLookupBucket(a, b int) int {
 			rnd--
 		}
 	}
-	panic(nil) // should never happen
+	panic("topicRadius chooseLookupBucket") // should never happen
 }
 
 func (r *topicRadius) needMoreLookups(a, b int, maxValue float64) bool {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -243,7 +243,7 @@ func (t *Trie) tryGetAllLeftKeyAndValue(origNode Node, prefix []byte, limit []by
 			if err != nil {
 				return nil, nil, n, false, err
 			}
-			if err == nil && didResolve {
+			if didResolve {
 				n = n.copy()
 				n.Children[i] = newnode
 			}

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -501,9 +501,6 @@ func (whisper *Whisper) AddSymKeyFromPassword(password string) (string, error) {
 	// kdf should run no less than 0.1 seconds on an average computer,
 	// because it's an once in a session experience
 	derived := pbkdf2.Key([]byte(password), nil, 65356, aesKeyLength, sha256.New)
-	if err != nil {
-		return "", err
-	}
 
 	whisper.keyMu.Lock()
 	defer whisper.keyMu.Unlock()


### PR DESCRIPTION
# Proposed changes

This PR fixes the nil issues reported by from nilness and staticcheck.

- issues from staticcheck

```text
cmd/puppeth/wizard_netstats.go:85:20: possible nil pointer dereference (SA5011)
        cmd/puppeth/wizard_netstats.go:88:5: this check suggests that the pointer can be nil
mobile/ethereum.go:71:24: possible nil pointer dereference (SA5011)
        mobile/ethereum.go:68:5: this check suggests that the pointer can be nil
```

- issues from nilness

```text
consensus/XDPoS/engines/engine_v2/forensics.go:212:125: nil dereference in field selection

light/postprocess.go:167:8: panic with nil value
les/backend.go:150:8: panic with nil value
les/odr_requests.go:199:8: panic with nil value
les/odr_requests.go:359:8: panic with nil value
les/peer.go:282:8: panic with nil value
les/peer.go:304:8: panic with nil value
les/peer.go:323:8: panic with nil value
les/randselect.go:112:9: panic with nil value
les/randselect.go:172:7: panic with nil value
les/retrieve.go:309:8: panic with nil value
p2p/discv5/ticket.go:444:8: panic with nil value
p2p/discv5/ticket.go:805:7: panic with nil value

accounts/abi/bind/base.go:294:9: impossible condition: nil != nil
whisper/whisperv6/whisper.go:504:9: impossible condition: nil != nil

consensus/clique/clique.go:393:11: tautological condition: nil == nil
trie/trie.go:244:11: tautological condition: nil == nil

consensus/XDPoS/engines/engine_v1/engine.go:479:11: tautological condition: nil == nil
cmd/gc/main.go:190:17: tautological condition: non-nil != nil
cmd/gc/main.go:173:19: tautological condition: non-nil != nil
core/blockchain.go:1665:46: tautological condition: non-nil != nil
core/blockchain.go:1944:45: tautological condition: non-nil != nil
core/order_pool_test.go:64:9: impossible condition: nil != nil
eth/handler.go:286:10: tautological condition: non-nil != nil
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
