### PR TITLE
use global function when cli v1

### DIFF
--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -71,9 +71,9 @@ func runCmd(ctx *cli.Context) error {
 	logconfig := &vm.LogConfig{
 		EnableMemory:     !ctx.GlobalBool(DisableMemoryFlag.Name),
 		DisableStack:     ctx.GlobalBool(DisableStackFlag.Name),
-		DisableStorage:   ctx.Bool(DisableStorageFlag.Name),
-		EnableReturnData: !ctx.Bool(DisableReturnDataFlag.Name),
-		Debug:            ctx.Bool(DebugFlag.Name),
+		DisableStorage:   ctx.GlobalBool(DisableStorageFlag.Name),
+		EnableReturnData: !ctx.GlobalBool(DisableReturnDataFlag.Name),
+		Debug:            ctx.GlobalBool(DebugFlag.Name),
 	}
 
 	var (

--- a/cmd/evm/staterunner.go
+++ b/cmd/evm/staterunner.go
@@ -52,8 +52,8 @@ func stateTestCmd(ctx *cli.Context) error {
 	config := &vm.LogConfig{
 		EnableMemory:     !ctx.GlobalBool(DisableMemoryFlag.Name),
 		DisableStack:     ctx.GlobalBool(DisableStackFlag.Name),
-		DisableStorage:   ctx.Bool(DisableStorageFlag.Name),
-		EnableReturnData: !ctx.Bool(DisableReturnDataFlag.Name),
+		DisableStorage:   ctx.GlobalBool(DisableStorageFlag.Name),
+		EnableReturnData: !ctx.GlobalBool(DisableReturnDataFlag.Name),
 	}
 
 	var (

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -178,11 +178,11 @@ func Setup(ctx *cli.Context) error {
 		handler        slog.Handler
 		terminalOutput = io.Writer(os.Stderr)
 		output         io.Writer
-		logFmtFlag     = ctx.String(logFormatFlag.Name)
+		logFmtFlag     = ctx.GlobalString(logFormatFlag.Name)
 	)
 	var (
-		logFile  = ctx.String(logFileFlag.Name)
-		rotation = ctx.Bool(logRotateFlag.Name)
+		logFile  = ctx.GlobalString(logFileFlag.Name)
+		rotation = ctx.GlobalBool(logRotateFlag.Name)
 	)
 	if len(logFile) > 0 {
 		if err := validateLogLocation(filepath.Dir(logFile)); err != nil {
@@ -205,10 +205,10 @@ func Setup(ctx *cli.Context) error {
 		}
 		logOutputFile = &lumberjack.Logger{
 			Filename:   logFile,
-			MaxSize:    ctx.Int(logMaxSizeMBsFlag.Name),
-			MaxBackups: ctx.Int(logMaxBackupsFlag.Name),
-			MaxAge:     ctx.Int(logMaxAgeFlag.Name),
-			Compress:   ctx.Bool(logCompressFlag.Name),
+			MaxSize:    ctx.GlobalInt(logMaxSizeMBsFlag.Name),
+			MaxBackups: ctx.GlobalInt(logMaxBackupsFlag.Name),
+			MaxAge:     ctx.GlobalInt(logMaxAgeFlag.Name),
+			Compress:   ctx.GlobalBool(logCompressFlag.Name),
 		}
 		output = io.MultiWriter(terminalOutput, logOutputFile)
 	} else if logFile != "" {
@@ -223,7 +223,7 @@ func Setup(ctx *cli.Context) error {
 	}
 
 	switch {
-	case ctx.Bool(logjsonFlag.Name):
+	case ctx.GlobalBool(logjsonFlag.Name):
 		// Retain backwards compatibility with `--log-json` flag if `--log-format` not set
 		defer log.Warn("The flag '--log-json' is deprecated, please use '--log-format=json' instead")
 		handler = log.JSONHandlerWithLevel(output, log.LevelInfo)
@@ -244,18 +244,18 @@ func Setup(ctx *cli.Context) error {
 		handler = log.NewTerminalHandler(output, useColor)
 	default:
 		// Unknown log format specified
-		return fmt.Errorf("unknown log format: %v", ctx.String(logFormatFlag.Name))
+		return fmt.Errorf("unknown log format: %v", ctx.GlobalString(logFormatFlag.Name))
 	}
 
 	glogger = log.NewGlogHandler(handler)
 
 	// logging
-	verbosity := log.FromLegacyLevel(ctx.Int(verbosityFlag.Name))
+	verbosity := log.FromLegacyLevel(ctx.GlobalInt(verbosityFlag.Name))
 	glogger.Verbosity(verbosity)
-	vmodule := ctx.String(logVmoduleFlag.Name)
+	vmodule := ctx.GlobalString(logVmoduleFlag.Name)
 	if vmodule == "" {
 		// Retain backwards compatibility with `--vmodule` flag if `--log-vmodule` not set
-		vmodule = ctx.String(vmoduleFlag.Name)
+		vmodule = ctx.GlobalString(vmoduleFlag.Name)
 		if vmodule != "" {
 			defer log.Warn("The flag '--vmodule' is deprecated, please use '--log-vmodule' instead")
 		}


### PR DESCRIPTION
# Proposed changes

We should use `GlobalString` and `GlobalBool` if we are using "gopkg.in/urfave/cli.v1".

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
