### PR TITLE
all: simplify function TransitionDb

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -478,8 +478,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call XDPoSChain.Cal
 	vmenv := vm.NewEVM(evmContext, txContext, statedb, nil, b.config, vm.Config{NoBaseFee: true})
 	gaspool := new(core.GasPool).AddGas(math.MaxUint64)
 	owner := common.Address{}
-	res, err, _ := core.NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
-	return res, err
+	return core.NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
 }
 
 // SendTransaction updates the pending block to include the given transaction.

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -368,7 +368,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call XDPoSChain.Call
 		b.pendingState.RevertToSnapshot(snapshot)
 
 		if err != nil {
-			if err == core.ErrIntrinsicGas {
+			if errors.Is(err, core.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			return true, nil, err // Bail out

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -403,7 +403,7 @@ func applyTransaction(config *params.ChainConfig, tokensFee map[common.Address]*
 	// End Bypass blacklist address
 
 	// Apply the transaction to the current state (included in the env)
-	result, err, _ := ApplyMessage(evm, msg, gp, coinbaseOwner)
+	result, err := ApplyMessage(evm, msg, gp, coinbaseOwner)
 
 	if err != nil {
 		return nil, 0, err, false

--- a/core/token_validator.go
+++ b/core/token_validator.go
@@ -117,7 +117,7 @@ func CallContractWithState(call ethereum.CallMsg, chain consensus.ChainContext, 
 	vmenv := vm.NewEVM(evmContext, txContext, statedb, nil, chain.Config(), vm.Config{})
 	gaspool := new(GasPool).AddGas(1000000)
 	owner := common.Address{}
-	result, err, _ := NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
+	result, err := NewStateTransition(vmenv, msg, gaspool).TransitionDb(owner)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -526,7 +526,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 
 		vmenv := vm.NewEVM(blockCtx, txContext, statedb, XDCxState, api.config, vm.Config{})
 		owner := common.Address{}
-		if _, err, _ := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), owner); err != nil {
 			failed = err
 			break
 		}
@@ -750,7 +750,7 @@ func (api *PrivateDebugAPI) traceTx(ctx context.Context, message core.Message, t
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
 
 	owner := common.Address{}
-	result, err, _ := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), owner)
+	result, err := core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), owner)
 	if err != nil {
 		return nil, fmt.Errorf("tracing failed: %v", err)
 	}

--- a/eth/tracers/testing/calltrace_test.go
+++ b/eth/tracers/testing/calltrace_test.go
@@ -120,7 +120,7 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 				t.Fatalf("failed to prepare transaction for tracing: %v", err)
 			}
 			st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-			if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+			if _, err = st.TransitionDb(common.Address{}); err != nil {
 				t.Fatalf("failed to execute transaction: %v", err)
 			}
 			// Retrieve the trace result and compare against the etalon
@@ -231,7 +231,7 @@ func benchTracer(tracerName string, test *callTracerTest, b *testing.B) {
 		evm := vm.NewEVM(context, txContext, statedb, nil, test.Genesis.Config, vm.Config{Debug: true, Tracer: tracer})
 		snap := statedb.Snapshot()
 		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-		if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+		if _, err = st.TransitionDb(common.Address{}); err != nil {
 			b.Fatalf("failed to execute transaction: %v", err)
 		}
 		if _, err = tracer.GetResult(); err != nil {

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -158,7 +158,7 @@ func TestZeroValueToNotExitCall(t *testing.T) {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
 	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-	if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+	if _, err = st.TransitionDb(common.Address{}); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
 	// Retrieve the trace result and compare against the etalon
@@ -244,7 +244,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
 	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-	if _, err, _ = st.TransitionDb(common.Address{}); err != nil {
+	if _, err = st.TransitionDb(common.Address{}); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}
 	// Retrieve the trace result and compare against the etalon
@@ -346,7 +346,7 @@ func BenchmarkTransactionTrace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		snap := statedb.Snapshot()
 		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-		_, err, _ = st.TransitionDb(common.Address{})
+		_, err = st.TransitionDb(common.Address{})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1448,7 +1448,7 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, bl
 		return nil, err
 	}
 	// If the result contains a revert reason, try to unpack and return it.
-	if result.Failed() && len(result.Return()) > 0 {
+	if result.Failed() {
 		return nil, newRevertError(result.Return())
 	}
 	return result.Return(), nil

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -142,7 +142,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
 				owner := common.Address{}
-				result, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+				result, _ := core.ApplyMessage(vmenv, msg, gp, owner)
 				res = append(res, result.Return()...)
 			}
 		} else {
@@ -160,7 +160,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			vmenv := vm.NewEVM(context, txContext, statedb, nil, config, vm.Config{NoBaseFee: true})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
 			owner := common.Address{}
-			result, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+			result, _ := core.ApplyMessage(vmenv, msg, gp, owner)
 			if statedb.Error() == nil {
 				res = append(res, result.Return()...)
 			}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -191,7 +191,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		vmenv := vm.NewEVM(context, txContext, st, nil, config, vm.Config{NoBaseFee: true})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		owner := common.Address{}
-		result, _, _ := core.ApplyMessage(vmenv, msg, gp, owner)
+		result, _ := core.ApplyMessage(vmenv, msg, gp, owner)
 		res = append(res, result.Return()...)
 		if st.Error() != nil {
 			return res, st.Error()

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -166,7 +166,7 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config) (*state.StateD
 	gaspool.AddGas(block.GasLimit())
 
 	coinbase := &t.json.Env.Coinbase
-	if _, err, _ := core.ApplyMessage(evm, msg, gaspool, *coinbase); err != nil {
+	if _, err := core.ApplyMessage(evm, msg, gaspool, *coinbase); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
 	if logs := rlpHash(statedb.Logs()); logs != common.Hash(post.Logs) {


### PR DESCRIPTION
# Proposed changes
The following 3 commits address the incompletely resolved issues in #632 :

1. Simplify the return values of the function `TransitionDb` and related functions to align them with the upstream code.

2. The changes from the previous PR caused an issue where the `execution reverted` message was not correctly returned. This happened because, in cases of insufficient balance, a revert is required without a return value, which was not properly handled. Therefore, the condition checking for a non-zero length of return values has been removed, allowing `newRevertError` to handle this scenario.

3. The upstream function returns a wrapped error:

   ```go
   if st.gas < gas {
       return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas), nil
   }
   ```

   We should use `errors.Is(err, core.ErrIntrinsicGas)` to compare the wrapped error.

### Test
test contract is following:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.19;

contract TestRevert {
    function revertLogic(address payable recipient)
        external
        payable
        returns (uint256)
    {
        recipient.transfer(msg.value);
        require(msg.value > 10, "Transfer amount must be greater than ten");

        return msg.value;
    }

    // Function to allow contract to send ETH to another account
    function sendXDC(address payable recipient, uint256 amount) external returns (uint256){
        // Transfer the specified amount to the recipient
        recipient.transfer(amount* 1 ether);

        return amount;
        
    }

    receive() external payable {
    }

    fallback() external payable {
    }
}


```

**eth_call**
The `curl` command I used:
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "eth_call",
  "params": [
    {
      "from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",  
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "data": "0x1afd35fe000000000000000000000000885c1e1b9c24758b56b6a36c13a94efdb4e4e3b10000000000000000000000000000000000000000000000000000000000000001"
    },
    "latest"
  ]}'
  ```
and their response:

| PR are applied | Response                                                                                                      |
| -------------- | ------------------------------------------------------------------------------------------------------------- |
| Yes            | {"jsonrpc":"2.0","id":1002,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}<br> |
| No             | {"jsonrpc":"2.0","id":1002,"result":"0x0000000000000000000000000000000000000000000000000000000000000001"}<br> |


#### Revet test
##### Request（The balance is 100, and an internal transaction attempts to transfer 200 to the address`0x873C36f9Fd02e0C57a393aFE80D14f244fE04378`）
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "eth_call",
  "params": [
    {            
      "from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "data": "0x1afd35fe000000000000000000000000885c1e1b9c24758b56b6a36c13a94efdb4e4e3b100000000000000000000000000000000000000000000000000000000000000c8",
    },
  ]}' | jq
```
##### Response
```bash
{
    "jsonrpc": "2.0",
    "id": 1002,
    "error": {
        "code": 3,
        "message": "execution reverted",
        "data": "0x"
    }
}
```
##### Request（gas exceeds the gasLimit）
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "eth_call",
  "params": [
    {            
      "from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",
      "to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
      "gas": "0x10",
      "data": "0x1afd35fe000000000000000000000000885c1e1b9c24758b56b6a36c13a94efdb4e4e3b10000000000000000000000000000000000000000000000000000000000000008",
    },
  ]}' | jq
```
##### Response
```bash
{
    "jsonrpc": "2.0",
    "id": 1002,
    "error": {
        "code": -32000,
        "message": "err: intrinsic gas too low: have 16, want 22680 (supplied gas 16)"
    }
}
```
##### Request(revert caused by business logic)
```bash
RPC="http://127.0.0.1:8545"
curl -s -X POST -H "Content-Type: application/json" ${RPC} -d '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "eth_estimateGas",
    "params": [
        {
		"from": "0x873C36f9Fd02e0C57a393aFE80D14f244fE04378",
		"to": "0xEb14F05e78bDB995a55aAc7D2b2D26D2215F22Fd",
		"value":"0x3",
		"data": "0x8a73d3ab000000000000000000000000eb14f05e78bdb995a55aac7d2b2d26d2215f22fd"
        }
    ]}' | jq
```

##### Response
```bash
{
    "jsonrpc": "2.0",
    "id": 1002,
    "error": {
        "code": -32000,
        "message": "always failing transaction (execution reverted) (Transfer amount must be greater than ten)"
    }
}
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [x] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
