### PR TITLE
Fix tc cross epoch different masternode counts issue

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/epochSwitch.go
+++ b/consensus/XDPoS/engines/engine_v2/epochSwitch.go
@@ -152,7 +152,7 @@ func (x *XDPoS_v2) IsEpochSwitch(header *types.Header) (bool, uint64, error) {
 		log.Info("[IsEpochSwitch] true, parent equals V2.SwitchBlock", "round", round, "number", header.Number.Uint64(), "hash", header.Hash())
 		return true, epochNum, nil
 	}
-	log.Debug("[IsEpochSwitch]", "is", parentRound < epochStartRound, "parentRound", parentRound, "round", round, "number", header.Number.Uint64(), "epochNum", epochNum, "hash", header.Hash())
+	log.Debug("[IsEpochSwitch]", "is", parentRound < epochStartRound, "parentRound", parentRound, "round", round, "number", header.Number.Uint64(), "epochNum", epochNum, "hash", header.Hash().Hex())
 	// if isEpochSwitch, add to cache
 	if parentRound < epochStartRound {
 		x.round2epochBlockInfo.Add(round, &types.BlockInfo{

--- a/consensus/tests/engine_v2_tests/sync_info_test.go
+++ b/consensus/tests/engine_v2_tests/sync_info_test.go
@@ -1,9 +1,11 @@
 package engine_v2_tests
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
+	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
@@ -98,5 +100,129 @@ func TestSkipVerifySyncInfoIfBothQcTcNotQualified(t *testing.T) {
 
 	verified, err := engineV2.VerifySyncInfoMessage(blockchain, syncInfoMsg)
 	assert.False(t, verified)
+	assert.Nil(t, err)
+}
+
+func TestVerifySyncInfoIfTcUseDifferentEpoch(t *testing.T) {
+	config := params.TestXDPoSMockChainConfig
+	blockchain, _, currentBlock, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 1349, config, nil)
+	adaptor := blockchain.Engine().(*XDPoS.XDPoS)
+	x := adaptor.EngineV2
+
+	// Insert block 1350
+	t.Logf("Inserting block with propose at 1350...")
+	blockCoinbaseA := "0xaaa0000000000000000000000000000000001350"
+	// NOTE: voterAddr never exist in the Masternode list, but all acc1,2,3 already does
+	tx, err := voteTX(37117, 0, signer.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	//Get from block validator error message
+	merkleRoot := "8a355a8636d1aae24d5a63df0318534e09110891d6ab7bf20587da64725083be"
+	header := &types.Header{
+		Root:       common.HexToHash(merkleRoot),
+		Number:     big.NewInt(int64(1350)),
+		ParentHash: currentBlock.Hash(),
+		Coinbase:   common.HexToAddress(blockCoinbaseA),
+	}
+
+	header.Extra = generateV2Extra(450, currentBlock, signer, signFn, nil)
+
+	parentBlock, err := createBlockFromHeader(blockchain, header, []*types.Transaction{tx}, signer, signFn, config)
+	assert.Nil(t, err)
+	err = blockchain.InsertBlock(parentBlock)
+	assert.Nil(t, err)
+	// 1350 is a gap block, need to update the snapshot
+	err = blockchain.UpdateM1()
+	assert.Nil(t, err)
+	t.Logf("Inserting block from 1351 to 1799...")
+	for i := 1351; i <= 1799; i++ {
+		blockCoinbase := fmt.Sprintf("0xaaa000000000000000000000000000000000%4d", i)
+		//Get from block validator error message
+		header = &types.Header{
+			Root:       common.HexToHash(merkleRoot),
+			Number:     big.NewInt(int64(i)),
+			ParentHash: parentBlock.Hash(),
+			Coinbase:   common.HexToAddress(blockCoinbase),
+		}
+
+		header.Extra = generateV2Extra(int64(i)-900, parentBlock, signer, signFn, nil)
+
+		block, err := createBlockFromHeader(blockchain, header, nil, signer, signFn, config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = blockchain.InsertBlock(block)
+		assert.Nil(t, err)
+		parentBlock = block
+	}
+	t.Logf("build epoch block with new set of masternodes")
+	blockCoinbase := fmt.Sprintf("0xaaa0000000000000000000000000000000001800")
+	//Get from block validator error message
+	header = &types.Header{
+		Root:       common.HexToHash(merkleRoot),
+		Number:     big.NewInt(int64(1800)),
+		ParentHash: parentBlock.Hash(),
+		Coinbase:   common.HexToAddress(blockCoinbase),
+	}
+
+	header.Extra = generateV2Extra(900, parentBlock, signer, signFn, nil)
+	validators := []byte{}
+
+	snap, err := x.GetSnapshot(blockchain, parentBlock.Header())
+	assert.Nil(t, err)
+
+	for _, v := range snap.NextEpochCandidates {
+		validators = append(validators, v[:]...)
+	}
+	// set up 1 more masternode to make it difference
+	validators = append(validators, voterAddr[:]...)
+	header.Validators = validators
+	block, err := createBlockFromHeader(blockchain, header, nil, signer, signFn, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = blockchain.InsertBlock(block)
+	assert.Nil(t, err)
+	parentBlock = block
+
+	var extraField types.ExtraFields_v2
+	err = utils.DecodeBytesExtraFields(parentBlock.Extra(), &extraField)
+	if err != nil {
+		t.Fatal("Fail to decode extra data", err)
+	}
+
+	timeoutForSign := &types.TimeoutForSign{
+		Round:     types.Round(899),
+		GapNumber: 450,
+	}
+
+	// Sign from acc 1, 2, 3 and voter
+	acc1SignedHash := SignHashByPK(acc1Key, types.TimeoutSigHash(timeoutForSign).Bytes())
+	acc2SignedHash := SignHashByPK(acc2Key, types.TimeoutSigHash(timeoutForSign).Bytes())
+	acc3SignedHash := SignHashByPK(acc3Key, types.TimeoutSigHash(timeoutForSign).Bytes())
+	voterSignedHash := SignHashByPK(voterKey, types.TimeoutSigHash(timeoutForSign).Bytes())
+
+	var signatures []types.Signature
+	signatures = append(signatures, acc1SignedHash, acc2SignedHash, acc3SignedHash, voterSignedHash)
+
+	newTC := &types.TimeoutCert{
+		Round:      timeoutForSign.Round,
+		Signatures: signatures,
+		GapNumber:  timeoutForSign.GapNumber,
+	}
+
+	syncInfoMsg := &types.SyncInfo{
+		HighestQuorumCert:  extraField.QuorumCert,
+		HighestTimeoutCert: newTC,
+	}
+
+	x.SetPropertiesFaker(syncInfoMsg.HighestQuorumCert, &types.TimeoutCert{
+		Round:      types.Round(898),
+		Signatures: []types.Signature{},
+	})
+
+	verified, err := x.VerifySyncInfoMessage(blockchain, syncInfoMsg)
+	assert.True(t, verified)
 	assert.Nil(t, err)
 }

--- a/core/types/consensus_v2.go
+++ b/core/types/consensus_v2.go
@@ -21,7 +21,7 @@ type BlockInfo struct {
 
 // Vote message in XDPoS 2.0
 type Vote struct {
-	signer            common.Address	//field not exported 
+	signer            common.Address //field not exported
 	ProposedBlockInfo *BlockInfo     `json:"proposedBlockInfo"`
 	Signature         Signature      `json:"signature"`
 	GapNumber         uint64         `json:"gapNumber"`
@@ -81,9 +81,9 @@ func (s *SyncInfo) Hash() common.Hash {
 
 // Quorum Certificate struct in XDPoS 2.0
 type QuorumCert struct {
-	ProposedBlockInfo *BlockInfo `json:"proposedBlockInfo"`
+	ProposedBlockInfo *BlockInfo  `json:"proposedBlockInfo"`
 	Signatures        []Signature `json:"signatures"`
-	GapNumber         uint64 `json:"gapNumber"`
+	GapNumber         uint64      `json:"gapNumber"`
 }
 
 // Timeout Certificate struct in XDPoS 2.0

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 2       // Major version component of the current release
 	VersionMinor = 4       // Minor version component of the current release
-	VersionPatch = 4       // Patch version component of the current release
+	VersionPatch = 5       // Patch version component of the current release
 	VersionMeta  = "beta1" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
# Proposed changes
Fix tc cross epoch different masternode counts issue

## Root Cause
Found out by testnet issue, node start sending sync info message, because one of node not functioning (normal). And Sync Info Message contains latest TC and QC. But TC is generated by last epoch which only have 17 signatures but current epoch requires 19 signatures. So sync info is not accepting by all the nodes. Cause some nodes are at old round and some nodes are at new round.

## Fix
When process TC, it should use the right epoch information, not the current epoch / round information.

## Side Fix
When send timeout message, node also save timeout message into local pool, and we have XDPoS_getLatestPoolStatus to receive signer. But we only assign signer while verify incoming timeout.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
