### PR TITLE
metrics/influxdb: fix staticcheck warning SA1015: replace time.Tick with time.NewTicker

### DIFF
--- a/metrics/influxdb/influxdb.go
+++ b/metrics/influxdb/influxdb.go
@@ -69,16 +69,19 @@ func (r *reporter) makeClient() (err error) {
 }
 
 func (r *reporter) run() {
-	intervalTicker := time.Tick(r.interval)
-	pingTicker := time.Tick(time.Second * 5)
+	intervalTicker := time.NewTicker(r.interval)
+	pingTicker := time.NewTicker(time.Second * 5)
+
+	defer intervalTicker.Stop()
+	defer pingTicker.Stop()
 
 	for {
 		select {
-		case <-intervalTicker:
+		case <-intervalTicker.C:
 			if err := r.send(); err != nil {
 				log.Printf("unable to send to InfluxDB. err=%v", err)
 			}
-		case <-pingTicker:
+		case <-pingTicker.C:
 			_, _, err := r.client.Ping()
 			if err != nil {
 				log.Printf("got error while sending a ping to InfluxDB, trying to recreate client. err=%v", err)


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA1015](https://staticcheck.dev/docs/checks#SA1015):

using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here.

Before Go 1.23, time.Tickers had to be closed to be able to be garbage collected. Since time.Tick doesn’t make it possible to close the underlying ticker, using it repeatedly would leak memory.

Go 1.23 fixes this by allowing tickers to be collected even if they weren’t closed.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
