### PR TITLE
 XDCxDAO: fix staticcheck warning SA5007: infinite recursive call

### DIFF
--- a/XDCxDAO/mongodb.go
+++ b/XDCxDAO/mongodb.go
@@ -825,7 +825,10 @@ func (db *MongoDatabase) EnsureIndexes() error {
 }
 
 func (db *MongoDatabase) Close() error {
-	return db.Close()
+	if db.Session != nil {
+		db.Session.Close()
+	}
+	return nil
 }
 
 // HasAncient returns an error as we don't have a backing chain freezer.


### PR DESCRIPTION
# Proposed changes

This PR fixes the  staticcheck warning [SA5007: infinite recursive call](https://staticcheck.dev/docs/checks#SA5007):

A function that calls itself recursively needs to have an exit condition. Otherwise it will recurse forever, until the system runs out of memory.

This issue can be caused by simple bugs such as forgetting to add an exit condition. It can also happen “on purpose”. Some languages have tail call optimization which makes certain infinite recursive calls safe to use. Go, however, does not implement TCO, and as such a loop should be used instead.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
