### PR TITLE
core: fix staticcheck warning SA6005: should use strings.EqualFold

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -389,7 +389,7 @@ func applyTransaction(config *params.ChainConfig, tokensFee map[common.Address]*
 
 		currentBlockNumber := blockNumber.Int64()
 		if addr, ok := blockMap[currentBlockNumber]; ok {
-			if strings.ToLower(addr) == strings.ToLower(addrFrom) {
+			if strings.EqualFold(addr, addrFrom) { // case insensitive
 				bal := addrMap[addr]
 				hBalance := new(big.Int)
 				hBalance.SetString(bal+"000000000000000000", 10)


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [SA6005: should use strings.EqualFold](https://staticcheck.dev/docs/checks#SA6005):

Converting two strings to the same case and comparing them like so

```go
if strings.ToLower(s1) == strings.ToLower(s2) {
    ...
}
```

is significantly more expensive than comparing them with `strings.EqualFold(s1, s2)`. This is due to memory usage as well as computational complexity.

`strings.ToLower` will have to allocate memory for the new strings, as well as convert both strings fully, even if they differ on the very first byte. `strings.EqualFold`, on the other hand, compares the strings one character at a time. It doesn’t need to create two intermediate strings and can return as soon as the first non-matching character has been found.

For a more in-depth explanation of this issue, see https://blog.digitalocean.com/how-to-efficiently-compare-strings-in-go/

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
