### PR TITLE
XDCxlending: fix staticcheck warning S1008: simplify returning boolean expression

### DIFF
--- a/XDCxlending/XDCxlending.go
+++ b/XDCxlending/XDCxlending.go
@@ -684,10 +684,7 @@ func (l *Lending) HasLendingState(block *types.Block, author common.Address) boo
 		return false
 	}
 	_, err = l.StateCache.OpenTrie(root)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func (l *Lending) GetTriegc() *prque.Prque {

--- a/XDCxlending/lendingstate/relayer.go
+++ b/XDCxlending/lendingstate/relayer.go
@@ -41,10 +41,7 @@ func IsResignedRelayer(relayer common.Address, statedb *state.StateDB) bool {
 	slot := RelayerMappingSlot["RESIGN_REQUESTS"]
 	locBig := GetLocMappingAtKey(relayer.Hash(), slot)
 	locHash := common.BigToHash(locBig)
-	if statedb.GetState(common.HexToAddress(common.RelayerRegistrationSMC), locHash) != (common.Hash{}) {
-		return true
-	}
-	return false
+	return statedb.GetState(common.HexToAddress(common.RelayerRegistrationSMC), locHash) != (common.Hash{})
 }
 
 func GetBaseTokenLength(relayer common.Address, statedb *state.StateDB) uint64 {


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [S1008: simplify returning boolean expression](https://staticcheck.dev/docs/checks#S1008):

Before:

```go
if <expr> {
    return true
}
return false
```

After:

```go
return <expr>
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
