### PR TITLE
all: fix staticcheck warning SA1006

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -86,10 +86,10 @@ func SimulateWalletAddressAndSignFn() (common.Address, func(account accounts.Acc
 	pass := "" // not used but required by API
 	a1, err := ks.NewAccount(pass)
 	if err != nil {
-		return common.Address{}, nil, fmt.Errorf(err.Error())
+		return common.Address{}, nil, err
 	}
 	if err := ks.Unlock(a1, ""); err != nil {
-		return a1.Address, nil, fmt.Errorf(err.Error())
+		return a1.Address, nil, err
 	}
 	return a1.Address, ks.SignHash, nil
 }

--- a/consensus/XDPoS/engines/engine_v2/forensics_test.go
+++ b/consensus/XDPoS/engines/engine_v2/forensics_test.go
@@ -58,10 +58,10 @@ func getSignerAndSignFn(pk *ecdsa.PrivateKey) (common.Address, func(account acco
 	pass := "" // not used but required by API
 	a1, err := ks.ImportECDSA(pk, pass)
 	if err != nil {
-		return common.Address{}, nil, fmt.Errorf(err.Error())
+		return common.Address{}, nil, err
 	}
 	if err := ks.Unlock(a1, ""); err != nil {
-		return a1.Address, nil, fmt.Errorf(err.Error())
+		return a1.Address, nil, err
 	}
 	return a1.Address, ks.SignHash, nil
 }

--- a/consensus/tests/engine_v2_tests/helper.go
+++ b/consensus/tests/engine_v2_tests/helper.go
@@ -88,10 +88,10 @@ func getSignerAndSignFn(pk *ecdsa.PrivateKey) (common.Address, func(account acco
 	pass := "" // not used but required by API
 	a1, err := ks.ImportECDSA(pk, pass)
 	if err != nil {
-		return common.Address{}, nil, fmt.Errorf(err.Error())
+		return common.Address{}, nil, err
 	}
 	if err := ks.Unlock(a1, ""); err != nil {
-		return a1.Address, nil, fmt.Errorf(err.Error())
+		return a1.Address, nil, err
 	}
 	return a1.Address, ks.SignHash, nil
 }

--- a/metrics/json_test.go
+++ b/metrics/json_test.go
@@ -13,7 +13,7 @@ func TestRegistryMarshallJSON(t *testing.T) {
 	r.Register("counter", NewCounter())
 	enc.Encode(r)
 	if s := b.String(); s != "{\"counter\":{\"count\":0}}\n" {
-		t.Fatalf(s)
+		t.Fatal(s)
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA1006: Printf with dynamic first argument and no further arguments](https://staticcheck.dev/docs/checks#SA1006):

Using fmt.Printf with a dynamic first argument can lead to unexpected output. The first argument is a format string, where certain character combinations have special meaning. If, for example, a user were to enter a string such as

```text
Interest rate: 5%
```

and you printed it with

```go
fmt.Printf(s)
```

it would lead to the following output:

```text
Interest rate: 5%!(NOVERB).
```

Similarly, forming the first parameter via string concatenation with user input should be avoided for the same reason. When printing user input, either use a variant of fmt.Print, or use the %s Printf verb and pass the string as an argument.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
