### PR TITLE
 all: fix staticcheck warning ST1005

### DIFF
--- a/XDCx/XDCx.go
+++ b/XDCx/XDCx.go
@@ -275,11 +275,11 @@ func (XDCx *XDCX) GetAveragePriceLastEpoch(chain consensus.ChainContext, statedb
 		if inversePrice != nil && inversePrice.Sign() > 0 {
 			quoteTokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, quoteToken)
 			if err != nil || quoteTokenDecimal.Sign() == 0 {
-				return nil, fmt.Errorf("fail to get tokenDecimal. Token: %v . Err: %v", quoteToken.String(), err)
+				return nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", quoteToken.String(), err)
 			}
 			baseTokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, baseToken)
 			if err != nil || baseTokenDecimal.Sign() == 0 {
-				return nil, fmt.Errorf("fail to get tokenDecimal. Token: %v . Err: %v", baseToken.String(), err)
+				return nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", baseToken.String(), err)
 			}
 			price = new(big.Int).Mul(baseTokenDecimal, quoteTokenDecimal)
 			price = new(big.Int).Div(price, inversePrice)
@@ -302,7 +302,7 @@ func (XDCx *XDCX) ConvertXDCToToken(chain consensus.ChainContext, statedb *state
 
 	tokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, token)
 	if err != nil || tokenDecimal.Sign() == 0 {
-		return common.Big0, common.Big0, fmt.Errorf("fail to get tokenDecimal. Token: %v . Err: %v", token.String(), err)
+		return common.Big0, common.Big0, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", token.String(), err)
 	}
 	tokenQuantity := new(big.Int).Mul(quantity, tokenDecimal)
 	tokenQuantity = new(big.Int).Div(tokenQuantity, tokenPriceInXDC)
@@ -568,7 +568,7 @@ func (XDCx *XDCX) GetTradingState(block *types.Block, author common.Address) (*t
 		return nil, err
 	}
 	if XDCx.StateCache == nil {
-		return nil, errors.New("Not initialized XDCx")
+		return nil, errors.New("not initialized XDCx")
 	}
 	return tradingstate.New(root, XDCx.StateCache)
 }

--- a/XDCx/order_processor.go
+++ b/XDCx/order_processor.go
@@ -243,7 +243,7 @@ func (XDCx *XDCX) processOrderList(coinbase common.Address, chain consensus.Chai
 				inversePrice := tradingStateDB.GetLastPrice(tradingstate.GetTradingOrderBookHash(common.XDCNativeAddressBinary, oldestOrder.QuoteToken))
 				quoteTokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, oldestOrder.QuoteToken)
 				if err != nil || quoteTokenDecimal.Sign() == 0 {
-					return nil, nil, nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", oldestOrder.QuoteToken.String(), err)
+					return nil, nil, nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", oldestOrder.QuoteToken.String(), err)
 				}
 				log.Debug("TryGet inversePrice XDC/QuoteToken", "inversePrice", inversePrice)
 				if inversePrice != nil && inversePrice.Sign() > 0 {
@@ -368,11 +368,11 @@ func (XDCx *XDCX) processOrderList(coinbase common.Address, chain consensus.Chai
 func (XDCx *XDCX) getTradeQuantity(quotePrice *big.Int, coinbase common.Address, chain consensus.ChainContext, statedb *state.StateDB, takerOrder *tradingstate.OrderItem, makerOrder *tradingstate.OrderItem, quantityToTrade *big.Int) (*big.Int, bool, *tradingstate.SettleBalance, error) {
 	baseTokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, makerOrder.BaseToken)
 	if err != nil || baseTokenDecimal.Sign() == 0 {
-		return tradingstate.Zero, false, nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", makerOrder.BaseToken.String(), err)
+		return tradingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", makerOrder.BaseToken.String(), err)
 	}
 	quoteTokenDecimal, err := XDCx.GetTokenDecimal(chain, statedb, makerOrder.QuoteToken)
 	if err != nil || quoteTokenDecimal.Sign() == 0 {
-		return tradingstate.Zero, false, nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", makerOrder.QuoteToken.String(), err)
+		return tradingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", makerOrder.QuoteToken.String(), err)
 	}
 	if makerOrder.QuoteToken == common.XDCNativeAddressBinary {
 		quotePrice = quoteTokenDecimal
@@ -526,7 +526,7 @@ func DoSettleBalance(coinbase common.Address, takerOrder, makerOrder *tradingsta
 	matchingFee = new(big.Int).Add(matchingFee, common.RelayerFee)
 
 	if common.EmptyHash(takerExOwner.Hash()) || common.EmptyHash(makerExOwner.Hash()) {
-		return fmt.Errorf("Echange owner empty , Taker: %v , maker : %v ", takerExOwner, makerExOwner)
+		return fmt.Errorf("empty echange owner: taker: %v , maker : %v", takerExOwner, makerExOwner)
 	}
 	mapBalances := map[common.Address]map[common.Address]*big.Int{}
 	//Checking balance

--- a/XDCx/tradingstate/dump.go
+++ b/XDCx/tradingstate/dump.go
@@ -50,7 +50,7 @@ type DumpOrderBookInfo struct {
 func (self *TradingStateDB) DumpAskTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
 	exhangeObject := self.getStateExchangeObject(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]DumpOrderList{}
 	it := trie.NewIterator(exhangeObject.getAsksTrie(self.db).NodeIterator(nil))
@@ -65,7 +65,7 @@ func (self *TradingStateDB) DumpAskTrie(orderBook common.Hash) (map[*big.Int]Dum
 		} else {
 			var data orderList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,price :%v ", orderBook.Hex(), price)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , price :%v", orderBook.Hex(), price)
 			}
 			stateOrderList := newStateOrderList(self, Ask, orderBook, priceHash, data, nil)
 			mapResult[price] = stateOrderList.DumpOrderList(self.db)
@@ -93,7 +93,7 @@ func (self *TradingStateDB) DumpAskTrie(orderBook common.Hash) (map[*big.Int]Dum
 func (self *TradingStateDB) DumpBidTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
 	exhangeObject := self.getStateExchangeObject(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]DumpOrderList{}
 	it := trie.NewIterator(exhangeObject.getBidsTrie(self.db).NodeIterator(nil))
@@ -108,7 +108,7 @@ func (self *TradingStateDB) DumpBidTrie(orderBook common.Hash) (map[*big.Int]Dum
 		} else {
 			var data orderList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,price :%v ", orderBook.Hex(), price)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , price :%v", orderBook.Hex(), price)
 			}
 			stateOrderList := newStateOrderList(self, Bid, orderBook, priceHash, data, nil)
 			mapResult[price] = stateOrderList.DumpOrderList(self.db)
@@ -136,7 +136,7 @@ func (self *TradingStateDB) DumpBidTrie(orderBook common.Hash) (map[*big.Int]Dum
 func (self *TradingStateDB) GetBids(orderBook common.Hash) (map[*big.Int]*big.Int, error) {
 	exhangeObject := self.getStateExchangeObject(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]*big.Int{}
 	it := trie.NewIterator(exhangeObject.getBidsTrie(self.db).NodeIterator(nil))
@@ -151,7 +151,7 @@ func (self *TradingStateDB) GetBids(orderBook common.Hash) (map[*big.Int]*big.In
 		} else {
 			var data orderList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,price :%v ", orderBook.Hex(), price)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , price :%v", orderBook.Hex(), price)
 			}
 			stateOrderList := newStateOrderList(self, Bid, orderBook, priceHash, data, nil)
 			mapResult[price] = stateOrderList.data.Volume
@@ -179,7 +179,7 @@ func (self *TradingStateDB) GetBids(orderBook common.Hash) (map[*big.Int]*big.In
 func (self *TradingStateDB) GetAsks(orderBook common.Hash) (map[*big.Int]*big.Int, error) {
 	exhangeObject := self.getStateExchangeObject(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]*big.Int{}
 	it := trie.NewIterator(exhangeObject.getAsksTrie(self.db).NodeIterator(nil))
@@ -194,7 +194,7 @@ func (self *TradingStateDB) GetAsks(orderBook common.Hash) (map[*big.Int]*big.In
 		} else {
 			var data orderList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,price :%v ", orderBook.Hex(), price)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , price : %v", orderBook.Hex(), price)
 			}
 			stateOrderList := newStateOrderList(self, Ask, orderBook, priceHash, data, nil)
 			mapResult[price] = stateOrderList.data.Volume
@@ -255,7 +255,7 @@ func (self *stateOrderList) DumpOrderList(db Database) DumpOrderList {
 func (self *TradingStateDB) DumpOrderBookInfo(orderBook common.Hash) (*DumpOrderBookInfo, error) {
 	exhangeObject := self.getStateExchangeObject(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	result := &DumpOrderBookInfo{}
 	result.LastPrice = exhangeObject.data.LastPrice
@@ -318,7 +318,7 @@ func (self *liquidationPriceState) DumpLendingBook(db Database) (DumpLendingBook
 		} else {
 			var data orderList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return result, fmt.Errorf("Failed to decode state lending book orderbook : %s ,liquidation price :%s , lendingBook : %s ,err : %v", self.orderBook, self.liquidationPrice, lendingBook, err)
+				return result, fmt.Errorf("failed to decode state lending book orderbook: %s , liquidation price : %s , lendingBook : %s , err : %v", self.orderBook, self.liquidationPrice, lendingBook, err)
 			}
 			stateLendingBook := newStateLendingBook(self.orderBook, self.liquidationPrice, lendingBook, data, nil)
 			result.LendingBooks[lendingBook] = stateLendingBook.DumpOrderList(db)
@@ -335,7 +335,7 @@ func (self *liquidationPriceState) DumpLendingBook(db Database) (DumpLendingBook
 func (self *TradingStateDB) DumpLiquidationPriceTrie(orderBook common.Hash) (map[*big.Int]DumpLendingBook, error) {
 	exhangeObject := self.getStateExchangeObject(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]DumpLendingBook{}
 	it := trie.NewIterator(exhangeObject.getLiquidationPriceTrie(self.db).NodeIterator(nil))
@@ -350,7 +350,7 @@ func (self *TradingStateDB) DumpLiquidationPriceTrie(orderBook common.Hash) (map
 		} else {
 			var data orderList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,price :%v ", orderBook.Hex(), price)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , price : %v", orderBook.Hex(), price)
 			}
 			liquidationPriceState := newLiquidationPriceState(self, orderBook, priceHash, data, nil)
 			dumpLendingBook, err := liquidationPriceState.DumpLendingBook(self.db)

--- a/XDCx/tradingstate/relayer_state.go
+++ b/XDCx/tradingstate/relayer_state.go
@@ -106,7 +106,7 @@ func GetAllTradingPairs(statedb *state.StateDB) (map[common.Hash]bool, error) {
 		toTokenSlot := new(big.Int).Add(locBig, RelayerStructMappingSlot["_toTokens"])
 		toTokenLength := statedb.GetState(common.HexToAddress(common.RelayerRegistrationSMC), common.BigToHash(toTokenSlot)).Big().Uint64()
 		if toTokenLength != fromTokenLength {
-			return map[common.Hash]bool{}, fmt.Errorf("Invalid length from token & to toke : from :%d , to :%d ", fromTokenLength, toTokenLength)
+			return map[common.Hash]bool{}, fmt.Errorf("invalid length from token & to token: from :%d , to :%d ", fromTokenLength, toTokenLength)
 		}
 		fromTokens := []common.Address{}
 		fromTokenSlotHash := common.BytesToHash(fromTokenSlot.Bytes())
@@ -279,7 +279,7 @@ func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Addr
 		newBalance := new(big.Int).Add(balance, value)
 		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
 		if common.BigToHash(newBalance).Big().Cmp(newBalance) != 0 {
-			return nil, fmt.Errorf("Overflow when try add token balance , max is 2^256 , balance : %v , value:%v ", balance, value)
+			return nil, fmt.Errorf("overflow when try add token balance , max is 2^256 , balance : %v , value : %v", balance, value)
 		} else {
 			return newBalance, nil
 		}

--- a/XDCxlending/XDCxlending.go
+++ b/XDCxlending/XDCxlending.go
@@ -665,7 +665,7 @@ func (l *Lending) GetLendingState(block *types.Block, author common.Address) (*l
 		return nil, err
 	}
 	if l.StateCache == nil {
-		return nil, errors.New("Not initialized XDCx")
+		return nil, errors.New("not initialized XDCx")
 	}
 	state, err := lendingstate.New(root, l.StateCache)
 	if err != nil {

--- a/XDCxlending/lendingstate/dump.go
+++ b/XDCxlending/lendingstate/dump.go
@@ -18,11 +18,11 @@ package lendingstate
 
 import (
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"math/big"
 	"sort"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
@@ -42,7 +42,7 @@ type DumpOrderBookInfo struct {
 func (self *LendingStateDB) DumpInvestingTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]DumpOrderList{}
 	it := trie.NewIterator(exhangeObject.getInvestingTrie(self.db).NodeIterator(nil))
@@ -57,7 +57,7 @@ func (self *LendingStateDB) DumpInvestingTrie(orderBook common.Hash) (map[*big.I
 		} else {
 			var data itemList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , interest : %v", orderBook.Hex(), interest)
 			}
 			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
 			mapResult[interest] = stateOrderList.DumpItemList(self.db)
@@ -85,7 +85,7 @@ func (self *LendingStateDB) DumpInvestingTrie(orderBook common.Hash) (map[*big.I
 func (self *LendingStateDB) DumpBorrowingTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]DumpOrderList{}
 	it := trie.NewIterator(exhangeObject.getBorrowingTrie(self.db).NodeIterator(nil))
@@ -100,7 +100,7 @@ func (self *LendingStateDB) DumpBorrowingTrie(orderBook common.Hash) (map[*big.I
 		} else {
 			var data itemList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , interest : %v", orderBook.Hex(), interest)
 			}
 			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
 			mapResult[interest] = stateOrderList.DumpItemList(self.db)
@@ -128,7 +128,7 @@ func (self *LendingStateDB) DumpBorrowingTrie(orderBook common.Hash) (map[*big.I
 func (self *LendingStateDB) GetInvestings(orderBook common.Hash) (map[*big.Int]*big.Int, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]*big.Int{}
 	it := trie.NewIterator(exhangeObject.getInvestingTrie(self.db).NodeIterator(nil))
@@ -143,7 +143,7 @@ func (self *LendingStateDB) GetInvestings(orderBook common.Hash) (map[*big.Int]*
 		} else {
 			var data itemList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , interest : %v", orderBook.Hex(), interest)
 			}
 			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
 			mapResult[interest] = stateOrderList.data.Volume
@@ -171,7 +171,7 @@ func (self *LendingStateDB) GetInvestings(orderBook common.Hash) (map[*big.Int]*
 func (self *LendingStateDB) GetBorrowings(orderBook common.Hash) (map[*big.Int]*big.Int, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]*big.Int{}
 	it := trie.NewIterator(exhangeObject.getBorrowingTrie(self.db).NodeIterator(nil))
@@ -186,7 +186,7 @@ func (self *LendingStateDB) GetBorrowings(orderBook common.Hash) (map[*big.Int]*
 		} else {
 			var data itemList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,interest :%v ", orderBook.Hex(), interest)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , interest : %v", orderBook.Hex(), interest)
 			}
 			stateOrderList := newItemListState(orderBook, interestHash, data, nil)
 			mapResult[interest] = stateOrderList.data.Volume
@@ -248,7 +248,7 @@ func (self *itemListState) DumpItemList(db Database) DumpOrderList {
 func (self *LendingStateDB) DumpOrderBookInfo(orderBook common.Hash) (*DumpOrderBookInfo, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	result := &DumpOrderBookInfo{}
 	result.Nonce = exhangeObject.data.Nonce
@@ -296,7 +296,7 @@ func (self *liquidationTimeState) DumpItemList(db Database) DumpOrderList {
 func (self *LendingStateDB) DumpLiquidationTimeTrie(orderBook common.Hash) (map[*big.Int]DumpOrderList, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]DumpOrderList{}
 	it := trie.NewIterator(exhangeObject.getLiquidationTimeTrie(self.db).NodeIterator(nil))
@@ -311,7 +311,7 @@ func (self *LendingStateDB) DumpLiquidationTimeTrie(orderBook common.Hash) (map[
 		} else {
 			var data itemList
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,unixTime :%v ", orderBook.Hex(), unixTime)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , unixTime : %v", orderBook.Hex(), unixTime)
 			}
 			stateOrderList := newLiquidationTimeState(orderBook, unixTimeHash, data, nil)
 			mapResult[unixTime] = stateOrderList.DumpItemList(self.db)
@@ -339,7 +339,7 @@ func (self *LendingStateDB) DumpLiquidationTimeTrie(orderBook common.Hash) (map[
 func (self *LendingStateDB) DumpLendingOrderTrie(orderBook common.Hash) (map[*big.Int]LendingItem, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]LendingItem{}
 	it := trie.NewIterator(exhangeObject.getLendingItemTrie(self.db).NodeIterator(nil))
@@ -354,7 +354,7 @@ func (self *LendingStateDB) DumpLendingOrderTrie(orderBook common.Hash) (map[*bi
 		} else {
 			var data LendingItem
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,orderId :%v ", orderBook.Hex(), orderId)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , orderId : %v", orderBook.Hex(), orderId)
 			}
 			mapResult[orderId] = data
 		}
@@ -379,7 +379,7 @@ func (self *LendingStateDB) DumpLendingOrderTrie(orderBook common.Hash) (map[*bi
 func (self *LendingStateDB) DumpLendingTradeTrie(orderBook common.Hash) (map[*big.Int]LendingTrade, error) {
 	exhangeObject := self.getLendingExchange(orderBook)
 	if exhangeObject == nil {
-		return nil, fmt.Errorf("Order book not found orderBook : %v ", orderBook.Hex())
+		return nil, fmt.Errorf("not found orderBook: %v", orderBook.Hex())
 	}
 	mapResult := map[*big.Int]LendingTrade{}
 	it := trie.NewIterator(exhangeObject.getLendingTradeTrie(self.db).NodeIterator(nil))
@@ -394,7 +394,7 @@ func (self *LendingStateDB) DumpLendingTradeTrie(orderBook common.Hash) (map[*bi
 		} else {
 			var data LendingTrade
 			if err := rlp.DecodeBytes(it.Value, &data); err != nil {
-				return nil, fmt.Errorf("Fail when decode order iist orderBook : %v ,tradeId :%v ", orderBook.Hex(), tradeId)
+				return nil, fmt.Errorf("fail when decode order iist orderBook: %v , tradeId : %v", orderBook.Hex(), tradeId)
 			}
 			mapResult[tradeId] = data
 		}

--- a/XDCxlending/lendingstate/relayer.go
+++ b/XDCxlending/lendingstate/relayer.go
@@ -235,7 +235,7 @@ func CheckAddTokenBalance(addr common.Address, value *big.Int, token common.Addr
 		newBalance := new(big.Int).Add(balance, value)
 		log.Debug("CheckAddTokenBalance settle balance: ADD TOKEN BALANCE ", "token", token.String(), "address", addr.String(), "balance", balance, "value", value, "newBalance", newBalance)
 		if common.BigToHash(newBalance).Big().Cmp(newBalance) != 0 {
-			return nil, fmt.Errorf("Overflow when try add token balance , max is 2^256 , balance : %v , value:%v ", balance, value)
+			return nil, fmt.Errorf("overflow when try add token balance , max is 2^256 , balance : %v , value : %v", balance, value)
 		} else {
 			return newBalance, nil
 		}

--- a/XDCxlending/lendingstate/statedb.go
+++ b/XDCxlending/lendingstate/statedb.go
@@ -241,7 +241,7 @@ func (self *LendingStateDB) SubAmountLendingItem(orderBook common.Hash, orderId 
 	priceHash := common.BigToHash(price)
 	lendingExchange := self.GetOrNewLendingExchangeObject(orderBook)
 	if lendingExchange == nil {
-		return fmt.Errorf("Order book not found : %s ", orderBook.Hex())
+		return fmt.Errorf("not found order book: %s", orderBook.Hex())
 	}
 	var orderList *itemListState
 	switch side {
@@ -250,18 +250,18 @@ func (self *LendingStateDB) SubAmountLendingItem(orderBook common.Hash, orderId 
 	case Borrowing:
 		orderList = lendingExchange.getBorrowingOrderList(self.db, priceHash)
 	default:
-		return fmt.Errorf("Order type not found : %s ", side)
+		return fmt.Errorf("not found order type: %s", side)
 	}
 	if orderList == nil || orderList.empty() {
-		return fmt.Errorf("Order list empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderId.Hex(), priceHash.Hex())
+		return fmt.Errorf("empty orderList: order book : %s , order id : %s , key : %s", orderBook, orderId.Hex(), priceHash.Hex())
 	}
 	lendingItem := lendingExchange.getLendingItem(self.db, orderId)
 	if lendingItem == nil || lendingItem.empty() {
-		return fmt.Errorf("Order item empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderId.Hex(), priceHash.Hex())
+		return fmt.Errorf("empty order item: order book : %s , order id : %s , key : %s", orderBook, orderId.Hex(), priceHash.Hex())
 	}
 	currentAmount := new(big.Int).SetBytes(orderList.GetOrderAmount(self.db, orderId).Bytes()[:])
 	if currentAmount.Cmp(amount) < 0 {
-		return fmt.Errorf("Order amount not enough : %s , have : %d , want : %d ", orderId.Hex(), currentAmount, amount)
+		return fmt.Errorf("not enough order amount %s: have : %d , want : %d", orderId.Hex(), currentAmount, amount)
 	}
 	self.journal = append(self.journal, subAmountOrder{
 		orderBook: orderBook,
@@ -295,7 +295,7 @@ func (self *LendingStateDB) CancelLendingOrder(orderBook common.Hash, order *Len
 	orderIdHash := common.BigToHash(new(big.Int).SetUint64(order.LendingId))
 	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
 	if stateObject == nil {
-		return fmt.Errorf("Order book not found : %s ", orderBook.Hex())
+		return fmt.Errorf("not found order book: %s", orderBook.Hex())
 	}
 	lendingItem := stateObject.getLendingItem(self.db, orderIdHash)
 	var orderList *itemListState
@@ -305,16 +305,16 @@ func (self *LendingStateDB) CancelLendingOrder(orderBook common.Hash, order *Len
 	case Borrowing:
 		orderList = stateObject.getBorrowingOrderList(self.db, interestHash)
 	default:
-		return fmt.Errorf("Order side not found : %s ", order.Side)
+		return fmt.Errorf("not found order side: %s", order.Side)
 	}
 	if orderList == nil || orderList.empty() {
-		return fmt.Errorf("Order list empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderIdHash.Hex(), interestHash.Hex())
+		return fmt.Errorf("empty OrderList: order book : %s , order id : %s , key : %s", orderBook, orderIdHash.Hex(), interestHash.Hex())
 	}
 	if lendingItem == nil || lendingItem.empty() {
-		return fmt.Errorf("Order item empty  order book : %s , order id  : %s , key  : %s ", orderBook, orderIdHash.Hex(), interestHash.Hex())
+		return fmt.Errorf("empty order item: order book : %s , order id : %s , key : %s", orderBook, orderIdHash.Hex(), interestHash.Hex())
 	}
 	if lendingItem.data.UserAddress != order.UserAddress {
-		return fmt.Errorf("Error Order User Address mismatch when cancel order book : %s , order id  : %s , got : %s , expect : %s ", orderBook, orderIdHash.Hex(), lendingItem.data.UserAddress.Hex(), order.UserAddress.Hex())
+		return fmt.Errorf("error Order UserAddress mismatch when cancel order book: %s , order id : %s , got : %s , expect : %s", orderBook, orderIdHash.Hex(), lendingItem.data.UserAddress.Hex(), order.UserAddress.Hex())
 	}
 	self.journal = append(self.journal, cancelOrder{
 		orderBook: orderBook,
@@ -381,7 +381,7 @@ func (self *LendingStateDB) GetBestLendingIdAndAmount(orderBook common.Hash, pri
 		case Borrowing:
 			stateOrderList = stateObject.getBorrowingOrderList(self.db, common.BigToHash(price))
 		default:
-			return EmptyHash, Zero, fmt.Errorf("not found side :%s ", side)
+			return EmptyHash, Zero, fmt.Errorf("not found side: %s", side)
 		}
 		if stateOrderList != nil {
 			key, _, err := stateOrderList.getTrie(self.db).TryGetBestLeftKeyAndValue()
@@ -392,9 +392,9 @@ func (self *LendingStateDB) GetBestLendingIdAndAmount(orderBook common.Hash, pri
 			amount := stateOrderList.GetOrderAmount(self.db, orderId)
 			return orderId, new(big.Int).SetBytes(amount.Bytes()), nil
 		}
-		return EmptyHash, Zero, fmt.Errorf("not found order list with orderBook : %s , key : %d , side :%s ", orderBook.Hex(), price, side)
+		return EmptyHash, Zero, fmt.Errorf("not found order list with orderBook: %s , key : %d , side : %s", orderBook.Hex(), price, side)
 	}
-	return EmptyHash, Zero, fmt.Errorf("not found orderBook : %s ", orderBook.Hex())
+	return EmptyHash, Zero, fmt.Errorf("not found orderBook: %s", orderBook.Hex())
 }
 
 // updateLendingExchange writes the given object to the trie.
@@ -621,14 +621,14 @@ func (self *LendingStateDB) RemoveLiquidationTime(lendingBook common.Hash, trade
 	tradeIdHash := common.Uint64ToHash(tradeId)
 	lendingExchangeState := self.getLendingExchange(lendingBook)
 	if lendingExchangeState == nil {
-		return fmt.Errorf("lending book not found : %s ", lendingBook.Hex())
+		return fmt.Errorf("lending book not found: %s", lendingBook.Hex())
 	}
 	liquidationTime := lendingExchangeState.getLiquidationTimeOrderList(self.db, timeHash)
 	if liquidationTime == nil {
-		return fmt.Errorf("liquidation time not found : %s , %d ", lendingBook.Hex(), time)
+		return fmt.Errorf("not found liquidation time: %s , %d", lendingBook.Hex(), time)
 	}
 	if !liquidationTime.Exist(self.db, tradeIdHash) {
-		return fmt.Errorf("tradeId not exist : %s , %d , %d ", lendingBook.Hex(), time, tradeId)
+		return fmt.Errorf("not exist tradeId: %s , %d , %d", lendingBook.Hex(), time, tradeId)
 	}
 	liquidationTime.removeTradeId(self.db, tradeIdHash)
 	liquidationTime.subVolume(One)
@@ -659,11 +659,11 @@ func (self *LendingStateDB) CancelLendingTrade(orderBook common.Hash, tradeId ui
 	tradeIdHash := common.Uint64ToHash(tradeId)
 	stateObject := self.GetOrNewLendingExchangeObject(orderBook)
 	if stateObject == nil {
-		return fmt.Errorf("Order book not found : %s ", orderBook.Hex())
+		return fmt.Errorf("not found order book: %s", orderBook.Hex())
 	}
 	lendingTrade := stateObject.getLendingTrade(self.db, tradeIdHash)
 	if lendingTrade == nil || lendingTrade.empty() {
-		return fmt.Errorf("lending trade empty  order book : %s , trade id  : %s , trade id hash  : %s ", orderBook, tradeIdHash.Hex(), tradeIdHash.Hex())
+		return fmt.Errorf("lending trade empty order book: %s , trade id : %s , trade id hash : %s", orderBook, tradeIdHash.Hex(), tradeIdHash.Hex())
 	}
 	self.journal = append(self.journal, cancelTrading{
 		orderBook: orderBook,

--- a/XDCxlending/order_processor.go
+++ b/XDCxlending/order_processor.go
@@ -438,7 +438,7 @@ func (l *Lending) getLendQuantity(
 	}
 	LendingTokenDecimal, err := l.XDCx.GetTokenDecimal(chain, statedb, makerOrder.LendingToken)
 	if err != nil || LendingTokenDecimal.Sign() == 0 {
-		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", makerOrder.LendingToken.String(), err)
+		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", makerOrder.LendingToken.String(), err)
 	}
 	collateralToken := makerOrder.CollateralToken
 	if takerOrder.Side == lendingstate.Borrowing {
@@ -446,7 +446,7 @@ func (l *Lending) getLendQuantity(
 	}
 	collateralTokenDecimal, err := l.XDCx.GetTokenDecimal(chain, statedb, collateralToken)
 	if err != nil || collateralTokenDecimal.Sign() == 0 {
-		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal. Token: %v . Err: %v", collateralToken.String(), err)
+		return lendingstate.Zero, lendingstate.Zero, false, nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", collateralToken.String(), err)
 	}
 	if takerOrder.Relayer == makerOrder.Relayer {
 		if err := lendingstate.CheckRelayerFee(takerOrder.Relayer, new(big.Int).Mul(common.RelayerLendingFee, big.NewInt(2)), statedb); err != nil {
@@ -582,7 +582,7 @@ func DoSettleBalance(coinbase common.Address, takerOrder, makerOrder *lendingsta
 	matchingFee = new(big.Int).Add(matchingFee, common.RelayerLendingFee)
 
 	if common.EmptyHash(takerExOwner.Hash()) || common.EmptyHash(makerExOwner.Hash()) {
-		return fmt.Errorf("Echange owner empty , Taker: %v , maker : %v ", takerExOwner, makerExOwner)
+		return fmt.Errorf("empty echange owner: taker: %v , maker : %v", takerExOwner, makerExOwner)
 	}
 	mapBalances := map[common.Address]map[common.Address]*big.Int{}
 	//Checking balance
@@ -971,11 +971,11 @@ func (l *Lending) GetMediumTradePriceBeforeEpoch(chain consensus.ChainContext, s
 		if inversePrice != nil && inversePrice.Sign() > 0 {
 			quoteTokenDecimal, err := l.XDCx.GetTokenDecimal(chain, statedb, quoteToken)
 			if err != nil || quoteTokenDecimal.Sign() == 0 {
-				return nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", quoteToken.String(), err)
+				return nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", quoteToken.String(), err)
 			}
 			baseTokenDecimal, err := l.XDCx.GetTokenDecimal(chain, statedb, baseToken)
 			if err != nil || baseTokenDecimal.Sign() == 0 {
-				return nil, fmt.Errorf("Fail to get tokenDecimal. Token: %v . Err: %v", baseToken, err)
+				return nil, fmt.Errorf("fail to get tokenDecimal: Token: %v . Err: %v", baseToken, err)
 			}
 			price = new(big.Int).Mul(baseTokenDecimal, quoteTokenDecimal)
 			price = new(big.Int).Div(price, inversePrice)
@@ -1098,7 +1098,7 @@ func (l *Lending) AutoTopUp(statedb *state.StateDB, tradingState *tradingstate.T
 		return nil, fmt.Errorf("process deposit for emptyLendingTrade is not allowed. lendingTradeId: %v", lendingTradeId.Hex())
 	}
 	if currentPrice.Cmp(lendingTrade.LiquidationPrice) >= 0 {
-		return nil, fmt.Errorf("CurrentPrice is still higher than or equal to LiquidationPrice. current price: %v  , liquidation price : %v  ", currentPrice, lendingTrade.LiquidationPrice)
+		return nil, fmt.Errorf("currentPrice is still higher than or equal to LiquidationPrice. current price: %v  , liquidation price : %v  ", currentPrice, lendingTrade.LiquidationPrice)
 	}
 	// newLiquidationPrice = currentPrice * 90%
 	newLiquidationPrice := new(big.Int).Mul(currentPrice, common.RateTopUp)
@@ -1165,7 +1165,7 @@ func (l *Lending) ProcessRepayLendingTrade(header *types.Header, chain consensus
 
 	if tokenBalance.Cmp(paymentBalance) < 0 {
 		if lendingTrade.LiquidationTime > time {
-			return nil, fmt.Errorf("Not enough balance need : %s , have : %s ", paymentBalance, tokenBalance)
+			return nil, fmt.Errorf("not enough balance need : %s , have : %s", paymentBalance, tokenBalance)
 		}
 		newLendingTrade := &lendingstate.LendingTrade{}
 		var err error

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -102,7 +102,7 @@ func TestTypeRegexp(t *testing.T) {
 			t.Errorf("type %q: failed to parse type string: %v", tt.blob, err)
 		}
 		if !reflect.DeepEqual(typ, tt.kind) {
-			t.Errorf("type %q: parsed type mismatch:\nGOT %s\nWANT %s ", tt.blob, spew.Sdump(typeWithoutStringer(typ)), spew.Sdump(typeWithoutStringer(tt.kind)))
+			t.Errorf("type %q: parsed type mismatch:\nGOT %s\nWANT %s", tt.blob, spew.Sdump(typeWithoutStringer(typ)), spew.Sdump(typeWithoutStringer(tt.kind)))
 		}
 	}
 }

--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -201,11 +201,11 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 
 func decryptKeyV3(keyProtected *encryptedKeyJSONV3, auth string) (keyBytes []byte, keyId []byte, err error) {
 	if keyProtected.Version != version {
-		return nil, nil, fmt.Errorf("Version not supported: %v", keyProtected.Version)
+		return nil, nil, fmt.Errorf("not supported Version: %v", keyProtected.Version)
 	}
 
 	if keyProtected.Crypto.Cipher != "aes-128-ctr" {
-		return nil, nil, fmt.Errorf("Cipher not supported: %v", keyProtected.Crypto.Cipher)
+		return nil, nil, fmt.Errorf("not supported Cipher: %v", keyProtected.Crypto.Cipher)
 	}
 
 	keyId = uuid.Parse(keyProtected.Id)
@@ -293,13 +293,13 @@ func getKDFKey(cryptoJSON cryptoJSON, auth string) ([]byte, error) {
 		c := ensureInt(cryptoJSON.KDFParams["c"])
 		prf := cryptoJSON.KDFParams["prf"].(string)
 		if prf != "hmac-sha256" {
-			return nil, fmt.Errorf("Unsupported PBKDF2 PRF: %s", prf)
+			return nil, fmt.Errorf("unsupported PBKDF2 PRF: %s", prf)
 		}
 		key := pbkdf2.Key(authArray, salt, c, dkLen, sha256.New)
 		return key, nil
 	}
 
-	return nil, fmt.Errorf("Unsupported KDF: %s", cryptoJSON.KDF)
+	return nil, fmt.Errorf("unsupported KDF: %s", cryptoJSON.KDF)
 }
 
 // TODO: can we do without this when unmarshalling dynamic JSON?

--- a/accounts/keystore/keystore_plain_test.go
+++ b/accounts/keystore/keystore_plain_test.go
@@ -211,7 +211,7 @@ func testDecryptV3(test KeyStoreTestV3, t *testing.T) {
 	}
 	privHex := hex.EncodeToString(privBytes)
 	if test.Priv != privHex {
-		t.Fatal(fmt.Errorf("Decrypted bytes not equal to test, expected %v have %v", test.Priv, privHex))
+		t.Fatal(fmt.Errorf("decrypted bytes not equal to test, expected %v have %v", test.Priv, privHex))
 	}
 }
 
@@ -222,7 +222,7 @@ func testDecryptV1(test KeyStoreTestV1, t *testing.T) {
 	}
 	privHex := hex.EncodeToString(privBytes)
 	if test.Priv != privHex {
-		t.Fatal(fmt.Errorf("Decrypted bytes not equal to test, expected %v have %v", test.Priv, privHex))
+		t.Fatal(fmt.Errorf("decrypted bytes not equal to test, expected %v have %v", test.Priv, privHex))
 	}
 }
 

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -164,7 +164,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 	}
 	// Ensure the wallet is capable of signing the given transaction
 	if chainID != nil && w.version[0] <= 1 && w.version[1] <= 0 && w.version[2] <= 2 {
-		return common.Address{}, nil, fmt.Errorf("Ledger v%d.%d.%d doesn't support signing this transaction, please update to v1.0.3 at least", w.version[0], w.version[1], w.version[2])
+		return common.Address{}, nil, fmt.Errorf("ledger v%d.%d.%d doesn't support signing this transaction, please update to v1.0.3 at least", w.version[0], w.version[1], w.version[2])
 	}
 	// All infos gathered and metadata checks out, request signing
 	return w.ledgerSign(path, tx, chainID)
@@ -175,18 +175,18 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 //
 // The version retrieval protocol is defined as follows:
 //
-//   CLA | INS | P1 | P2 | Lc | Le
-//   ----+-----+----+----+----+---
-//    E0 | 06  | 00 | 00 | 00 | 04
+//	CLA | INS | P1 | P2 | Lc | Le
+//	----+-----+----+----+----+---
+//	 E0 | 06  | 00 | 00 | 00 | 04
 //
 // With no input data, and the output data being:
 //
-//   Description                                        | Length
-//   ---------------------------------------------------+--------
-//   Flags 01: arbitrary data signature enabled by user | 1 byte
-//   Application major version                          | 1 byte
-//   Application minor version                          | 1 byte
-//   Application patch version                          | 1 byte
+//	Description                                        | Length
+//	---------------------------------------------------+--------
+//	Flags 01: arbitrary data signature enabled by user | 1 byte
+//	Application major version                          | 1 byte
+//	Application minor version                          | 1 byte
+//	Application patch version                          | 1 byte
 func (w *ledgerDriver) ledgerVersion() ([3]byte, error) {
 	// Send the request and wait for the response
 	reply, err := w.ledgerExchange(ledgerOpGetConfiguration, 0, 0, nil)
@@ -207,32 +207,32 @@ func (w *ledgerDriver) ledgerVersion() ([3]byte, error) {
 //
 // The address derivation protocol is defined as follows:
 //
-//   CLA | INS | P1 | P2 | Lc  | Le
-//   ----+-----+----+----+-----+---
-//    E0 | 02  | 00 return address
-//               01 display address and confirm before returning
-//                  | 00: do not return the chain code
-//                  | 01: return the chain code
-//                       | var | 00
+//	CLA | INS | P1 | P2 | Lc  | Le
+//	----+-----+----+----+-----+---
+//	 E0 | 02  | 00 return address
+//	            01 display address and confirm before returning
+//	               | 00: do not return the chain code
+//	               | 01: return the chain code
+//	                    | var | 00
 //
 // Where the input data is:
 //
-//   Description                                      | Length
-//   -------------------------------------------------+--------
-//   Number of BIP 32 derivations to perform (max 10) | 1 byte
-//   First derivation index (big endian)              | 4 bytes
-//   ...                                              | 4 bytes
-//   Last derivation index (big endian)               | 4 bytes
+//	Description                                      | Length
+//	-------------------------------------------------+--------
+//	Number of BIP 32 derivations to perform (max 10) | 1 byte
+//	First derivation index (big endian)              | 4 bytes
+//	...                                              | 4 bytes
+//	Last derivation index (big endian)               | 4 bytes
 //
 // And the output data is:
 //
-//   Description             | Length
-//   ------------------------+-------------------
-//   Public Key length       | 1 byte
-//   Uncompressed Public Key | arbitrary
-//   Ethereum address length | 1 byte
-//   Ethereum address        | 40 bytes hex ascii
-//   Chain code if requested | 32 bytes
+//	Description             | Length
+//	------------------------+-------------------
+//	Public Key length       | 1 byte
+//	Uncompressed Public Key | arbitrary
+//	Ethereum address length | 1 byte
+//	Ethereum address        | 40 bytes hex ascii
+//	Chain code if requested | 32 bytes
 func (w *ledgerDriver) ledgerDerive(derivationPath []uint32) (common.Address, error) {
 	// Flatten the derivation path into the Ledger request
 	path := make([]byte, 1+4*len(derivationPath))
@@ -268,35 +268,35 @@ func (w *ledgerDriver) ledgerDerive(derivationPath []uint32) (common.Address, er
 //
 // The transaction signing protocol is defined as follows:
 //
-//   CLA | INS | P1 | P2 | Lc  | Le
-//   ----+-----+----+----+-----+---
-//    E0 | 04  | 00: first transaction data block
-//               80: subsequent transaction data block
-//                  | 00 | variable | variable
+//	CLA | INS | P1 | P2 | Lc  | Le
+//	----+-----+----+----+-----+---
+//	 E0 | 04  | 00: first transaction data block
+//	            80: subsequent transaction data block
+//	               | 00 | variable | variable
 //
 // Where the input for the first transaction block (first 255 bytes) is:
 //
-//   Description                                      | Length
-//   -------------------------------------------------+----------
-//   Number of BIP 32 derivations to perform (max 10) | 1 byte
-//   First derivation index (big endian)              | 4 bytes
-//   ...                                              | 4 bytes
-//   Last derivation index (big endian)               | 4 bytes
-//   RLP transaction chunk                            | arbitrary
+//	Description                                      | Length
+//	-------------------------------------------------+----------
+//	Number of BIP 32 derivations to perform (max 10) | 1 byte
+//	First derivation index (big endian)              | 4 bytes
+//	...                                              | 4 bytes
+//	Last derivation index (big endian)               | 4 bytes
+//	RLP transaction chunk                            | arbitrary
 //
 // And the input for subsequent transaction blocks (first 255 bytes) are:
 //
-//   Description           | Length
-//   ----------------------+----------
-//   RLP transaction chunk | arbitrary
+//	Description           | Length
+//	----------------------+----------
+//	RLP transaction chunk | arbitrary
 //
 // And the output data is:
 //
-//   Description | Length
-//   ------------+---------
-//   signature V | 1 byte
-//   signature R | 32 bytes
-//   signature S | 32 bytes
+//	Description | Length
+//	------------+---------
+//	signature V | 1 byte
+//	signature R | 32 bytes
+//	signature S | 32 bytes
 func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction, chainID *big.Int) (common.Address, *types.Transaction, error) {
 	// Flatten the derivation path into the Ledger request
 	path := make([]byte, 1+4*len(derivationPath))
@@ -370,12 +370,12 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 //
 // The common transport header is defined as follows:
 //
-//  Description                           | Length
-//  --------------------------------------+----------
-//  Communication channel ID (big endian) | 2 bytes
-//  Command tag                           | 1 byte
-//  Packet sequence index (big endian)    | 2 bytes
-//  Payload                               | arbitrary
+//	Description                           | Length
+//	--------------------------------------+----------
+//	Communication channel ID (big endian) | 2 bytes
+//	Command tag                           | 1 byte
+//	Packet sequence index (big endian)    | 2 bytes
+//	Payload                               | arbitrary
 //
 // The Communication channel ID allows commands multiplexing over the same
 // physical link. It is not used for the time being, and should be set to 0101
@@ -389,15 +389,15 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 //
 // APDU Command payloads are encoded as follows:
 //
-//  Description              | Length
-//  -----------------------------------
-//  APDU length (big endian) | 2 bytes
-//  APDU CLA                 | 1 byte
-//  APDU INS                 | 1 byte
-//  APDU P1                  | 1 byte
-//  APDU P2                  | 1 byte
-//  APDU length              | 1 byte
-//  Optional APDU data       | arbitrary
+//	Description              | Length
+//	-----------------------------------
+//	APDU length (big endian) | 2 bytes
+//	APDU CLA                 | 1 byte
+//	APDU INS                 | 1 byte
+//	APDU P1                  | 1 byte
+//	APDU P2                  | 1 byte
+//	APDU length              | 1 byte
+//	Optional APDU data       | arbitrary
 func (w *ledgerDriver) ledgerExchange(opcode ledgerOpcode, p1 ledgerParam1, p2 ledgerParam2, data []byte) ([]byte, error) {
 	// Construct the message payload, possibly split into multiple chunks
 	apdu := make([]byte, 2, 7+len(data))

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -396,7 +396,7 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		if msg.Tier >= uint(*tiersFlag) {
-			if err = sendError(wsconn, errors.New("Invalid funding tier requested")); err != nil {
+			if err = sendError(wsconn, errors.New("invalid funding tier requested")); err != nil {
 				log.Warn("Failed to send tier error to client", "err", err)
 				return
 			}
@@ -433,7 +433,7 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			if !result.Success {
 				log.Warn("Captcha verification failed", "err", string(result.Errors))
-				if err = sendError(wsconn, errors.New("Beep-bop, you're a robot!")); err != nil {
+				if err = sendError(wsconn, errors.New("beep-bop, you're a robot")); err != nil {
 					log.Warn("Failed to send captcha failure to client", "err", err)
 					return
 				}
@@ -462,7 +462,7 @@ func (f *faucet) apiHandler(w http.ResponseWriter, r *http.Request) {
 		case *noauthFlag:
 			username, avatar, address, err = authNoAuth(msg.URL)
 		default:
-			err = errors.New("Something funky happened, please open an issue at https://github.com/XinFinOrg/XDPoSChain/issues")
+			err = errors.New("something funky happened, please open an issue at https://github.com/XinFinOrg/XDPoSChain/issues")
 		}
 		if err != nil {
 			if err = sendError(wsconn, err); err != nil {
@@ -679,7 +679,7 @@ func authGitHub(url string) (string, string, common.Address, error) {
 		return "", "", common.Address{}, err
 	}
 	if gist.Owner.Login == "" {
-		return "", "", common.Address{}, errors.New("Anonymous Gists not allowed")
+		return "", "", common.Address{}, errors.New("anonymous gists not allowed")
 	}
 	// Iterate over all the files and look for Ethereum addresses
 	var address common.Address
@@ -690,7 +690,7 @@ func authGitHub(url string) (string, string, common.Address, error) {
 		}
 	}
 	if address == (common.Address{}) {
-		return "", "", common.Address{}, errors.New("No Ethereum address found to fund")
+		return "", "", common.Address{}, errors.New("no Ethereum address found to fund")
 	}
 	// Validate the user's existence since the API is unhelpful here
 	if res, err = http.Head("https://github.com/" + gist.Owner.Login); err != nil {
@@ -699,7 +699,7 @@ func authGitHub(url string) (string, string, common.Address, error) {
 	res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return "", "", common.Address{}, errors.New("Invalid user... boom!")
+		return "", "", common.Address{}, errors.New("invalid user... boom")
 	}
 	// Everything passed validation, return the gathered infos
 	return gist.Owner.Login + "@github", fmt.Sprintf("https://github.com/%s.png?size=64", gist.Owner.Login), address, nil
@@ -711,7 +711,7 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	// Ensure the user specified a meaningful URL, no fancy nonsense
 	parts := strings.Split(url, "/")
 	if len(parts) < 4 || parts[len(parts)-2] != "status" {
-		return "", "", common.Address{}, errors.New("Invalid Twitter status URL")
+		return "", "", common.Address{}, errors.New("invalid Twitter status URL")
 	}
 	// Twitter's API isn't really friendly with direct links. Still, we don't
 	// want to do ask read permissions from users, so just load the public posts and
@@ -725,7 +725,7 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	// Resolve the username from the final redirect, no intermediate junk
 	parts = strings.Split(res.Request.URL.String(), "/")
 	if len(parts) < 4 || parts[len(parts)-2] != "status" {
-		return "", "", common.Address{}, errors.New("Invalid Twitter status URL")
+		return "", "", common.Address{}, errors.New("invalid Twitter status URL")
 	}
 	username := parts[len(parts)-3]
 
@@ -735,7 +735,7 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	}
 	address := common.HexToAddress(string(regexp.MustCompile("0x[0-9a-fA-F]{40}").Find(body)))
 	if address == (common.Address{}) {
-		return "", "", common.Address{}, errors.New("No Ethereum address found to fund")
+		return "", "", common.Address{}, errors.New("no Ethereum address found to fund")
 	}
 	var avatar string
 	if parts = regexp.MustCompile("src=\"([^\"]+twimg.com/profile_images[^\"]+)\"").FindStringSubmatch(string(body)); len(parts) == 2 {
@@ -750,7 +750,7 @@ func authGooglePlus(url string) (string, string, common.Address, error) {
 	// Ensure the user specified a meaningful URL, no fancy nonsense
 	parts := strings.Split(url, "/")
 	if len(parts) < 4 || parts[len(parts)-2] != "posts" {
-		return "", "", common.Address{}, errors.New("Invalid Google+ post URL")
+		return "", "", common.Address{}, errors.New("invalid Google+ post URL")
 	}
 	username := parts[len(parts)-3]
 
@@ -769,7 +769,7 @@ func authGooglePlus(url string) (string, string, common.Address, error) {
 	}
 	address := common.HexToAddress(string(regexp.MustCompile("0x[0-9a-fA-F]{40}").Find(body)))
 	if address == (common.Address{}) {
-		return "", "", common.Address{}, errors.New("No Ethereum address found to fund")
+		return "", "", common.Address{}, errors.New("no Ethereum address found to fund")
 	}
 	var avatar string
 	if parts = regexp.MustCompile("src=\"([^\"]+googleusercontent.com[^\"]+photo.jpg)\"").FindStringSubmatch(string(body)); len(parts) == 2 {
@@ -784,7 +784,7 @@ func authFacebook(url string) (string, string, common.Address, error) {
 	// Ensure the user specified a meaningful URL, no fancy nonsense
 	parts := strings.Split(url, "/")
 	if len(parts) < 4 || parts[len(parts)-2] != "posts" {
-		return "", "", common.Address{}, errors.New("Invalid Facebook post URL")
+		return "", "", common.Address{}, errors.New("invalid Facebook post URL")
 	}
 	username := parts[len(parts)-3]
 
@@ -803,7 +803,7 @@ func authFacebook(url string) (string, string, common.Address, error) {
 	}
 	address := common.HexToAddress(string(regexp.MustCompile("0x[0-9a-fA-F]{40}").Find(body)))
 	if address == (common.Address{}) {
-		return "", "", common.Address{}, errors.New("No Ethereum address found to fund")
+		return "", "", common.Address{}, errors.New("no Ethereum address found to fund")
 	}
 	var avatar string
 	if parts = regexp.MustCompile("src=\"([^\"]+fbcdn.net[^\"]+)\"").FindStringSubmatch(string(body)); len(parts) == 2 {
@@ -818,7 +818,7 @@ func authFacebook(url string) (string, string, common.Address, error) {
 func authNoAuth(url string) (string, string, common.Address, error) {
 	address := common.HexToAddress(regexp.MustCompile("0x[0-9a-fA-F]{40}").FindString(url))
 	if address == (common.Address{}) {
-		return "", "", common.Address{}, errors.New("No Ethereum address found to fund")
+		return "", "", common.Address{}, errors.New("no Ethereum address found to fund")
 	}
 	return address.Hex() + "@noauth", "", address, nil
 }

--- a/cmd/faucet/website.go
+++ b/cmd/faucet/website.go
@@ -96,11 +96,11 @@ func Asset(name string) ([]byte, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("Asset %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("can't read Asset %s by error: %v", name, err)
 		}
 		return a.bytes, nil
 	}
-	return nil, fmt.Errorf("Asset %s not found", name)
+	return nil, fmt.Errorf("not found Asset %s", name)
 }
 
 // AssetString returns the asset contents as a string (instead of a []byte).
@@ -134,11 +134,11 @@ func AssetInfo(name string) (os.FileInfo, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("AssetInfo %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("can't read AssetInfo %s by error: %v", name, err)
 		}
 		return a.info, nil
 	}
-	return nil, fmt.Errorf("AssetInfo %s not found", name)
+	return nil, fmt.Errorf("not found AssetInfo %s", name)
 }
 
 // AssetDigest returns the digest of the file with the given name. It returns an
@@ -148,11 +148,11 @@ func AssetDigest(name string) ([sha256.Size]byte, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return [sha256.Size]byte{}, fmt.Errorf("AssetDigest %s can't read by error: %v", name, err)
+			return [sha256.Size]byte{}, fmt.Errorf("can't read AssetDigest %s by error: %v", name, err)
 		}
 		return a.digest, nil
 	}
-	return [sha256.Size]byte{}, fmt.Errorf("AssetDigest %s not found", name)
+	return [sha256.Size]byte{}, fmt.Errorf("not found AssetDigest %s", name)
 }
 
 // Digests returns a map of all known files and their checksums.
@@ -208,12 +208,12 @@ func AssetDir(name string) ([]string, error) {
 		for _, p := range pathList {
 			node = node.Children[p]
 			if node == nil {
-				return nil, fmt.Errorf("Asset %s not found", name)
+				return nil, fmt.Errorf("not found Asset %s", name)
 			}
 		}
 	}
 	if node.Func != nil {
-		return nil, fmt.Errorf("Asset %s not found", name)
+		return nil, fmt.Errorf("not found Asset %s", name)
 	}
 	rv := make([]string, 0, len(node.Children))
 	for childName := range node.Children {

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -190,7 +190,7 @@ func TestBinaryAddressToString(t *testing.T) {
 		have := tt.bin.String()
 		want := tt.str
 		if have != want {
-			t.Errorf("fail to convert binary address to string address\nwant:%s\nhave:%s", have, want)
+			t.Errorf("fail to convert binary address to string address\nwant: %s\nhave: %s", have, want)
 		}
 	}
 }
@@ -199,7 +199,7 @@ func TestStringToBinaryAddress(t *testing.T) {
 		want := tt.bin
 		have := HexToAddress(tt.str)
 		if have != want {
-			t.Errorf("fail to convert string address to binary address\nwant:%s\nhave:%s", have, want)
+			t.Errorf("fail to convert string address to binary address\nwant: %s\nhave: %s", have, want)
 		}
 	}
 }

--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -439,7 +439,7 @@ func (x *XDPoS) CalculateMissingRounds(chain consensus.ChainReader, header *type
 	case params.ConsensusEngineVersion2:
 		return x.EngineV2.CalculateMissingRounds(chain, header)
 	default: // Default "v1"
-		return nil, errors.New("Not supported in the v1 consensus")
+		return nil, errors.New("not supported in the v1 consensus")
 	}
 }
 

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -394,7 +394,7 @@ func (x *XDPoS_v1) GetPeriod() uint64 { return x.config.Period }
 
 func (x *XDPoS_v1) whoIsCreator(snap *SnapshotV1, header *types.Header) (common.Address, error) {
 	if header.Number.Uint64() == 0 {
-		return common.Address{}, errors.New("Don't take block 0")
+		return common.Address{}, errors.New("don't take block 0")
 	}
 	m, err := ecrecover(header, snap.sigcache)
 	if err != nil {
@@ -444,7 +444,7 @@ func (x *XDPoS_v1) yourTurn(chain consensus.ChainReader, parent *types.Header, s
 		return 0, -1, -1, false, err
 	}
 	if len(masternodes) == 0 {
-		return 0, -1, -1, false, errors.New("Masternodes not found")
+		return 0, -1, -1, false, errors.New("masternodes not found")
 	}
 	pre := common.Address{}
 	// masternode[0] has chance to create block 1
@@ -1029,7 +1029,7 @@ func (x *XDPoS_v1) getSignersFromContract(chain consensus.ChainReader, checkpoin
 	}
 	signers, err := x.HookGetSignersFromContract(startGapBlockHeader.Hash())
 	if err != nil {
-		return []common.Address{}, fmt.Errorf("Can't get signers from Smart Contract . Err: %v", err)
+		return []common.Address{}, fmt.Errorf("can't get signers from Smart Contract . Err: %v", err)
 	}
 	return signers, nil
 }

--- a/consensus/XDPoS/engines/engine_v1/utils.go
+++ b/consensus/XDPoS/engines/engine_v1/utils.go
@@ -26,7 +26,7 @@ func decodeMasternodesFromHeaderExtra(checkpointHeader *types.Header) []common.A
 // Get m2 list from checkpoint block.
 func getM1M2FromCheckpointHeader(checkpointHeader *types.Header, currentHeader *types.Header, config *params.ChainConfig) (map[common.Address]common.Address, error) {
 	if checkpointHeader.Number.Uint64()%common.EpocBlockRandomize != 0 {
-		return nil, errors.New("This block is not checkpoint block epoc.")
+		return nil, errors.New("this block is not checkpoint block")
 	}
 	// Get signers from this block.
 	masternodes := decodeMasternodesFromHeaderExtra(checkpointHeader)

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -661,7 +661,7 @@ func (x *XDPoS_v2) VerifyTimeoutMessage(chain consensus.ChainReader, timeoutMsg 
 	}
 	if len(snap.NextEpochCandidates) == 0 {
 		log.Error("[VerifyTimeoutMessage] cannot find NextEpochCandidates from snapshot", "messageGapNumber", timeoutMsg.GapNumber)
-		return false, errors.New("Empty master node lists from snapshot")
+		return false, errors.New("empty master node lists from snapshot")
 	}
 
 	verified, signer, err := x.verifyMsgSignature(types.TimeoutSigHash(&types.TimeoutForSign{
@@ -789,7 +789,7 @@ func (x *XDPoS_v2) verifyQC(blockChainReader consensus.ChainReader, quorumCert *
 	epochInfo, err := x.getEpochSwitchInfo(blockChainReader, parentHeader, quorumCert.ProposedBlockInfo.Hash)
 	if err != nil {
 		log.Error("[verifyQC] Error when getting epoch switch Info to verify QC", "Error", err)
-		return errors.New("Fail to verify QC due to failure in getting epoch switch info")
+		return errors.New("fail to verify QC due to failure in getting epoch switch info")
 	}
 
 	signatures, duplicates := UniqueSignatures(quorumCert.Signatures)
@@ -821,12 +821,12 @@ func (x *XDPoS_v2) verifyQC(blockChainReader consensus.ChainReader, quorumCert *
 			}), sig, epochInfo.Masternodes)
 			if err != nil {
 				log.Error("[verifyQC] Error while verfying QC message signatures", "Error", err)
-				haveError = errors.New("Error while verfying QC message signatures")
+				haveError = errors.New("error while verfying QC message signatures")
 				return
 			}
 			if !verified {
 				log.Warn("[verifyQC] Signature not verified doing QC verification", "QC", quorumCert)
-				haveError = errors.New("Fail to verify QC due to signature mis-match")
+				haveError = errors.New("fail to verify QC due to signature mis-match")
 				return
 			}
 		}(signature)

--- a/consensus/XDPoS/engines/engine_v2/forensics.go
+++ b/consensus/XDPoS/engines/engine_v2/forensics.go
@@ -164,7 +164,7 @@ func (f *Forensics) SendForensicProof(chain consensus.ChainReader, engine *XDPoS
 
 	if ancestorBlock == nil {
 		log.Error("[SendForensicProof] Unable to find the ancestor block by its hash", "Hash", ancestorHash)
-		return errors.New("Can't find ancestor block via hash")
+		return errors.New("can't find ancestor block via hash")
 	}
 
 	content, err := json.Marshal(&types.ForensicsContent{
@@ -455,7 +455,7 @@ func (f *Forensics) isExtendingFromAncestor(blockChainReader consensus.ChainRead
 	for i := 0; i < blockNumDiff; i++ {
 		parentBlock := blockChainReader.GetHeaderByHash(nextBlockHash)
 		if parentBlock == nil {
-			return false, fmt.Errorf("Could not find its parent block when checking whether currentBlock %v with hash %v is extending from the ancestorBlock %v", currentBlock.Number, currentBlock.Hash, ancestorBlock.Number)
+			return false, fmt.Errorf("could not find its parent block when checking whether currentBlock %v with hash %v is extending from the ancestorBlock %v", currentBlock.Number, currentBlock.Hash, ancestorBlock.Number)
 		} else {
 			nextBlockHash = parentBlock.ParentHash
 		}

--- a/consensus/XDPoS/engines/engine_v2/utils.go
+++ b/consensus/XDPoS/engines/engine_v2/utils.go
@@ -98,7 +98,7 @@ func (x *XDPoS_v2) signSignature(signingHash common.Hash) (types.Signature, erro
 
 	signedHash, err := signFn(accounts.Account{Address: signer}, signingHash.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("Error %v while signing hash", err)
+		return nil, fmt.Errorf("error %v while signing hash", err)
 	}
 	return signedHash, nil
 }
@@ -106,12 +106,12 @@ func (x *XDPoS_v2) signSignature(signingHash common.Hash) (types.Signature, erro
 func (x *XDPoS_v2) verifyMsgSignature(signedHashToBeVerified common.Hash, signature types.Signature, masternodes []common.Address) (bool, common.Address, error) {
 	var signerAddress common.Address
 	if len(masternodes) == 0 {
-		return false, signerAddress, errors.New("Empty masternode list detected when verifying message signatures")
+		return false, signerAddress, errors.New("empty masternode list detected when verifying message signatures")
 	}
 	// Recover the public key and the Ethereum address
 	pubkey, err := crypto.Ecrecover(signedHashToBeVerified.Bytes(), signature)
 	if err != nil {
-		return false, signerAddress, fmt.Errorf("Error while verifying message: %v", err)
+		return false, signerAddress, fmt.Errorf("error while verifying message: %v", err)
 	}
 
 	copy(signerAddress[:], crypto.Keccak256(pubkey[1:])[12:])

--- a/consensus/XDPoS/engines/engine_v2/vote.go
+++ b/consensus/XDPoS/engines/engine_v2/vote.go
@@ -79,7 +79,7 @@ func (x *XDPoS_v2) voteHandler(chain consensus.ChainReader, voteMsg *types.Vote)
 	epochInfo, err := x.getEpochSwitchInfo(chain, chain.CurrentHeader(), chain.CurrentHeader().Hash())
 	if err != nil {
 		log.Error("[voteHandler] Error when getting epoch switch Info", "error", err)
-		return errors.New("Fail on voteHandler due to failure in getting epoch switch info")
+		return errors.New("fail on voteHandler due to failure in getting epoch switch info")
 	}
 
 	certThreshold := x.config.V2.Config(uint64(voteMsg.ProposedBlockInfo.Round)).CertThreshold
@@ -178,7 +178,7 @@ func (x *XDPoS_v2) onVotePoolThresholdReached(chain consensus.ChainReader, poole
 	epochInfo, err := x.getEpochSwitchInfo(chain, chain.CurrentHeader(), chain.CurrentHeader().Hash())
 	if err != nil {
 		log.Error("[voteHandler] Error when getting epoch switch Info", "error", err)
-		return errors.New("Fail on voteHandler due to failure in getting epoch switch info")
+		return errors.New("fail on voteHandler due to failure in getting epoch switch info")
 	}
 
 	// Skip and wait for the next vote to process again if valid votes is less than what we required
@@ -249,7 +249,7 @@ func (x *XDPoS_v2) isExtendingFromAncestor(blockChainReader consensus.ChainReade
 	for i := 0; i < blockNumDiff; i++ {
 		parentBlock := blockChainReader.GetHeaderByHash(nextBlockHash)
 		if parentBlock == nil {
-			return false, fmt.Errorf("Could not find its parent block when checking whether currentBlock %v with hash %v is extending from the ancestorBlock %v", currentBlock.Number, currentBlock.Hash, ancestorBlock.Number)
+			return false, fmt.Errorf("could not find its parent block when checking whether currentBlock %v with hash %v is extending from the ancestorBlock %v", currentBlock.Number, currentBlock.Hash, ancestorBlock.Number)
 		} else {
 			nextBlockHash = parentBlock.ParentHash
 		}

--- a/consensus/XDPoS/utils/errors.go
+++ b/consensus/XDPoS/utils/errors.go
@@ -85,20 +85,20 @@ var (
 
 	ErrEmptyEpochSwitchValidators = errors.New("empty validators list on epoch switch block")
 
-	ErrInvalidV2Extra                = errors.New("Invalid v2 extra in the block")
-	ErrInvalidQC                     = errors.New("Invalid QC content")
-	ErrInvalidQCSignatures           = errors.New("Invalid QC Signatures")
-	ErrInvalidTC                     = errors.New("Invalid TC content")
-	ErrInvalidTCSignatures           = errors.New("Invalid TC Signatures")
-	ErrEmptyBlockInfoHash            = errors.New("BlockInfo hash is empty")
-	ErrInvalidFieldInNonEpochSwitch  = errors.New("Invalid field exist in a non-epoch swtich block")
-	ErrValidatorNotWithinMasternodes = errors.New("Validator address is not in the master node list")
-	ErrCoinbaseAndValidatorMismatch  = errors.New("Validator and coinbase address in header does not match")
-	ErrNotItsTurn                    = errors.New("Not validator's turn to mine this block")
+	ErrInvalidV2Extra                = errors.New("invalid v2 extra in the block")
+	ErrInvalidQC                     = errors.New("invalid QC content")
+	ErrInvalidQCSignatures           = errors.New("invalid QC Signatures")
+	ErrInvalidTC                     = errors.New("invalid TC content")
+	ErrInvalidTCSignatures           = errors.New("invalid TC Signatures")
+	ErrEmptyBlockInfoHash            = errors.New("blockInfo hash is empty")
+	ErrInvalidFieldInNonEpochSwitch  = errors.New("invalid field exist in a non-epoch swtich block")
+	ErrValidatorNotWithinMasternodes = errors.New("validator address is not in the master node list")
+	ErrCoinbaseAndValidatorMismatch  = errors.New("validator and coinbase address in header does not match")
+	ErrNotItsTurn                    = errors.New("not validator's turn to mine this block")
 
-	ErrRoundInvalid = errors.New("Invalid Round, it shall be bigger than QC round")
+	ErrRoundInvalid = errors.New("invalid Round, it shall be bigger than QC round")
 
-	ErrAlreadyMined = errors.New("Already mined")
+	ErrAlreadyMined = errors.New("already mined")
 )
 
 type ErrIncomingMessageRoundNotEqualCurrentRound struct {

--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -43,7 +43,7 @@ var (
 
 	ErrNotReadyToPropose = errors.New("not ready to propose, QC is not ready")
 
-	ErrNotReadyToMine = errors.New("Not ready to mine, it's not your turn")
+	ErrNotReadyToMine = errors.New("not ready to mine, it's not your turn")
 
-	ErrCoinbaseMismatch = errors.New("Block Coinbase address does not match its wallte address")
+	ErrCoinbaseMismatch = errors.New("block Coinbase address does not match its wallte address")
 )

--- a/consensus/tests/engine_v1_tests/helper.go
+++ b/consensus/tests/engine_v1_tests/helper.go
@@ -249,7 +249,7 @@ func PrepareXDCTestBlockChain(t *testing.T, numOfBlocks int, chainConfig *params
 	blockchain.Client = backend
 
 	if err != nil {
-		panic(fmt.Errorf("Error while creating simulated wallet for generating singer address and signer fn: %v", err))
+		panic(fmt.Errorf("error while creating simulated wallet for generating singer address and signer fn: %v", err))
 	}
 	blockchain.Engine().(*XDPoS.XDPoS).Authorize(signer, signFn)
 
@@ -322,13 +322,13 @@ func CreateBlock(blockchain *BlockChain, chainConfig *params.ChainConfig, starti
 		// Sign all the things for v1 block use v1 sigHash function
 		sighash, err := signFn(accounts.Account{Address: signer}, blockchain.Engine().(*XDPoS.XDPoS).SigHash(header).Bytes())
 		if err != nil {
-			panic(errors.New("Error when sign last v1 block hash during test block creation"))
+			panic(errors.New("error when sign last v1 block hash during test block creation"))
 		}
 		copy(header.Extra[len(header.Extra)-utils.ExtraSeal:], sighash)
 	}
 	block, err := createBlockFromHeader(blockchain, header, nil, signer, signFn, chainConfig)
 	if err != nil {
-		panic(fmt.Errorf("Fail to create block in test helper, %v", err))
+		panic(fmt.Errorf("fail to create block in test helper, %v", err))
 	}
 	return block
 }

--- a/consensus/tests/engine_v2_tests/api_test.go
+++ b/consensus/tests/engine_v2_tests/api_test.go
@@ -20,7 +20,7 @@ func TestGetMissedRoundsInEpochByBlockNumOnlyForV2Consensus(t *testing.T) {
 
 	data, err := engine.APIs(bc.GetBlockChain())[0].Service.(*XDPoS.API).GetMissedRoundsInEpochByBlockNum(&blockNum)
 
-	assert.EqualError(t, err, "Not supported in the v1 consensus")
+	assert.EqualError(t, err, "not supported in the v1 consensus")
 	assert.Nil(t, data)
 }
 

--- a/consensus/tests/engine_v2_tests/helper.go
+++ b/consensus/tests/engine_v2_tests/helper.go
@@ -371,7 +371,7 @@ func PrepareXDCTestBlockChainForV2Engine(t *testing.T, numOfBlocks int, chainCon
 	var err error
 	signer, signFn, err := backends.SimulateWalletAddressAndSignFn()
 	if err != nil {
-		panic(fmt.Errorf("Error while creating simulated wallet for generating singer address and signer fn: %v", err))
+		panic(fmt.Errorf("error while creating simulated wallet for generating singer address and signer fn: %v", err))
 	}
 	backend := getCommonBackend(t, chainConfig)
 	blockchain := backend.GetBlockChain()
@@ -634,14 +634,14 @@ func CreateBlock(blockchain *BlockChain, chainConfig *params.ChainConfig, starti
 			// Sign all the things for v1 block use v1 sigHash function
 			sighash, err := signFn(accounts.Account{Address: signer}, blockchain.Engine().(*XDPoS.XDPoS).SigHash(header).Bytes())
 			if err != nil {
-				panic(errors.New("Error when sign last v1 block hash during test block creation"))
+				panic(errors.New("error when sign last v1 block hash during test block creation"))
 			}
 			copy(header.Extra[len(header.Extra)-utils.ExtraSeal:], sighash)
 		}
 	}
 	block, err := createBlockFromHeader(blockchain, header, nil, signer, signFn, chainConfig)
 	if err != nil {
-		panic(fmt.Errorf("Fail to create block in test helper, %v", err))
+		panic(fmt.Errorf("fail to create block in test helper, %v", err))
 	}
 	return block
 }
@@ -758,7 +758,7 @@ func findSignerAndSignFn(bc *BlockChain, header *types.Header, signer common.Add
 		}
 		addressedSignFn = signFn
 		if err != nil {
-			panic(errors.New("Error trying to use one of the pre-defined private key to sign"))
+			panic(errors.New("error trying to use one of the pre-defined private key to sign"))
 		}
 	}
 
@@ -806,7 +806,7 @@ func generateV2Extra(roundNumber int64, currentBlock *types.Block, signer common
 
 	signedHash, err := signFn(accounts.Account{Address: signer}, types.VoteSigHash(voteForSign).Bytes())
 	if err != nil {
-		panic(fmt.Errorf("Error generate QC by creating signedHash: %v", err))
+		panic(fmt.Errorf("error generate QC by creating signedHash: %v", err))
 	}
 	var signatures []types.Signature
 	if len(accKeys) == 0 {
@@ -831,7 +831,7 @@ func generateV2Extra(roundNumber int64, currentBlock *types.Block, signer common
 	}
 	extraInBytes, err := extra.EncodeToBytes()
 	if err != nil {
-		panic(fmt.Errorf("Error encode extra into bytes: %v", err))
+		panic(fmt.Errorf("error encode extra into bytes: %v", err))
 	}
 	return extraInBytes
 }

--- a/consensus/tests/engine_v2_tests/verify_header_test.go
+++ b/consensus/tests/engine_v2_tests/verify_header_test.go
@@ -119,7 +119,7 @@ func TestShouldVerifyBlock(t *testing.T) {
 	// Genrate QC
 	signedHash, err := signFn(accounts.Account{Address: signer}, types.VoteSigHash(voteForSign).Bytes())
 	if err != nil {
-		panic(fmt.Errorf("Error generate QC by creating signedHash: %v", err))
+		panic(fmt.Errorf("error generate QC by creating signedHash: %v", err))
 	}
 	// Sign from acc 1, 2, 3
 	acc1SignedHash := SignHashByPK(acc1Key, types.VoteSigHash(voteForSign).Bytes())
@@ -139,7 +139,7 @@ func TestShouldVerifyBlock(t *testing.T) {
 	}
 	extraInBytes, err := extra.EncodeToBytes()
 	if err != nil {
-		panic(fmt.Errorf("Error encode extra into bytes: %v", err))
+		panic(fmt.Errorf("error encode extra into bytes: %v", err))
 	}
 
 	invalidRoundBlock := blockchain.GetBlockByNumber(902).Header()
@@ -398,7 +398,7 @@ func TestShouldFailIfNotEnoughQCSignatures(t *testing.T) {
 	}
 	extraInBytes, err := extra.EncodeToBytes()
 	if err != nil {
-		panic(fmt.Errorf("Error encode extra into bytes: %v", err))
+		panic(fmt.Errorf("error encode extra into bytes: %v", err))
 	}
 	headerWithDuplicatedSignatures := currentBlock.Header()
 	headerWithDuplicatedSignatures.Extra = extraInBytes

--- a/consensus/tests/engine_v2_tests/vote_test.go
+++ b/consensus/tests/engine_v2_tests/vote_test.go
@@ -539,7 +539,7 @@ func TestVerifyVoteMsg(t *testing.T) {
 	engineV2.SetNewRoundFaker(blockchain, types.Round(14), false)
 	verified, err = engineV2.VerifyVoteMessage(blockchain, voteMsg)
 	assert.False(t, verified)
-	assert.Equal(t, "Error while verifying message: invalid signature length", err.Error())
+	assert.Equal(t, "error while verifying message: invalid signature length", err.Error())
 
 	// Valid vote message from a master node
 	signHash, _ := signFn(accounts.Account{Address: signer}, types.VoteSigHash(voteForSign).Bytes())

--- a/console/bridge.go
+++ b/console/bridge.go
@@ -76,7 +76,7 @@ func (b *bridge) NewAccount(call jsre.Call) (goja.Value, error) {
 			return nil, err
 		}
 		if password != confirm {
-			return nil, errors.New("passwords don't match!")
+			return nil, errors.New("passwords don't match")
 		}
 	// A single string password was specified, use that
 	case len(call.Arguments) == 1 && call.Argument(0).ToString() != nil:

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1650,7 +1650,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 						finalizedTrades := map[common.Hash]*lendingstate.LendingTrade{}
 						finalizedTrades, _, _, _, _, err = lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
 						if err != nil {
-							return i, events, coalescedLogs, fmt.Errorf("failed to ProcessLiquidationData. Err: %v ", err)
+							return i, events, coalescedLogs, fmt.Errorf("failed to ProcessLiquidationData. Err: %v", err)
 						}
 						if isSDKNode {
 							finalizedTx := lendingstate.FinalizedResult{}
@@ -1678,7 +1678,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 					expectRoot, _ := lendingService.GetLendingStateRoot(block, author)
 					parentRoot, _ := lendingService.GetLendingStateRoot(parent, parentAuthor)
 					if gotRoot != expectRoot {
-						err = fmt.Errorf("invalid lending state merke trie got : %s , expect : %s , parent :%s ", gotRoot.Hex(), expectRoot.Hex(), parentRoot.Hex())
+						err = fmt.Errorf("invalid lending state merke trie got: %s, expect: %s, parent: %s", gotRoot.Hex(), expectRoot.Hex(), parentRoot.Hex())
 						bc.reportBlock(block, nil, err)
 						return i, events, coalescedLogs, err
 					}
@@ -1930,7 +1930,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 				if block.Number().Uint64()%bc.chainConfig.XDPoS.Epoch == common.LiquidateLendingTradeBlock {
 					finalizedTrades, _, _, _, _, err := lendingService.ProcessLiquidationData(block.Header(), bc, statedb, tradingState, lendingState)
 					if err != nil {
-						return nil, fmt.Errorf("failed to ProcessLiquidationData. Err: %v ", err)
+						return nil, fmt.Errorf("failed to ProcessLiquidationData. Err: %v", err)
 					}
 					if isSDKNode {
 						finalizedTx := lendingstate.FinalizedResult{}
@@ -1957,7 +1957,7 @@ func (bc *BlockChain) getResultBlock(block *types.Block, verifiedM2 bool) (*Resu
 				expectRoot, _ := lendingService.GetLendingStateRoot(block, author)
 				parentRoot, _ := lendingService.GetLendingStateRoot(parent, parentAuthor)
 				if gotRoot != expectRoot {
-					err = fmt.Errorf("invalid lending state merke trie got : %s , expect : %s , parent : %s ", gotRoot.Hex(), expectRoot.Hex(), parentRoot.Hex())
+					err = fmt.Errorf("invalid lending state merke trie got: %s , expect : %s , parent : %s", gotRoot.Hex(), expectRoot.Hex(), parentRoot.Hex())
 					bc.reportBlock(block, nil, err)
 					return nil, err
 				}
@@ -2177,10 +2177,10 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 	}
 	if oldBlock == nil {
-		return errors.New("Invalid old chain")
+		return errors.New("invalid old chain")
 	}
 	if newBlock == nil {
-		return errors.New("Invalid new chain")
+		return errors.New("invalid new chain")
 	}
 
 	for {
@@ -2196,10 +2196,10 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 
 		oldBlock, newBlock = bc.GetBlock(oldBlock.ParentHash(), oldBlock.NumberU64()-1), bc.GetBlock(newBlock.ParentHash(), newBlock.NumberU64()-1)
 		if oldBlock == nil {
-			return errors.New("Invalid old chain")
+			return errors.New("invalid old chain")
 		}
 		if newBlock == nil {
-			return errors.New("Invalid new chain")
+			return errors.New("invalid new chain")
 		}
 	}
 	// Ensure XDPoS engine committed block will be not reverted

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -623,7 +623,7 @@ func (pool *LendingPool) validateTx(tx *types.LendingTransaction, local bool) er
 
 	// check if sender is in black list
 	if tx.From() != nil && common.Blacklist[*tx.From()] {
-		return fmt.Errorf("Reject transaction with sender in black-list: %v", tx.From().Hex())
+		return fmt.Errorf("reject transaction with sender in black-list: %v", tx.From().Hex())
 	}
 	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
 	if tx.Size() > 32*1024 {

--- a/core/order_pool.go
+++ b/core/order_pool.go
@@ -61,7 +61,7 @@ var (
 
 var (
 	ErrPendingNonceTooLow = errors.New("pending nonce too low")
-	ErrPoolOverflow       = errors.New("Exceed pool size")
+	ErrPoolOverflow       = errors.New("exceed pool size")
 )
 
 // OrderPoolConfig are the configuration parameters of the order transaction pool.
@@ -532,7 +532,7 @@ func (pool *OrderPool) validateTx(tx *types.OrderTransaction, local bool) error 
 
 	// check if sender is in black list
 	if tx.From() != nil && common.Blacklist[*tx.From()] {
-		return fmt.Errorf("Reject transaction with sender in black-list: %v", tx.From().Hex())
+		return fmt.Errorf("reject transaction with sender in black-list: %v", tx.From().Hex())
 	}
 	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
 	if tx.Size() > 32*1024 {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -581,11 +581,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// check if sender is in black list
 	if tx.From() != nil && common.Blacklist[*tx.From()] {
-		return fmt.Errorf("Reject transaction with sender in black-list: %v", tx.From().Hex())
+		return fmt.Errorf("reject transaction with sender in black-list: %v", tx.From().Hex())
 	}
 	// check if receiver is in black list
 	if tx.To() != nil && common.Blacklist[*tx.To()] {
-		return fmt.Errorf("Reject transaction with receiver in black-list: %v", tx.To().Hex())
+		return fmt.Errorf("reject transaction with receiver in black-list: %v", tx.To().Hex())
 	}
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur if you create a transaction using the RPC.

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -575,10 +575,10 @@ func (c *ringSignatureVerifier) RequiredGas(input []byte) uint64 {
 func (c *ringSignatureVerifier) Run(proof []byte) ([]byte, error) {
 	der, err := privacy.Deserialize(proof)
 	if err != nil {
-		return []byte{}, errors.New("Fail to deserialize proof")
+		return []byte{}, errors.New("fail to deserialize proof")
 	}
 	if !privacy.Verify(der, false) {
-		return []byte{}, errors.New("Fail to verify ring signature")
+		return []byte{}, errors.New("fail to verify ring signature")
 	}
 	return []byte{}, nil
 }

--- a/core/vm/privacy/bulletproof.go
+++ b/core/vm/privacy/bulletproof.go
@@ -985,7 +985,7 @@ func MRPProve(values []*big.Int) (MultiRangeProof, error) {
 	}
 
 	if !acceptedInputNumber {
-		return MultiRangeProof{}, errors.New("Value number is not supported - just 1, 2, 4, 8")
+		return MultiRangeProof{}, errors.New("value number is not supported - just 1, 2, 4, 8")
 	}
 
 	EC = genECPrimeGroupKey(m * bitsPerValue)
@@ -1002,15 +1002,15 @@ func MRPProve(values []*big.Int) (MultiRangeProof, error) {
 	for j := range values {
 		v := values[j]
 		if v.Cmp(big.NewInt(0)) == -1 {
-			return MultiRangeProof{}, errors.New("Value is below range! Not proving")
+			return MultiRangeProof{}, errors.New("value is below range! Not proving")
 		}
 
 		if v.Cmp(MAX_64_BITS) == 1 {
-			return MultiRangeProof{}, errors.New("Value is above range! Not proving")
+			return MultiRangeProof{}, errors.New("value is above range! Not proving")
 		}
 
 		if v.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bitsPerValue)), EC.N)) == 1 {
-			return MultiRangeProof{}, errors.New("Value is above range! Not proving")
+			return MultiRangeProof{}, errors.New("value is above range! Not proving")
 		}
 
 		gamma, err := rand.Int(rand.Reader, EC.N)

--- a/core/vm/privacy/ringct.go
+++ b/core/vm/privacy/ringct.go
@@ -171,7 +171,7 @@ func (r *RingSignature) Serialize() ([]byte, error) {
 	}
 
 	if len(sig) != 8+8+32+32+(32+33)*r.NumRing*r.Size+33*r.NumRing {
-		return []byte{}, errors.New("Could not serialize ring signature")
+		return []byte{}, errors.New("could not serialize ring signature")
 	}
 
 	return sig, nil
@@ -198,7 +198,7 @@ func computeSignatureSize(numRing int, ringSize int) int {
 // deserializes the byteified signature into a RingSignature struct
 func Deserialize(r []byte) (*RingSignature, error) {
 	if len(r) < 16 {
-		return nil, errors.New("Failed to deserialize ring signature")
+		return nil, errors.New("failed to deserialize ring signature")
 	}
 	offset := 0
 	sig := new(RingSignature)
@@ -455,7 +455,7 @@ func Sign(m [32]byte, rings []Ring, privkeys []*ecdsa.PrivateKey, s int) (*RingS
 			px, py := curve.ScalarMult(rings[j][idx].X, rings[j][idx].Y, PadTo32Bytes(C[idx].Bytes())) // px, py = c_i*P_i
 			sx, sy := curve.ScalarBaseMult(PadTo32Bytes(S[j][idx].Bytes()))                            // sx, sy = s[n-1]*G
 			if px == nil || py == nil || sx == nil || sy == nil {
-				return nil, errors.New("Could not create ring signature")
+				return nil, errors.New("could not create ring signature")
 			}
 			l_x, l_y := curve.Add(sx, sy, px, py)
 			L[j][idx] = &ecdsa.PublicKey{curve, l_x, l_y}
@@ -467,7 +467,7 @@ func Sign(m [32]byte, rings []Ring, privkeys []*ecdsa.PrivateKey, s int) (*RingS
 			hx, hy := HashPoint(rings[j][idx])
 			sx, sy = curve.ScalarMult(hx, hy, S[j][idx].Bytes()) // sx, sy = s[n-1]*H_p(P_i)
 			if px == nil || py == nil || sx == nil || sy == nil {
-				return nil, errors.New("Could not create ring signature")
+				return nil, errors.New("could not create ring signature")
 			}
 			r_x, r_y := curve.Add(sx, sy, px, py)
 			R[j][idx] = &ecdsa.PublicKey{curve, r_x, r_y}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -601,7 +601,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 		}
 		root := statedb.IntermediateRoot(true)
 		if root != block.Root() {
-			return nil, nil, fmt.Errorf("invalid merkle root (number :%d  got : %x expect: %x)", block.NumberU64(), root.Hex(), block.Root())
+			return nil, nil, fmt.Errorf("invalid merkle root (number %d : got : %x expect: %x)", block.NumberU64(), root.Hex(), block.Root())
 		}
 		// Finalize the state so any modifications are written to the trie
 		root, err = statedb.Commit(true)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -154,7 +154,7 @@ func New(ctx *node.ServiceContext, config *ethconfig.Config, XDCXServ *XDCx.XDCX
 	if !config.SkipBcVersionCheck {
 		bcVersion := core.GetBlockChainVersion(chainDb)
 		if bcVersion != core.BlockChainVersion && bcVersion != 0 {
-			return nil, fmt.Errorf("Blockchain DB version mismatch (%d / %d). Run geth upgradedb.\n", bcVersion, core.BlockChainVersion)
+			return nil, fmt.Errorf("blockchain DB version mismatch (%d / %d). Run geth upgradedb", bcVersion, core.BlockChainVersion)
 		}
 		core.WriteBlockChainVersion(chainDb, core.BlockChainVersion)
 	}
@@ -247,7 +247,7 @@ func New(ctx *node.ServiceContext, config *ethconfig.Config, XDCXServ *XDCx.XDCX
 			}
 			if block.NumberU64()%common.MergeSignRange == 0 || !eth.chainConfig.IsTIP2019(block.Number()) {
 				if err := contracts.CreateTransactionSign(chainConfig, eth.txPool, eth.accountManager, block, chainDb, eb); err != nil {
-					return fmt.Errorf("Fail to create tx sign for importing block: %v", err)
+					return fmt.Errorf("fail to create tx sign for importing block: %v", err)
 				}
 			}
 			return nil
@@ -478,7 +478,7 @@ func (s *Ethereum) ValidateMasternode() (bool, error) {
 			return false, nil
 		}
 	} else {
-		return false, errors.New("Only verify masternode permission in XDPoS protocol")
+		return false, errors.New("only verify masternode permission in XDPoS protocol")
 	}
 	return true, nil
 }

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -18,7 +18,6 @@ package downloader
 
 import (
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/ethdb/memorydb"
 	"hash"
 	"sync"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/crypto/sha3"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
+	"github.com/XinFinOrg/XDPoSChain/ethdb/memorydb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 )
@@ -327,7 +327,7 @@ func (s *stateSync) commit(force bool) error {
 	b := s.d.stateDB.NewBatch()
 	s.sched.Commit(b)
 	if err := b.Write(); err != nil {
-		return fmt.Errorf("DB write error: %v", err)
+		return fmt.Errorf("write DB error: %v", err)
 	}
 	s.updateStats(s.numUncommitted, 0, 0, time.Since(start))
 	s.numUncommitted = 0

--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -264,7 +264,7 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		foundationWalletAddr := chain.Config().XDPoS.FoudationWalletAddr
 		if foundationWalletAddr == (common.Address{}) {
 			log.Error("Foundation Wallet Address is empty", "error", foundationWalletAddr)
-			return errors.New("Foundation Wallet Address is empty"), nil
+			return errors.New("foundation Wallet Address is empty"), nil
 		}
 		rewards := make(map[string]interface{})
 		if number > 0 && number-rCheckpoint > 0 && foundationWalletAddr != (common.Address{}) {

--- a/eth/tracers/internal/tracers/assets.go
+++ b/eth/tracers/internal/tracers/assets.go
@@ -306,11 +306,11 @@ func Asset(name string) ([]byte, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("Asset %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("can't read Asset %s by error: %v", name, err)
 		}
 		return a.bytes, nil
 	}
-	return nil, fmt.Errorf("Asset %s not found", name)
+	return nil, fmt.Errorf("not found Asset %s", name)
 }
 
 // AssetString returns the asset contents as a string (instead of a []byte).
@@ -344,11 +344,11 @@ func AssetInfo(name string) (os.FileInfo, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("AssetInfo %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("can't read AssetInfo %s by error: %v", name, err)
 		}
 		return a.info, nil
 	}
-	return nil, fmt.Errorf("AssetInfo %s not found", name)
+	return nil, fmt.Errorf("not found AssetInfo %s", name)
 }
 
 // AssetDigest returns the digest of the file with the given name. It returns an
@@ -358,11 +358,11 @@ func AssetDigest(name string) ([sha256.Size]byte, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return [sha256.Size]byte{}, fmt.Errorf("AssetDigest %s can't read by error: %v", name, err)
+			return [sha256.Size]byte{}, fmt.Errorf("can't read AssetDigest %s by error: %v", name, err)
 		}
 		return a.digest, nil
 	}
-	return [sha256.Size]byte{}, fmt.Errorf("AssetDigest %s not found", name)
+	return [sha256.Size]byte{}, fmt.Errorf("not found AssetDigest %s", name)
 }
 
 // Digests returns a map of all known files and their checksums.
@@ -426,12 +426,12 @@ func AssetDir(name string) ([]string, error) {
 		for _, p := range pathList {
 			node = node.Children[p]
 			if node == nil {
-				return nil, fmt.Errorf("Asset %s not found", name)
+				return nil, fmt.Errorf("not found Asset %s", name)
 			}
 		}
 	}
 	if node.Func != nil {
-		return nil, fmt.Errorf("Asset %s not found", name)
+		return nil, fmt.Errorf("not found Asset %s", name)
 	}
 	rv := make([]string, 0, len(node.Children))
 	for childName := range node.Children {

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -123,12 +123,12 @@ func (tt *TestCmd) matchExactOutput(want []byte) error {
 		// Find the mismatch position.
 		for i := 0; i < n; i++ {
 			if want[i] != buf[i] {
-				return fmt.Errorf("Output mismatch at ◊:\n---------------- (stdout text)\n%s%s\n---------------- (expected text)\n%s",
+				return fmt.Errorf("output mismatch at ◊:\n---------------- (stdout text)\n%s%s\n---------------- (expected text)\n%s",
 					buf[:i], buf[i:n], want)
 			}
 		}
 		if n < len(want) {
-			return fmt.Errorf("Not enough output, got until ◊:\n---------------- (stdout text)\n%s\n---------------- (expected text)\n%s◊%s",
+			return fmt.Errorf("not enough output, got until ◊:\n---------------- (stdout text)\n%s\n---------------- (expected text)\n%s◊%s",
 				buf, want[:n], want[n:])
 		}
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2207,7 +2207,7 @@ func (s *PublicTransactionPoolAPI) sign(addr common.Address, tx *types.Transacti
 // SubmitTransaction is a helper function that submits tx to txPool and logs a message.
 func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
 	if tx.To() != nil && tx.IsSpecialTransaction() {
-		return common.Hash{}, errors.New("Dont allow transaction sent to BlockSigners & RandomizeSMC smart contract via API")
+		return common.Hash{}, errors.New("don't allow transaction sent to BlockSigners & RandomizeSMC smart contract via API")
 	}
 
 	// If the transaction fee cap is already specified, ensure the
@@ -2524,11 +2524,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestBid(ctx context.Context, baseToken
 	result := PriceVolume{}
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return result, errors.New("Current block not found")
+		return result, errors.New("current block not found")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return result, errors.New("XDCX service not found")
+		return result, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2540,7 +2540,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestBid(ctx context.Context, baseToken
 	}
 	result.Price, result.Volume = XDCxState.GetBestBidPrice(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken))
 	if result.Price.Sign() == 0 {
-		return result, errors.New("Bid tree not found")
+		return result, errors.New("not found bid tree")
 	}
 	return result, nil
 }
@@ -2549,11 +2549,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestAsk(ctx context.Context, baseToken
 	result := PriceVolume{}
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return result, errors.New("Current block not found")
+		return result, errors.New("not found current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return result, errors.New("XDCX service not found")
+		return result, errors.New("not found XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2565,7 +2565,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestAsk(ctx context.Context, baseToken
 	}
 	result.Price, result.Volume = XDCxState.GetBestAskPrice(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken))
 	if result.Price.Sign() == 0 {
-		return result, errors.New("Ask tree not found")
+		return result, errors.New("not find ask tree")
 	}
 	return result, nil
 }
@@ -2573,11 +2573,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestAsk(ctx context.Context, baseToken
 func (s *PublicXDCXTransactionPoolAPI) GetBidTree(ctx context.Context, baseToken, quoteToken common.Address) (map[*big.Int]tradingstate.DumpOrderList, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2597,11 +2597,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBidTree(ctx context.Context, baseToken
 func (s *PublicXDCXTransactionPoolAPI) GetPrice(ctx context.Context, baseToken, quoteToken common.Address) (*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2613,7 +2613,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetPrice(ctx context.Context, baseToken, 
 	}
 	price := XDCxState.GetLastPrice(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken))
 	if price == nil || price.Sign() == 0 {
-		return common.Big0, errors.New("Order book's price not found")
+		return common.Big0, errors.New("not find order book's price")
 	}
 	return price, nil
 }
@@ -2621,11 +2621,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetPrice(ctx context.Context, baseToken, 
 func (s *PublicXDCXTransactionPoolAPI) GetLastEpochPrice(ctx context.Context, baseToken, quoteToken common.Address) (*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2637,7 +2637,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetLastEpochPrice(ctx context.Context, ba
 	}
 	price := XDCxState.GetMediumPriceBeforeEpoch(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken))
 	if price == nil || price.Sign() == 0 {
-		return common.Big0, errors.New("Order book's price not found")
+		return common.Big0, errors.New("not find order book's price")
 	}
 	return price, nil
 }
@@ -2645,11 +2645,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetLastEpochPrice(ctx context.Context, ba
 func (s *PublicXDCXTransactionPoolAPI) GetCurrentEpochPrice(ctx context.Context, baseToken, quoteToken common.Address) (*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2661,7 +2661,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetCurrentEpochPrice(ctx context.Context,
 	}
 	price, _ := XDCxState.GetMediumPriceAndTotalAmount(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken))
 	if price == nil || price.Sign() == 0 {
-		return common.Big0, errors.New("Order book's price not found")
+		return common.Big0, errors.New("not find order book's price")
 	}
 	return price, nil
 }
@@ -2669,11 +2669,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetCurrentEpochPrice(ctx context.Context,
 func (s *PublicXDCXTransactionPoolAPI) GetAskTree(ctx context.Context, baseToken, quoteToken common.Address) (map[*big.Int]tradingstate.DumpOrderList, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2693,11 +2693,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetAskTree(ctx context.Context, baseToken
 func (s *PublicXDCXTransactionPoolAPI) GetOrderById(ctx context.Context, baseToken, quoteToken common.Address, orderId uint64) (interface{}, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2710,7 +2710,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetOrderById(ctx context.Context, baseTok
 	orderIdHash := common.BigToHash(new(big.Int).SetUint64(orderId))
 	orderitem := XDCxState.GetOrder(tradingstate.GetTradingOrderBookHash(baseToken, quoteToken), orderIdHash)
 	if orderitem.Quantity == nil || orderitem.Quantity.Sign() == 0 {
-		return nil, errors.New("Order not found")
+		return nil, errors.New("not found order")
 	}
 	return orderitem, nil
 }
@@ -2718,11 +2718,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetOrderById(ctx context.Context, baseTok
 func (s *PublicXDCXTransactionPoolAPI) GetTradingOrderBookInfo(ctx context.Context, baseToken, quoteToken common.Address) (*tradingstate.DumpOrderBookInfo, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2742,11 +2742,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetTradingOrderBookInfo(ctx context.Conte
 func (s *PublicXDCXTransactionPoolAPI) GetLiquidationPriceTree(ctx context.Context, baseToken, quoteToken common.Address) (map[*big.Int]tradingstate.DumpLendingBook, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2766,7 +2766,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetLiquidationPriceTree(ctx context.Conte
 func (s *PublicXDCXTransactionPoolAPI) GetInvestingTree(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]lendingstate.DumpOrderList, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
@@ -2790,7 +2790,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetInvestingTree(ctx context.Context, len
 func (s *PublicXDCXTransactionPoolAPI) GetBorrowingTree(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]lendingstate.DumpOrderList, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
@@ -2814,7 +2814,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetBorrowingTree(ctx context.Context, len
 func (s *PublicXDCXTransactionPoolAPI) GetLendingOrderBookInfo(tx context.Context, lendingToken common.Address, term uint64) (*lendingstate.DumpOrderBookInfo, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
@@ -2838,11 +2838,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetLendingOrderBookInfo(tx context.Contex
 func (s *PublicXDCXTransactionPoolAPI) getLendingOrderTree(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]lendingstate.LendingItem, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return nil, errors.New("XDCX Lending service not found")
+		return nil, errors.New("not find XDCX Lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2862,11 +2862,11 @@ func (s *PublicXDCXTransactionPoolAPI) getLendingOrderTree(ctx context.Context, 
 func (s *PublicXDCXTransactionPoolAPI) GetLendingTradeTree(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]lendingstate.LendingTrade, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return nil, errors.New("XDCX Lending service not found")
+		return nil, errors.New("not find XDCX lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2886,11 +2886,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetLendingTradeTree(ctx context.Context, 
 func (s *PublicXDCXTransactionPoolAPI) GetLiquidationTimeTree(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]lendingstate.DumpOrderList, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return nil, errors.New("XDCX Lending service not found")
+		return nil, errors.New("not find XDCX Lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2910,11 +2910,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetLiquidationTimeTree(ctx context.Contex
 func (s *PublicXDCXTransactionPoolAPI) GetLendingOrderCount(ctx context.Context, addr common.Address) (*hexutil.Uint64, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return nil, errors.New("XDCX Lending service not found")
+		return nil, errors.New("not find XDCX Lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2932,11 +2932,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestInvesting(ctx context.Context, len
 	result := InterestVolume{}
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return result, errors.New("Current block not found")
+		return result, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return result, errors.New("XDCX Lending service not found")
+		return result, errors.New("not find XDCX Lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2954,11 +2954,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestBorrowing(ctx context.Context, len
 	result := InterestVolume{}
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return result, errors.New("Current block not found")
+		return result, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return result, errors.New("XDCX Lending service not found")
+		return result, errors.New("not find XDCX Lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2975,11 +2975,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBestBorrowing(ctx context.Context, len
 func (s *PublicXDCXTransactionPoolAPI) GetBids(ctx context.Context, baseToken, quoteToken common.Address) (map[*big.Int]*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -2999,11 +2999,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetBids(ctx context.Context, baseToken, q
 func (s *PublicXDCXTransactionPoolAPI) GetAsks(ctx context.Context, baseToken, quoteToken common.Address) (map[*big.Int]*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	XDCxService := s.b.XDCxService()
 	if XDCxService == nil {
-		return nil, errors.New("XDCX service not found")
+		return nil, errors.New("not find XDCX service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -3023,7 +3023,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetAsks(ctx context.Context, baseToken, q
 func (s *PublicXDCXTransactionPoolAPI) GetInvests(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
@@ -3047,7 +3047,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetInvests(ctx context.Context, lendingTo
 func (s *PublicXDCXTransactionPoolAPI) GetBorrows(ctx context.Context, lendingToken common.Address, term uint64) (map[*big.Int]*big.Int, error) {
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return nil, errors.New("Current block not found")
+		return nil, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
@@ -3105,11 +3105,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetLendingOrderById(ctx context.Context, 
 	lendingItem := lendingstate.LendingItem{}
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return lendingItem, errors.New("Current block not found")
+		return lendingItem, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return lendingItem, errors.New("XDCX Lending service not found")
+		return lendingItem, errors.New("not find XDCX lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -3123,7 +3123,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetLendingOrderById(ctx context.Context, 
 	orderIdHash := common.BigToHash(new(big.Int).SetUint64(orderId))
 	lendingItem = lendingState.GetLendingOrder(lendingOrderBook, orderIdHash)
 	if lendingItem.LendingId != orderId {
-		return lendingItem, errors.New("Lending Item not found")
+		return lendingItem, errors.New("not find lending item")
 	}
 	return lendingItem, nil
 }
@@ -3132,11 +3132,11 @@ func (s *PublicXDCXTransactionPoolAPI) GetLendingTradeById(ctx context.Context, 
 	lendingItem := lendingstate.LendingTrade{}
 	block := s.b.CurrentBlock()
 	if block == nil {
-		return lendingItem, errors.New("Current block not found")
+		return lendingItem, errors.New("not find current block")
 	}
 	lendingService := s.b.LendingService()
 	if lendingService == nil {
-		return lendingItem, errors.New("XDCX Lending service not found")
+		return lendingItem, errors.New("not find XDCX Lending service")
 	}
 	author, err := s.b.GetEngine().Author(block.Header())
 	if err != nil {
@@ -3150,7 +3150,7 @@ func (s *PublicXDCXTransactionPoolAPI) GetLendingTradeById(ctx context.Context, 
 	tradeIdHash := common.BigToHash(new(big.Int).SetUint64(tradeId))
 	lendingItem = lendingState.GetLendingTrade(lendingOrderBook, tradeIdHash)
 	if lendingItem.TradeId != tradeId {
-		return lendingItem, errors.New("Lending Item not found")
+		return lendingItem, errors.New("not find lending item")
 	}
 	return lendingItem, nil
 }
@@ -3191,13 +3191,13 @@ type SignTransactionResult struct {
 // the given from address and it needs to be unlocked.
 func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args TransactionArgs) (*SignTransactionResult, error) {
 	if args.Gas == nil {
-		return nil, errors.New("gas not specified")
+		return nil, errors.New("not specify Gas")
 	}
 	if args.GasPrice == nil {
-		return nil, errors.New("gasPrice not specified")
+		return nil, errors.New("not specify GasPrice")
 	}
 	if args.Nonce == nil {
-		return nil, errors.New("nonce not specified")
+		return nil, errors.New("not specify Nonce")
 	}
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err

--- a/internal/jsre/deps/bindata.go
+++ b/internal/jsre/deps/bindata.go
@@ -117,11 +117,11 @@ func Asset(name string) ([]byte, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("Asset %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("can't read Asset %s by error: %v", name, err)
 		}
 		return a.bytes, nil
 	}
-	return nil, fmt.Errorf("Asset %s not found", name)
+	return nil, fmt.Errorf("not found Asset %s", name)
 }
 
 // AssetString returns the asset contents as a string (instead of a []byte).
@@ -155,11 +155,11 @@ func AssetInfo(name string) (os.FileInfo, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return nil, fmt.Errorf("AssetInfo %s can't read by error: %v", name, err)
+			return nil, fmt.Errorf("can't read AssetInfo %s by error: %v", name, err)
 		}
 		return a.info, nil
 	}
-	return nil, fmt.Errorf("AssetInfo %s not found", name)
+	return nil, fmt.Errorf("not found AssetInfo %s", name)
 }
 
 // AssetDigest returns the digest of the file with the given name. It returns an
@@ -169,11 +169,11 @@ func AssetDigest(name string) ([sha256.Size]byte, error) {
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
-			return [sha256.Size]byte{}, fmt.Errorf("AssetDigest %s can't read by error: %v", name, err)
+			return [sha256.Size]byte{}, fmt.Errorf("can't read AssetDigest %s by error: %v", name, err)
 		}
 		return a.digest, nil
 	}
-	return [sha256.Size]byte{}, fmt.Errorf("AssetDigest %s not found", name)
+	return [sha256.Size]byte{}, fmt.Errorf("not found AssetDigest %s", name)
 }
 
 // Digests returns a map of all known files and their checksums.
@@ -230,12 +230,12 @@ func AssetDir(name string) ([]string, error) {
 		for _, p := range pathList {
 			node = node.Children[p]
 			if node == nil {
-				return nil, fmt.Errorf("Asset %s not found", name)
+				return nil, fmt.Errorf("not found Asset %s", name)
 			}
 		}
 	}
 	if node.Func != nil {
-		return nil, fmt.Errorf("Asset %s not found", name)
+		return nil, fmt.Errorf("not found Asset %s", name)
 	}
 	rv := make([]string, 0, len(node.Children))
 	for childName := range node.Children {

--- a/internal/jsre/jsre.go
+++ b/internal/jsre/jsre.go
@@ -294,11 +294,11 @@ func (re *JSRE) loadScript(call Call) (goja.Value, error) {
 	file = common.AbsolutePath(re.assetPath, file)
 	source, err := os.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("Could not read file %s: %v", file, err)
+		return nil, fmt.Errorf("could not read file %s: %v", file, err)
 	}
 	value, err := compileAndRun(re.vm, file, string(source))
 	if err != nil {
-		return nil, fmt.Errorf("Error while compiling or running script: %v", err)
+		return nil, fmt.Errorf("error while compiling or running script: %v", err)
 	}
 	return value, nil
 }

--- a/les/protocol.go
+++ b/les/protocol.go
@@ -161,7 +161,7 @@ func (a *announceData) checkSignature(pubKey *ecdsa.PublicKey) error {
 	if bytes.Equal(pbytes, recPubkey) {
 		return nil
 	} else {
-		return errors.New("Wrong signature")
+		return errors.New("wrong signature")
 	}
 }
 

--- a/les/retrieve.go
+++ b/les/retrieve.go
@@ -119,7 +119,7 @@ func (rm *retrieveManager) retrieve(ctx context.Context, reqID uint64, req *dist
 	case <-ctx.Done():
 		sentReq.stop(ctx.Err())
 	case <-shutdown:
-		sentReq.stop(errors.New("Client is shutting down"))
+		sentReq.stop(errors.New("client is shutting down"))
 	}
 	return sentReq.getError()
 }

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -19,9 +19,10 @@ package light
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"math/big"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/bitutil"
@@ -81,9 +82,9 @@ var trustedCheckpoints = map[common.Hash]trustedCheckpoint{
 }
 
 var (
-	ErrNoTrustedCht       = errors.New("No trusted canonical hash trie")
-	ErrNoTrustedBloomTrie = errors.New("No trusted bloom trie")
-	ErrNoHeader           = errors.New("Header not found")
+	ErrNoTrustedCht       = errors.New("no trusted canonical hash trie")
+	ErrNoTrustedBloomTrie = errors.New("no trusted bloom trie")
+	ErrNoHeader           = errors.New("header not found")
 	chtPrefix             = []byte("chtRoot-") // chtPrefix + chtNum (uint64 big endian) -> trie root hash
 	ChtTablePrefix        = "cht-"
 )

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -353,11 +353,11 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 
 	// check if sender is in black list
 	if tx.From() != nil && common.Blacklist[*tx.From()] {
-		return fmt.Errorf("Reject transaction with sender in black-list: %v", tx.From().Hex())
+		return fmt.Errorf("reject transaction with sender in black-list: %v", tx.From().Hex())
 	}
 	// check if receiver is in black list
 	if tx.To() != nil && common.Blacklist[*tx.To()] {
-		return fmt.Errorf("Reject transaction with receiver in black-list: %v", tx.To().Hex())
+		return fmt.Errorf("reject transaction with receiver in black-list: %v", tx.To().Hex())
 	}
 
 	// validate minFee slot for XDCZ
@@ -423,7 +423,7 @@ func (self *TxPool) add(ctx context.Context, tx *types.Transaction) error {
 	hash := tx.Hash()
 
 	if self.pending[hash] != nil {
-		return fmt.Errorf("Known transaction (%x)", hash[:4])
+		return fmt.Errorf("known transaction (%x)", hash[:4])
 	}
 	err := self.validateTx(ctx, tx)
 	if err != nil {

--- a/log/logger.go
+++ b/log/logger.go
@@ -81,7 +81,7 @@ func LvlFromString(lvlString string) (Lvl, error) {
 	case "crit":
 		return LvlCrit, nil
 	default:
-		return LvlDebug, fmt.Errorf("Unknown level: %v", lvlString)
+		return LvlDebug, fmt.Errorf("unknown level: %v", lvlString)
 	}
 }
 

--- a/metrics/disk_nop.go
+++ b/metrics/disk_nop.go
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+//go:build !linux
 // +build !linux
 
 package metrics
@@ -22,5 +23,5 @@ import "errors"
 
 // ReadDiskStats retrieves the disk IO stats belonging to the current process.
 func ReadDiskStats(stats *DiskStats) error {
-	return errors.New("Not implemented")
+	return errors.New("not implemented")
 }

--- a/metrics/librato/client.go
+++ b/metrics/librato/client.go
@@ -96,7 +96,7 @@ func (self *LibratoClient) PostMetrics(batch Batch) (err error) {
 		if body, err = io.ReadAll(resp.Body); err != nil {
 			body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
 		}
-		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))
+		err = fmt.Errorf("unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))
 	}
 	return
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -158,7 +158,7 @@ func (self *Miner) HashRate() (tot int64) {
 
 func (self *Miner) SetExtra(extra []byte) error {
 	if uint64(len(extra)) > params.MaximumExtraDataSize {
-		return fmt.Errorf("Extra exceeds max length. %d > %v", len(extra), params.MaximumExtraDataSize)
+		return fmt.Errorf("extra exceeds max length: %d > %v", len(extra), params.MaximumExtraDataSize)
 	}
 	self.worker.setExtra(extra)
 	return nil

--- a/miner/remote_agent.go
+++ b/miner/remote_agent.go
@@ -128,7 +128,7 @@ func (a *RemoteAgent) GetWork() ([3]string, error) {
 		a.work[block.HashNoNonce()] = a.currentWork
 		return res, nil
 	}
-	return res, errors.New("No work available yet, don't panic.")
+	return res, errors.New("no work available yet, don't panic")
 }
 
 // SubmitWork tries to inject a pow solution into the remote agent, returning

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -56,7 +56,7 @@ func TestNodeLifeCycle(t *testing.T) {
 		t.Fatalf("failed to start node: %v", err)
 	}
 	if err := stack.Start(); err != ErrNodeRunning {
-		t.Fatalf("start failure mismatch: have %v, want %v ", err, ErrNodeRunning)
+		t.Fatalf("start failure mismatch: have %v, want %v", err, ErrNodeRunning)
 	}
 	// Ensure that a node can be restarted arbitrarily many times
 	for i := 0; i < 3; i++ {
@@ -69,7 +69,7 @@ func TestNodeLifeCycle(t *testing.T) {
 		t.Fatalf("failed to stop node: %v", err)
 	}
 	if err := stack.Stop(); err != ErrNodeStopped {
-		t.Fatalf("stop failure mismatch: have %v, want %v ", err, ErrNodeStopped)
+		t.Fatalf("stop failure mismatch: have %v, want %v", err, ErrNodeStopped)
 	}
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -160,7 +160,7 @@ func (p *Peer) Disconnect(reason DiscReason) {
 
 // String implements fmt.Stringer.
 func (p *Peer) String() string {
-	return fmt.Sprintf("Peer %x %v ", p.rw.id[:8], p.RemoteAddr())
+	return fmt.Sprintf("Peer %x %v", p.rw.id[:8], p.RemoteAddr())
 }
 
 // Inbound returns true if the peer is an inbound connection

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -364,7 +364,7 @@ type sharedUDPConn struct {
 func (s *sharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
 	packet, ok := <-s.unhandled
 	if !ok {
-		return 0, nil, errors.New("Connection was closed")
+		return 0, nil, errors.New("connection was closed")
 	}
 	l := len(packet.Data)
 	if l > len(b) {

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -106,7 +106,7 @@ func (t *BlockTest) Run() error {
 		return err
 	}
 	if gblock.Hash() != t.json.Genesis.Hash {
-		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x\n", gblock.Hash().Bytes(), t.json.Genesis.Hash)
+		return fmt.Errorf("genesis block hash doesn't match test: computed=%x, test=%x", gblock.Hash().Bytes(), t.json.Genesis.Hash)
 	}
 	if gblock.Root() != t.json.Genesis.StateRoot {
 		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", gblock.Root().Bytes(), t.json.Genesis.StateRoot)
@@ -174,7 +174,7 @@ func (t *BlockTest) insertBlocks(blockchain *core.BlockChain) ([]btBlock, error)
 			if b.BlockHeader == nil {
 				continue // OK - block is supposed to be invalid, continue with next block
 			} else {
-				return nil, fmt.Errorf("Block RLP decoding failed when expected to succeed: %v", err)
+				return nil, fmt.Errorf("block RLP decoding failed when expected to succeed: %v", err)
 			}
 		}
 		// RLP decoding worked, try to insert into chain:
@@ -184,16 +184,16 @@ func (t *BlockTest) insertBlocks(blockchain *core.BlockChain) ([]btBlock, error)
 			if b.BlockHeader == nil {
 				continue // OK - block is supposed to be invalid, continue with next block
 			} else {
-				return nil, fmt.Errorf("Block #%v insertion into chain failed: %v", blocks[i].Number(), err)
+				return nil, fmt.Errorf("block #%v insertion into chain failed: %v", blocks[i].Number(), err)
 			}
 		}
 		if b.BlockHeader == nil {
-			return nil, errors.New("Block insertion should have failed")
+			return nil, errors.New("block insertion should have failed")
 		}
 
 		// validate RLP decoding by checking all values against test file JSON
 		if err = validateHeader(b.BlockHeader, cb.Header()); err != nil {
-			return nil, fmt.Errorf("Deserialised block header validation failed: %v", err)
+			return nil, fmt.Errorf("deserialised block header validation failed: %v", err)
 		}
 		validBlocks = append(validBlocks, b)
 	}
@@ -202,49 +202,49 @@ func (t *BlockTest) insertBlocks(blockchain *core.BlockChain) ([]btBlock, error)
 
 func validateHeader(h *btHeader, h2 *types.Header) error {
 	if h.Bloom != h2.Bloom {
-		return fmt.Errorf("Bloom: want: %x have: %x", h.Bloom, h2.Bloom)
+		return fmt.Errorf("mismatch Bloom: want: %x have: %x", h.Bloom, h2.Bloom)
 	}
 	if h.Coinbase != h2.Coinbase {
-		return fmt.Errorf("Coinbase: want: %x have: %x", h.Coinbase, h2.Coinbase)
+		return fmt.Errorf("mismatch Coinbase: want: %x have: %x", h.Coinbase, h2.Coinbase)
 	}
 	if h.MixHash != h2.MixDigest {
-		return fmt.Errorf("MixHash: want: %x have: %x", h.MixHash, h2.MixDigest)
+		return fmt.Errorf("mismatch MixHash: want: %x have: %x", h.MixHash, h2.MixDigest)
 	}
 	if h.Nonce != h2.Nonce {
-		return fmt.Errorf("Nonce: want: %x have: %x", h.Nonce, h2.Nonce)
+		return fmt.Errorf("mismatch Nonce: want: %x have: %x", h.Nonce, h2.Nonce)
 	}
 	if h.Number.Cmp(h2.Number) != 0 {
-		return fmt.Errorf("Number: want: %v have: %v", h.Number, h2.Number)
+		return fmt.Errorf("mismatch Number: want: %v have: %v", h.Number, h2.Number)
 	}
 	if h.ParentHash != h2.ParentHash {
-		return fmt.Errorf("Parent hash: want: %x have: %x", h.ParentHash, h2.ParentHash)
+		return fmt.Errorf("mismatch Parent hash: want: %x have: %x", h.ParentHash, h2.ParentHash)
 	}
 	if h.ReceiptTrie != h2.ReceiptHash {
-		return fmt.Errorf("Receipt hash: want: %x have: %x", h.ReceiptTrie, h2.ReceiptHash)
+		return fmt.Errorf("mismatch Receipt hash: want: %x have: %x", h.ReceiptTrie, h2.ReceiptHash)
 	}
 	if h.TransactionsTrie != h2.TxHash {
-		return fmt.Errorf("Tx hash: want: %x have: %x", h.TransactionsTrie, h2.TxHash)
+		return fmt.Errorf("mismatch tx hash: want: %x have: %x", h.TransactionsTrie, h2.TxHash)
 	}
 	if h.StateRoot != h2.Root {
-		return fmt.Errorf("State hash: want: %x have: %x", h.StateRoot, h2.Root)
+		return fmt.Errorf("mismatch state hash: want: %x have: %x", h.StateRoot, h2.Root)
 	}
 	if h.UncleHash != h2.UncleHash {
-		return fmt.Errorf("Uncle hash: want: %x have: %x", h.UncleHash, h2.UncleHash)
+		return fmt.Errorf("mismatch UncleHash: want: %x have: %x", h.UncleHash, h2.UncleHash)
 	}
 	if !bytes.Equal(h.ExtraData, h2.Extra) {
-		return fmt.Errorf("Extra data: want: %x have: %x", h.ExtraData, h2.Extra)
+		return fmt.Errorf("mismatch ExtraData: want: %x have: %x", h.ExtraData, h2.Extra)
 	}
 	if h.Difficulty.Cmp(h2.Difficulty) != 0 {
-		return fmt.Errorf("Difficulty: want: %v have: %v", h.Difficulty, h2.Difficulty)
+		return fmt.Errorf("mismatch difficulty: want: %v have: %v", h.Difficulty, h2.Difficulty)
 	}
 	if h.GasLimit != h2.GasLimit {
-		return fmt.Errorf("GasLimit: want: %d have: %d", h.GasLimit, h2.GasLimit)
+		return fmt.Errorf("mismatch GasLimit: want: %d have: %d", h.GasLimit, h2.GasLimit)
 	}
 	if h.GasUsed != h2.GasUsed {
-		return fmt.Errorf("GasUsed: want: %d have: %d", h.GasUsed, h2.GasUsed)
+		return fmt.Errorf("mismatch GasUsed: want: %d have: %d", h.GasUsed, h2.GasUsed)
 	}
 	if h.Timestamp.Cmp(h2.Time) != 0 {
-		return fmt.Errorf("Timestamp: want: %v have: %v", h.Timestamp, h2.Time)
+		return fmt.Errorf("mismatch Timestamp: want: %v have: %v", h.Timestamp, h2.Time)
 	}
 	return nil
 }
@@ -282,7 +282,7 @@ func (t *BlockTest) validateImportedHeaders(cm *core.BlockChain, validBlocks []b
 	// be part of the longest chain until last block is imported.
 	for b := cm.CurrentBlock(); b != nil && b.NumberU64() != 0; b = cm.GetBlockByHash(b.Header().ParentHash) {
 		if err := validateHeader(bmap[b.Hash()].BlockHeader, b.Header()); err != nil {
-			return fmt.Errorf("Imported block header validation failed: %v", err)
+			return fmt.Errorf("imported block header validation failed: %v", err)
 		}
 	}
 	return nil

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -83,7 +83,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 		return err
 	}
 	if sender != common.BytesToAddress(tt.json.Sender) {
-		return fmt.Errorf("Sender mismatch: got %x, want %x", sender, tt.json.Sender)
+		return fmt.Errorf("mismatch Sender: got %x, want %x", sender, tt.json.Sender)
 	}
 	// Check decoded fields.
 	err = tt.json.Transaction.verify(signer, tx)
@@ -98,36 +98,36 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 
 func (tt *ttTransaction) verify(signer types.Signer, tx *types.Transaction) error {
 	if !bytes.Equal(tx.Data(), tt.Data) {
-		return fmt.Errorf("Tx input data mismatch: got %x want %x", tx.Data(), tt.Data)
+		return fmt.Errorf("mismatch tx input data: got %x want %x", tx.Data(), tt.Data)
 	}
 	if tx.Gas() != tt.GasLimit {
-		return fmt.Errorf("GasLimit mismatch: got %d, want %d", tx.Gas(), tt.GasLimit)
+		return fmt.Errorf("mismatch GasLimit: got %d, want %d", tx.Gas(), tt.GasLimit)
 	}
 	if tx.GasPrice().Cmp(tt.GasPrice) != 0 {
-		return fmt.Errorf("GasPrice mismatch: got %v, want %v", tx.GasPrice(), tt.GasPrice)
+		return fmt.Errorf("mismatch GasPrice: got %v, want %v", tx.GasPrice(), tt.GasPrice)
 	}
 	if tx.Nonce() != tt.Nonce {
-		return fmt.Errorf("Nonce mismatch: got %v, want %v", tx.Nonce(), tt.Nonce)
+		return fmt.Errorf("mismatch Nonce: got %v, want %v", tx.Nonce(), tt.Nonce)
 	}
 	v, r, s := tx.RawSignatureValues()
 	if r.Cmp(tt.R) != 0 {
-		return fmt.Errorf("R mismatch: got %v, want %v", r, tt.R)
+		return fmt.Errorf("mismatch R: got %v, want %v", r, tt.R)
 	}
 	if s.Cmp(tt.S) != 0 {
-		return fmt.Errorf("S mismatch: got %v, want %v", s, tt.S)
+		return fmt.Errorf("mismatch S: got %v, want %v", s, tt.S)
 	}
 	if v.Cmp(tt.V) != 0 {
-		return fmt.Errorf("V mismatch: got %v, want %v", v, tt.V)
+		return fmt.Errorf("mismatch V: got %v, want %v", v, tt.V)
 	}
 	if tx.To() == nil {
 		if tt.To != (common.Address{}) {
-			return fmt.Errorf("To mismatch when recipient is nil (contract creation): %x", tt.To)
+			return fmt.Errorf("mismatch To when recipient is nil (contract creation): %x", tt.To)
 		}
 	} else if *tx.To() != tt.To {
-		return fmt.Errorf("To mismatch: got %x, want %x", *tx.To(), tt.To)
+		return fmt.Errorf("mismatch To: got %x, want %x", *tx.To(), tt.To)
 	}
 	if tx.Value().Cmp(tt.Value) != 0 {
-		return fmt.Errorf("Value mismatch: got %x, want %x", tx.Value(), tt.Value)
+		return fmt.Errorf("mismatch Value: got %x, want %x", tx.Value(), tt.Value)
 	}
 	return nil
 }

--- a/whisper/whisperv5/whisper.go
+++ b/whisper/whisperv5/whisper.go
@@ -194,7 +194,7 @@ func (w *Whisper) getPeer(peerID []byte) (*Peer, error) {
 			return p, nil
 		}
 	}
-	return nil, fmt.Errorf("Could not find peer with ID: %x", peerID)
+	return nil, fmt.Errorf("could not find peer with ID: %x", peerID)
 }
 
 // AllowP2PMessagesFromPeer marks specific peer trusted,

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -326,7 +326,7 @@ func (whisper *Whisper) getPeer(peerID []byte) (*Peer, error) {
 			return p, nil
 		}
 	}
-	return nil, fmt.Errorf("Could not find peer with ID: %x", peerID)
+	return nil, fmt.Errorf("could not find peer with ID: %x", peerID)
 }
 
 // AllowP2PMessagesFromPeer marks specific peer trusted,


### PR DESCRIPTION
# Proposed changes

This PR fixes staticcheck warning [ST1005 Incorrectly formatted error string](https://staticcheck.dev/docs/checks#ST1005):

Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad"), so that log.Printf("Reading %s: %v", filename, err) formats without a spurious capital letter mid-message.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
