### PR TITLE
contracts: fix staticcheck warning S1025: unnecessary fmt.Sprintf("%s", x) 

### DIFF
--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -556,7 +556,7 @@ func Decrypt(key []byte, cryptoText string) string {
 	// XORKeyStream can work in-place if the two arguments are the same.
 	stream.XORKeyStream(ciphertext, ciphertext)
 
-	return fmt.Sprintf("%s", ciphertext)
+	return string(ciphertext[:])
 }
 
 // Generate random string.


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [S1025: unnecessary fmt.Sprintf("%s", x)](https://staticcheck.dev/docs/checks#S1025):

contracts/utils.go:559:9: the argument's underlying type is a slice of bytes, should use a simple conversion instead of fmt.Sprintf (S1025)

n many instances, there are easier and more efficient ways of getting a value’s string representation. Whenever a value’s underlying type is a string already, or the type has a String method, they should be used directly.

Given the following shared definitions

```go
type T1 string
type T2 int

func (T2) String() string { return "Hello, world" }

var x string
var y T1
var z T2
```

we can simplify

```go
fmt.Sprintf("%s", x)
fmt.Sprintf("%s", y)
fmt.Sprintf("%s", z)
```

to

```go
x
string(y)
z.String() 
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
