### PR TITLE
core, XDCxlending/lendingstate: fix staticcheck warning SA5001

### DIFF
--- a/XDCxlending/lendingstate/lendingitem_test.go
+++ b/XDCxlending/lendingstate/lendingitem_test.go
@@ -515,11 +515,11 @@ func Test_CreateOrder(t *testing.T) {
 
 func sendOrder(nonce uint64) {
 	rpcClient, err := rpc.DialHTTP("http://localhost:8501")
-	defer rpcClient.Close()
 	if err != nil {
 		fmt.Println("rpc.DialHTTP failed", "err", err)
 		os.Exit(1)
 	}
+	defer rpcClient.Close()
 	rand.Seed(time.Now().UTC().UnixNano())
 	item := &LendingOrderMsg{
 		AccountNonce:    nonce,

--- a/core/lending_pool_test.go
+++ b/core/lending_pool_test.go
@@ -46,10 +46,10 @@ type LendingMsg struct {
 
 func getLendingNonce(userAddress common.Address) (uint64, error) {
 	rpcClient, err := rpc.DialHTTP("http://127.0.0.1:8501")
-	defer rpcClient.Close()
 	if err != nil {
 		return 0, err
 	}
+	defer rpcClient.Close()
 	var result interface{}
 	err = rpcClient.Call(&result, "XDCx_getLendingOrderCount", userAddress)
 	if err != nil {

--- a/core/order_pool_test.go
+++ b/core/order_pool_test.go
@@ -55,10 +55,10 @@ var (
 
 func getNonce(t *testing.T, userAddress common.Address) (uint64, error) {
 	rpcClient, err := rpc.DialHTTP("http://127.0.0.1:8501")
-	defer rpcClient.Close()
 	if err != nil {
 		return 0, err
 	}
+	defer rpcClient.Close()
 	var result interface{}
 	err = rpcClient.Call(&result, "XDCx_getOrderCount", userAddress)
 	if err != nil {


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA5001 Deferring Close before checking for a possible error](https://staticcheck.dev/docs/checks#SA5001):

should check error returned from rpc.DialHTTP() before deferring rpcClient.Close()

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
