### PR TITLE
all: fix staticcheck warning SA2002: must call T.Fatalf in same goroutine

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -986,14 +986,17 @@ func TestCanonicalBlockRetrieval(t *testing.T) {
 					continue // busy wait for canonical hash to be written
 				}
 				if ch != block.Hash() {
-					t.Fatalf("unknown canonical hash, want %s, got %s", block.Hash().Hex(), ch.Hex())
+					t.Errorf("unknown canonical hash, want %s, got %s", block.Hash().Hex(), ch.Hex())
+					return
 				}
 				fb := GetBlock(blockchain.db, ch, block.NumberU64())
 				if fb == nil {
-					t.Fatalf("unable to retrieve block %d for canonical hash: %s", block.NumberU64(), ch.Hex())
+					t.Errorf("unable to retrieve block %d for canonical hash: %s", block.NumberU64(), ch.Hex())
+					return
 				}
 				if fb.Hash() != block.Hash() {
-					t.Fatalf("invalid block hash for block %d, want %s, got %s", block.NumberU64(), block.Hash().Hex(), fb.Hash().Hex())
+					t.Errorf("invalid block hash for block %d, want %s, got %s", block.NumberU64(), block.Hash().Hex(), fb.Hash().Hex())
+					return
 				}
 				return
 			}

--- a/p2p/simulations/mocker_test.go
+++ b/p2p/simulations/mocker_test.go
@@ -80,14 +80,17 @@ func TestMocker(t *testing.T) {
 	var opts SubscribeOpts
 	sub, err := client.SubscribeNetwork(events, opts)
 	defer sub.Unsubscribe()
-	//wait until all nodes are started and connected
-	//store every node up event in a map (value is irrelevant, mimic Set datatype)
+
+	// wait until all nodes are started and connected
+	// store every node up event in a map (value is irrelevant, mimic Set datatype)
 	nodemap := make(map[discover.NodeID]bool)
-	wg.Add(1)
 	nodesComplete := false
 	connCount := 0
+	wg.Add(1)
 	go func() {
-		for {
+		defer wg.Done()
+
+		for connCount < (nodeCount-1)*2 {
 			select {
 			case event := <-events:
 				//if the event is a node Up event only
@@ -102,14 +105,10 @@ func TestMocker(t *testing.T) {
 					}
 				} else if event.Conn != nil && nodesComplete {
 					connCount += 1
-					if connCount == (nodeCount-1)*2 {
-						wg.Done()
-						return
-					}
 				}
 			case <-time.After(30 * time.Second):
-				wg.Done()
-				t.Fatalf("Timeout waiting for nodes being started up!")
+				t.Errorf("Timeout waiting for nodes being started up!")
+				return
 			}
 		}
 	}()

--- a/whisper/whisperv6/peer_test.go
+++ b/whisper/whisperv6/peer_test.go
@@ -23,7 +23,6 @@ import (
 	mrand "math/rand"
 	"net"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -72,7 +71,6 @@ var keys = []string{
 }
 
 type TestData struct {
-	started int64
 	counter [NumNodes]int
 	mutex   sync.RWMutex
 }
@@ -226,14 +224,9 @@ func initialize(t *testing.T) {
 			},
 		}
 
+		startServer(t, node.server)
 		nodes[i] = &node
 	}
-
-	for i := 0; i < NumNodes; i++ {
-		go startServer(t, nodes[i].server)
-	}
-
-	waitForServersToStart(t)
 }
 
 func startServer(t *testing.T, s *p2p.Server) {
@@ -241,8 +234,6 @@ func startServer(t *testing.T, s *p2p.Server) {
 	if err != nil {
 		t.Fatalf("failed to start the fisrt server.")
 	}
-
-	atomic.AddInt64(&result.started, 1)
 }
 
 func stopServers() {
@@ -499,17 +490,4 @@ func checkBloomFilterExchange(t *testing.T) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-}
-
-func waitForServersToStart(t *testing.T) {
-	const iterations = 200
-	var started int64
-	for j := 0; j < iterations; j++ {
-		time.Sleep(50 * time.Millisecond)
-		started = atomic.LoadInt64(&result.started)
-		if started == NumNodes {
-			return
-		}
-	}
-	t.Fatalf("Failed to start all the servers, running: %d", started)
 }


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA2002](https://staticcheck.dev/docs/checks#SA2002):

Called testing.T.FailNow or SkipNow in a goroutine, which isn’t allowed

the goroutine calls T.Fatalf, which must be called in the same goroutine as the test

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
