### PR TITLE
all: fix staticcheck warning SA4010: append result never used

### DIFF
--- a/XDCxlending/lendingstate/statedb_test.go
+++ b/XDCxlending/lendingstate/statedb_test.go
@@ -18,10 +18,11 @@ package lendingstate
 
 import (
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/common"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"math/big"
 	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 )
 
 func TestEchangeStates(t *testing.T) {
@@ -225,9 +226,7 @@ func TestDumpStates(t *testing.T) {
 	orderBook := common.StringToHash("BTC/XDC")
 	numberOrder := 20
 	orderItems := []LendingItem{}
-	relayers := []common.Hash{}
 	for i := 0; i < numberOrder; i++ {
-		relayers = append(relayers, common.BigToHash(big.NewInt(int64(i))))
 		id := new(big.Int).SetUint64(uint64(i) + 1)
 		orderItems = append(orderItems, LendingItem{LendingId: id.Uint64(), Quantity: big.NewInt(int64(2*i + 1)), Interest: big.NewInt(1), Side: Investing, Signature: &Signature{V: 1, R: common.HexToHash("111111"), S: common.HexToHash("222222222222")}})
 		orderItems = append(orderItems, LendingItem{LendingId: id.Uint64(), Quantity: big.NewInt(int64(2*i + 1)), Interest: big.NewInt(1), Side: Borrowing, Signature: &Signature{V: 1, R: common.HexToHash("3333333333"), S: common.HexToHash("22222222222222222")}})

--- a/bmt/bmt.go
+++ b/bmt/bmt.go
@@ -196,11 +196,8 @@ type Tree struct {
 func (t *Tree) Draw(hash []byte, d int) string {
 	var left, right []string
 	var anc []*Node
-	for i, n := range t.leaves {
+	for _, n := range t.leaves {
 		left = append(left, fmt.Sprintf("%v", hashstr(n.left)))
-		if i%2 == 0 {
-			anc = append(anc, n.parent)
-		}
 		right = append(right, fmt.Sprintf("%v", hashstr(n.right)))
 	}
 	anc = t.leaves

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -769,7 +769,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&txs); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		var unkownTxs []*types.Transaction
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction
@@ -778,9 +777,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 			p.MarkTransaction(tx.Hash())
 			exist, _ := pm.knownTxs.ContainsOrAdd(tx.Hash(), true)
-			if !exist {
-				unkownTxs = append(unkownTxs, tx)
-			} else {
+			if exist {
 				log.Trace("Discard known tx", "hash", tx.Hash(), "nonce", tx.Nonce(), "to", tx.To())
 			}
 
@@ -797,7 +794,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&txs); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		var unkownOrderTxs []*types.OrderTransaction
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction
@@ -806,9 +802,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 			p.MarkOrderTransaction(tx.Hash())
 			exist, _ := pm.knowOrderTxs.ContainsOrAdd(tx.Hash(), true)
-			if !exist {
-				unkownOrderTxs = append(unkownOrderTxs, tx)
-			} else {
+			if exist {
 				log.Trace("Discard known tx", "hash", tx.Hash(), "nonce", tx.Nonce())
 			}
 
@@ -828,7 +822,6 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&txs); err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
-		var unkownLendingTxs []*types.LendingTransaction
 
 		for i, tx := range txs {
 			// Validate and mark the remote transaction
@@ -837,9 +830,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 			p.MarkLendingTransaction(tx.Hash())
 			exist, _ := pm.knowLendingTxs.ContainsOrAdd(tx.Hash(), true)
-			if !exist {
-				unkownLendingTxs = append(unkownLendingTxs, tx)
-			} else {
+			if exist {
 				log.Trace("Discard known tx", "hash", tx.Hash(), "nonce", tx.Nonce())
 			}
 


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA4010](https://staticcheck.dev/docs/checks#SA4010):

The result of append will never be observed anywhere

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
