### PR TITLE
fix: staticcheck warning SA4003: every value of uint64 >= 0

### DIFF
--- a/eth/hooks/engine_v1_hooks.go
+++ b/eth/hooks/engine_v1_hooks.go
@@ -30,43 +30,42 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 			log.Crit("Can't get state at head of canonical chain", "head number", bc.CurrentHeader().Number.Uint64(), "err", err)
 		}
 		prevEpoc := blockNumberEpoc - chain.Config().XDPoS.Epoch
-		if prevEpoc >= 0 {
-			start := time.Now()
-			prevHeader := chain.GetHeaderByNumber(prevEpoc)
-			penSigners := adaptor.GetMasternodes(chain, prevHeader)
-			if len(penSigners) > 0 {
-				// Loop for each block to check missing sign.
-				for i := prevEpoc; i < blockNumberEpoc; i++ {
-					if i%common.MergeSignRange == 0 || !chainConfig.IsTIP2019(big.NewInt(int64(i))) {
-						bheader := chain.GetHeaderByNumber(i)
-						bhash := bheader.Hash()
-						block := chain.GetBlock(bhash, i)
-						if len(penSigners) > 0 {
-							signedMasternodes, err := contracts.GetSignersFromContract(canonicalState, block)
-							if err != nil {
-								return nil, err
-							}
-							if len(signedMasternodes) > 0 {
-								// Check signer signed?
-								for _, signed := range signedMasternodes {
-									for j, addr := range penSigners {
-										if signed == addr {
-											// Remove it from dupSigners.
-											penSigners = append(penSigners[:j], penSigners[j+1:]...)
-										}
+
+		start := time.Now()
+		prevHeader := chain.GetHeaderByNumber(prevEpoc)
+		penSigners := adaptor.GetMasternodes(chain, prevHeader)
+		if len(penSigners) > 0 {
+			// Loop for each block to check missing sign.
+			for i := prevEpoc; i < blockNumberEpoc; i++ {
+				if i%common.MergeSignRange == 0 || !chainConfig.IsTIP2019(big.NewInt(int64(i))) {
+					bheader := chain.GetHeaderByNumber(i)
+					bhash := bheader.Hash()
+					block := chain.GetBlock(bhash, i)
+					if len(penSigners) > 0 {
+						signedMasternodes, err := contracts.GetSignersFromContract(canonicalState, block)
+						if err != nil {
+							return nil, err
+						}
+						if len(signedMasternodes) > 0 {
+							// Check signer signed?
+							for _, signed := range signedMasternodes {
+								for j, addr := range penSigners {
+									if signed == addr {
+										// Remove it from dupSigners.
+										penSigners = append(penSigners[:j], penSigners[j+1:]...)
 									}
 								}
 							}
-						} else {
-							break
 						}
+					} else {
+						break
 					}
 				}
 			}
-			log.Debug("Time Calculated HookPenalty ", "block", blockNumberEpoc, "time", common.PrettyDuration(time.Since(start)))
-			return penSigners, nil
 		}
-		return []common.Address{}, nil
+		log.Debug("Time Calculated HookPenalty ", "block", blockNumberEpoc, "time", common.PrettyDuration(time.Since(start)))
+		return penSigners, nil
+
 	}
 
 	// Hook scans for bad masternodes and decide to penalty them
@@ -77,105 +76,104 @@ func AttachConsensusV1Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 		if header.Number.Uint64() > comebackLength {
 			combackEpoch = header.Number.Uint64() - comebackLength
 		}
-		if prevEpoc >= 0 {
-			start := time.Now()
 
-			listBlockHash := make([]common.Hash, chain.Config().XDPoS.Epoch)
+		start := time.Now()
 
-			// get list block hash & stats total created block
-			statMiners := make(map[common.Address]int)
-			listBlockHash[0] = header.ParentHash
-			parentnumber := header.Number.Uint64() - 1
-			parentHash := header.ParentHash
-			for i := uint64(1); i < chain.Config().XDPoS.Epoch; i++ {
-				parentHeader := chain.GetHeader(parentHash, parentnumber)
-				miner, _ := adaptor.RecoverSigner(parentHeader)
-				value, exist := statMiners[miner]
-				if exist {
-					value = value + 1
-				} else {
-					value = 1
-				}
-				statMiners[miner] = value
-				parentHash = parentHeader.ParentHash
-				parentnumber--
-				listBlockHash[i] = parentHash
+		listBlockHash := make([]common.Hash, chain.Config().XDPoS.Epoch)
+
+		// get list block hash & stats total created block
+		statMiners := make(map[common.Address]int)
+		listBlockHash[0] = header.ParentHash
+		parentnumber := header.Number.Uint64() - 1
+		parentHash := header.ParentHash
+		for i := uint64(1); i < chain.Config().XDPoS.Epoch; i++ {
+			parentHeader := chain.GetHeader(parentHash, parentnumber)
+			miner, _ := adaptor.RecoverSigner(parentHeader)
+			value, exist := statMiners[miner]
+			if exist {
+				value = value + 1
+			} else {
+				value = 1
 			}
+			statMiners[miner] = value
+			parentHash = parentHeader.ParentHash
+			parentnumber--
+			listBlockHash[i] = parentHash
+		}
 
-			// add list not miner to penalties
-			prevHeader := chain.GetHeaderByNumber(prevEpoc)
-			preMasternodes := adaptor.GetMasternodes(chain, prevHeader)
-			penalties := []common.Address{}
-			for miner, total := range statMiners {
-				if total < common.MinimunMinerBlockPerEpoch {
-					log.Debug("Find a node not enough requirement create block", "addr", miner.Hex(), "total", total)
-					penalties = append(penalties, miner)
-				}
+		// add list not miner to penalties
+		prevHeader := chain.GetHeaderByNumber(prevEpoc)
+		preMasternodes := adaptor.GetMasternodes(chain, prevHeader)
+		penalties := []common.Address{}
+		for miner, total := range statMiners {
+			if total < common.MinimunMinerBlockPerEpoch {
+				log.Debug("Find a node not enough requirement create block", "addr", miner.Hex(), "total", total)
+				penalties = append(penalties, miner)
 			}
-			for _, addr := range preMasternodes {
-				if _, exist := statMiners[addr]; !exist {
-					log.Debug("Find a node don't create block", "addr", addr.Hex())
-					penalties = append(penalties, addr)
-				}
+		}
+		for _, addr := range preMasternodes {
+			if _, exist := statMiners[addr]; !exist {
+				log.Debug("Find a node don't create block", "addr", addr.Hex())
+				penalties = append(penalties, addr)
 			}
+		}
 
-			// get list check penalties signing block & list master nodes wil comeback
-			penComebacks := []common.Address{}
-			if combackEpoch > 0 {
-				combackHeader := chain.GetHeaderByNumber(combackEpoch)
-				penalties := common.ExtractAddressFromBytes(combackHeader.Penalties)
-				for _, penaltie := range penalties {
-					for _, addr := range candidates {
-						if penaltie == addr {
-							penComebacks = append(penComebacks, penaltie)
-						}
+		// get list check penalties signing block & list master nodes wil comeback
+		penComebacks := []common.Address{}
+		if combackEpoch > 0 {
+			combackHeader := chain.GetHeaderByNumber(combackEpoch)
+			penalties := common.ExtractAddressFromBytes(combackHeader.Penalties)
+			for _, penaltie := range penalties {
+				for _, addr := range candidates {
+					if penaltie == addr {
+						penComebacks = append(penComebacks, penaltie)
 					}
 				}
 			}
+		}
 
-			// Loop for each block to check missing sign. with comeback nodes
-			mapBlockHash := map[common.Hash]bool{}
-			for i := common.RangeReturnSigner - 1; i >= 0; i-- {
-				if len(penComebacks) > 0 {
-					blockNumber := header.Number.Uint64() - uint64(i) - 1
-					bhash := listBlockHash[i]
-					if blockNumber%common.MergeSignRange == 0 {
-						mapBlockHash[bhash] = true
-					}
-					signData, ok := adaptor.GetCachedSigningTxs(bhash)
-					if !ok {
-						block := chain.GetBlock(bhash, blockNumber)
-						txs := block.Transactions()
-						signData = adaptor.CacheSigningTxs(bhash, txs)
-					}
-					txs := signData.([]*types.Transaction)
-					// Check signer signed?
-					for _, tx := range txs {
-						blkHash := common.BytesToHash(tx.Data()[len(tx.Data())-32:])
-						from := *tx.From()
-						if mapBlockHash[blkHash] {
-							for j, addr := range penComebacks {
-								if from == addr {
-									// Remove it from dupSigners.
-									penComebacks = append(penComebacks[:j], penComebacks[j+1:]...)
-									break
-								}
+		// Loop for each block to check missing sign. with comeback nodes
+		mapBlockHash := map[common.Hash]bool{}
+		for i := common.RangeReturnSigner - 1; i >= 0; i-- {
+			if len(penComebacks) > 0 {
+				blockNumber := header.Number.Uint64() - uint64(i) - 1
+				bhash := listBlockHash[i]
+				if blockNumber%common.MergeSignRange == 0 {
+					mapBlockHash[bhash] = true
+				}
+				signData, ok := adaptor.GetCachedSigningTxs(bhash)
+				if !ok {
+					block := chain.GetBlock(bhash, blockNumber)
+					txs := block.Transactions()
+					signData = adaptor.CacheSigningTxs(bhash, txs)
+				}
+				txs := signData.([]*types.Transaction)
+				// Check signer signed?
+				for _, tx := range txs {
+					blkHash := common.BytesToHash(tx.Data()[len(tx.Data())-32:])
+					from := *tx.From()
+					if mapBlockHash[blkHash] {
+						for j, addr := range penComebacks {
+							if from == addr {
+								// Remove it from dupSigners.
+								penComebacks = append(penComebacks[:j], penComebacks[j+1:]...)
+								break
 							}
 						}
 					}
-				} else {
-					break
 				}
+			} else {
+				break
 			}
-
-			log.Debug("Time Calculated HookPenaltyTIPSigning ", "block", header.Number, "hash", header.Hash().Hex(), "pen comeback nodes", len(penComebacks), "not enough miner", len(penalties), "time", common.PrettyDuration(time.Since(start)))
-			penalties = append(penalties, penComebacks...)
-			if chain.Config().IsTIPRandomize(header.Number) {
-				return penalties, nil
-			}
-			return penComebacks, nil
 		}
-		return []common.Address{}, nil
+
+		log.Debug("Time Calculated HookPenaltyTIPSigning ", "block", header.Number, "hash", header.Hash().Hex(), "pen comeback nodes", len(penComebacks), "not enough miner", len(penalties), "time", common.PrettyDuration(time.Since(start)))
+		penalties = append(penalties, penComebacks...)
+		if chain.Config().IsTIPRandomize(header.Number) {
+			return penalties, nil
+		}
+
+		return penComebacks, nil
 	}
 
 	// Hook prepares validators M2 for the current epoch at checkpoint block

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -1230,7 +1230,7 @@ func (net *Network) checkTopicRegister(data *topicRegister) (*pong, error) {
 	if rlpHash(data.Topics) != pongpkt.data.(*pong).TopicHash {
 		return nil, errors.New("topic hash mismatch")
 	}
-	if data.Idx < 0 || int(data.Idx) >= len(data.Topics) {
+	if int(data.Idx) >= len(data.Topics) {
 		return nil, errors.New("topic index out of range")
 	}
 	return pongpkt.data.(*pong), nil

--- a/p2p/discv5/nodeevent_string.go
+++ b/p2p/discv5/nodeevent_string.go
@@ -16,7 +16,7 @@ var (
 
 func (i nodeEvent) String() string {
 	switch {
-	case 0 <= i && i <= 8:
+	case i <= 8:
 		return _nodeEvent_name_0[_nodeEvent_index_0[i]:_nodeEvent_index_0[i+1]]
 	case 265 <= i && i <= 267:
 		i -= 265


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA4003](https://staticcheck.dev/docs/checks#SA4003):

Comparing unsigned values against negative values is pointless

- every value of type uint64 is >= 0
- no value of type uint is less than 0

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
