### PR TITLE
fix staticcheck warning SA1012: pass nil Context to function

### DIFF
--- a/contracts/trc21issuer/trc21issuer_test.go
+++ b/contracts/trc21issuer/trc21issuer_test.go
@@ -1,6 +1,7 @@
 package trc21issuer
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -60,7 +61,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 	contractBackend.Commit()
 
 	//check trc21 SMC balance
-	balance, err := contractBackend.BalanceAt(nil, trc21IssuerAddr, nil)
+	balance, err := contractBackend.BalanceAt(context.TODO(), trc21IssuerAddr, nil)
 	if err != nil || balance.Cmp(minApply) != 0 {
 		t.Fatal("can't get balance  in trc21Issuer SMC: ", err, "got", balance, "wanted", minApply)
 	}
@@ -78,7 +79,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 		t.Fatal("can't execute transfer in tr20: ", err)
 	}
 	contractBackend.Commit()
-	receipt, err := contractBackend.TransactionReceipt(nil, tx.Hash())
+	receipt, err := contractBackend.TransactionReceipt(context.TODO(), tx.Hash())
 	if err != nil {
 		t.Fatal("can't transaction's receipt ", err, "hash", tx.Hash())
 	}
@@ -100,7 +101,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 		t.Fatal("check balance token fee in smart contract: got", balanceIssuerFee, "wanted", remainFee)
 	}
 	//check trc21 SMC balance
-	balance, err = contractBackend.BalanceAt(nil, trc21IssuerAddr, nil)
+	balance, err = contractBackend.BalanceAt(context.TODO(), trc21IssuerAddr, nil)
 	if err != nil || balance.Cmp(remainFee) != 0 {
 		t.Fatal("can't get balance token fee in  smart contract: ", err, "got", balanceIssuerFee, "wanted", remainFee)
 	}
@@ -130,7 +131,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 		t.Fatal("check balance after fail transfer in tr20: ", err, "get", balance, "wanted", remainAirDrop)
 	}
 
-	receipt, err = contractBackend.TransactionReceipt(nil, tx.Hash())
+	receipt, err = contractBackend.TransactionReceipt(context.TODO(), tx.Hash())
 	if err != nil {
 		t.Fatal("can't transaction's receipt ", err, "hash", tx.Hash())
 	}
@@ -142,7 +143,7 @@ func TestFeeTxWithTRC21Token(t *testing.T) {
 		t.Fatal("can't get balance token fee in  smart contract: ", err, "got", balanceIssuerFee, "wanted", remainFee)
 	}
 	//check trc21 SMC balance
-	balance, err = contractBackend.BalanceAt(nil, trc21IssuerAddr, nil)
+	balance, err = contractBackend.BalanceAt(context.TODO(), trc21IssuerAddr, nil)
 	if err != nil || balance.Cmp(remainFee) != 0 {
 		t.Fatal("can't get balance token fee in  smart contract: ", err, "got", balanceIssuerFee, "wanted", remainFee)
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -3442,14 +3442,14 @@ func GetSignersFromBlocks(b Backend, blockNumber uint64, blockHash common.Hash, 
 			limitNumber = currentNumber
 		}
 		for i := blockNumber + 1; i <= limitNumber; i++ {
-			header, err := b.HeaderByNumber(nil, rpc.BlockNumber(i))
+			header, err := b.HeaderByNumber(context.TODO(), rpc.BlockNumber(i))
 			if err != nil {
 				return addrs, err
 			}
 			if header == nil {
 				return addrs, errors.New("nil header in GetSignersFromBlocks")
 			}
-			blockData, err := b.BlockByNumber(nil, rpc.BlockNumber(i))
+			blockData, err := b.BlockByNumber(context.TODO(), rpc.BlockNumber(i))
 			if err != nil {
 				return addrs, err
 			}


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA1012: pass nil context.Context to a function](https://staticcheck.dev/docs/checks#SA1012):

A nil context.Context is being passed to a function, consider using context.TODO instead

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
