### PR TITLE
all: fix staticcheck warning S1039: unnecessary use of fmt.Sprintf

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -821,7 +821,7 @@ func TestBindings(t *testing.T) {
 	}
 	t.Log("Using config", params.TestXDPoSMockChainConfig)
 	// Skip the test if the go-ethereum sources are symlinked (https://github.com/golang/go/issues/14845)
-	linkTestCode := fmt.Sprintf("package linktest\nfunc CheckSymlinks(){\nfmt.Println(backends.NewSimulatedBackend(nil))\n}")
+	linkTestCode := "package linktest\nfunc CheckSymlinks(){\nfmt.Println(backends.NewSimulatedBackend(nil))\n}"
 	linkTestDeps, err := imports.Process(os.TempDir(), []byte(linkTestCode), nil)
 	if err != nil {
 		t.Fatalf("failed check for goimports symlink bug: %v", err)

--- a/cmd/puppeth/module_explorer.go
+++ b/cmd/puppeth/module_explorer.go
@@ -197,7 +197,7 @@ func checkExplorer(client *sshClient, network string) (*explorerInfos, error) {
 	// Run a sanity check to see if the devp2p is reachable
 	nodePort := infos.portmap[infos.envvars["NODE_PORT"]]
 	if err = checkPort(client.server, nodePort); err != nil {
-		log.Warn(fmt.Sprintf("Explorer devp2p port seems unreachable"), "server", client.server, "port", nodePort, "err", err)
+		log.Warn("Explorer devp2p port seems unreachable", "server", client.server, "port", nodePort, "err", err)
 	}
 	// Assemble and return the useful infos
 	stats := &explorerInfos{

--- a/cmd/puppeth/module_wallet.go
+++ b/cmd/puppeth/module_wallet.go
@@ -181,11 +181,11 @@ func checkWallet(client *sshClient, network string) (*walletInfos, error) {
 	// Run a sanity check to see if the devp2p and RPC ports are reachable
 	nodePort := infos.portmap[infos.envvars["NODE_PORT"]]
 	if err = checkPort(client.server, nodePort); err != nil {
-		log.Warn(fmt.Sprintf("Wallet devp2p port seems unreachable"), "server", client.server, "port", nodePort, "err", err)
+		log.Warn("Wallet devp2p port seems unreachable", "server", client.server, "port", nodePort, "err", err)
 	}
 	rpcPort := infos.portmap["8545/tcp"]
 	if err = checkPort(client.server, rpcPort); err != nil {
-		log.Warn(fmt.Sprintf("Wallet RPC port seems unreachable"), "server", client.server, "port", rpcPort, "err", err)
+		log.Warn("Wallet RPC port seems unreachable", "server", client.server, "port", rpcPort, "err", err)
 	}
 	// Assemble and return the useful infos
 	stats := &walletInfos{

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -648,7 +648,7 @@ loop:
 	}
 	log.Trace("loop stopped")
 
-	log.Debug(fmt.Sprintf("shutting down"))
+	log.Debug("shutting down")
 	if net.conn != nil {
 		net.conn.Close()
 	}

--- a/p2p/discv5/ntp.go
+++ b/p2p/discv5/ntp.go
@@ -51,7 +51,7 @@ func checkClockDrift() {
 	}
 	if drift < -driftThreshold || drift > driftThreshold {
 		warning := fmt.Sprintf("System clock seems off by %v, which can prevent network connectivity", drift)
-		howtofix := fmt.Sprintf("Please enable network time synchronisation in system settings")
+		howtofix := "Please enable network time synchronisation in system settings"
 		separator := strings.Repeat("-", len(warning))
 
 		log.Warn(separator)

--- a/whisper/mailserver/mailserver.go
+++ b/whisper/mailserver/mailserver.go
@@ -159,7 +159,7 @@ func (s *WMailServer) validateRequest(peerID []byte, request *whisper.Envelope) 
 	f := whisper.Filter{KeySym: s.key}
 	decrypted := request.Open(&f)
 	if decrypted == nil {
-		log.Warn(fmt.Sprintf("Failed to decrypt p2p request"))
+		log.Warn("Failed to decrypt p2p request")
 		return false, 0, 0, nil
 	}
 
@@ -171,19 +171,19 @@ func (s *WMailServer) validateRequest(peerID []byte, request *whisper.Envelope) 
 	// if you want to check the signature, you can do it here. e.g.:
 	// if !bytes.Equal(peerID, src) {
 	if src == nil {
-		log.Warn(fmt.Sprintf("Wrong signature of p2p request"))
+		log.Warn("Wrong signature of p2p request")
 		return false, 0, 0, nil
 	}
 
 	var bloom []byte
 	payloadSize := len(decrypted.Payload)
 	if payloadSize < 8 {
-		log.Warn(fmt.Sprintf("Undersized p2p request"))
+		log.Warn("Undersized p2p request")
 		return false, 0, 0, nil
 	} else if payloadSize == 8 {
 		bloom = whisper.MakeFullNodeBloom()
 	} else if payloadSize < 8+whisper.BloomFilterSize {
-		log.Warn(fmt.Sprintf("Undersized bloom filter in p2p request"))
+		log.Warn("Undersized bloom filter in p2p request")
 		return false, 0, 0, nil
 	} else {
 		bloom = decrypted.Payload[8 : 8+whisper.BloomFilterSize]


### PR DESCRIPTION
# Proposed changes

This PR fixes staticcheck warning [S1039: unnecessary use of fmt.Sprintf](https://staticcheck.dev/docs/checks#S1039):

Calling fmt.Sprint with a single string argument is unnecessary and identical to using the string directly.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
