### PR TITLE
core: fix staticcheck warning S1006: use for {} for infinite loops

### DIFF
--- a/core/lending_pool_test.go
+++ b/core/lending_pool_test.go
@@ -181,7 +181,7 @@ func TestSendLending(t *testing.T) {
 		t.FailNow()
 	}
 
-	for true {
+	for {
 		// 10%
 		interestRate := 10 * common.BaseLendingInterest.Uint64()
 		// lendToken: USD, collateral: BTC


### PR DESCRIPTION
# Proposed changes

This PR fixes the staticcheck warning [S1006: use for {} for infinite loops](https://staticcheck.dev/docs/checks#S1006):

For infinite loops, using for { ... } is the most idiomatic choice.

core/lending_pool_test.go:184:2: should use for {} instead of for true {} (S1006)

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
