### PR TITLE
core, XDCxlending/lendingstate: fix staticcheck warning S1002: omit comparison to bool constant

### DIFF
--- a/XDCxlending/lendingstate/lendingitem.go
+++ b/XDCxlending/lendingstate/lendingitem.go
@@ -207,7 +207,7 @@ func (l *LendingItem) VerifyLendingItem(state *state.StateDB) error {
 	if err := l.VerifyLendingStatus(); err != nil {
 		return err
 	}
-	if valid, _ := IsValidPair(state, l.Relayer, l.LendingToken, l.Term); valid == false {
+	if valid, _ := IsValidPair(state, l.Relayer, l.LendingToken, l.Term); !valid {
 		return fmt.Errorf("invalid pair . LendToken %s . Term: %v", l.LendingToken.Hex(), l.Term)
 	}
 	if l.Status == LendingStatusNew {

--- a/core/lending_pool.go
+++ b/core/lending_pool.go
@@ -598,7 +598,7 @@ func (pool *LendingPool) validateLending(tx *types.LendingTransaction) error {
 	if !lendingstate.IsValidRelayer(cloneStateDb, tx.RelayerAddress()) {
 		return fmt.Errorf("invalid lending relayer. ExchangeAddress: %s", tx.RelayerAddress().Hex())
 	}
-	if valid, _ := lendingstate.IsValidPair(cloneStateDb, tx.RelayerAddress(), tx.LendingToken(), tx.Term()); valid == false {
+	if valid, _ := lendingstate.IsValidPair(cloneStateDb, tx.RelayerAddress(), tx.LendingToken(), tx.Term()); !valid {
 		return fmt.Errorf("invalid pair. Relayer: %s. LendingToken: %s. Term: %d", tx.RelayerAddress().Hex(), tx.LendingToken().Hex(), tx.Term())
 	}
 	if tx.IsCreatedLending() {


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [S1002: omit comparison to bool constant](https://staticcheck.dev/docs/checks#S1002):

Before:

```go
if x == true {}
```

After:

```
if x {}
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
