### PR TITLE
crypto/bn256: fix staticcheck warning SA9009: ineffectual go compiler directive

### DIFF
--- a/crypto/bn256/cloudflare/gfp_decl.go
+++ b/crypto/bn256/cloudflare/gfp_decl.go
@@ -1,3 +1,4 @@
+//go:build (amd64 && !generic) || (arm64 && !generic)
 // +build amd64,!generic arm64,!generic
 
 package bn256
@@ -9,10 +10,10 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-//nolint:varcheck
+//nolint:varcheck,unused,deadcode
 var hasBMI2 = cpu.X86.HasBMI2
 
-// go:noescape
+//go:noescape
 func gfpNeg(c, a *gfP)
 
 //go:noescape


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA9009: ineffectual compiler directive](https://staticcheck.dev/docs/checks#SA9009):

A potential Go compiler directive was found, but is ineffectual as it begins with whitespace.

crypto/bn256/cloudflare/gfp_decl.go:15:1: ineffectual compiler directive due to extraneous space: "// go:noescape" (SA9009)

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
