### PR TITLE
all: remove empty function SaveData()

### DIFF
--- a/XDCx/XDCx.go
+++ b/XDCx/XDCx.go
@@ -71,8 +71,6 @@ func (XDCx *XDCX) Start(server *p2p.Server) error {
 	return nil
 }
 
-func (XDCx *XDCX) SaveData() {
-}
 func (XDCx *XDCX) Stop() error {
 	return nil
 }

--- a/XDCxlending/XDCxlending.go
+++ b/XDCxlending/XDCxlending.go
@@ -54,9 +54,6 @@ func (l *Lending) Start(server *p2p.Server) error {
 	return nil
 }
 
-func (l *Lending) SaveData() {
-}
-
 func (l *Lending) Stop() error {
 	return nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -922,12 +922,7 @@ func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {
 	return bc.stateCache.TrieDB().Node(hash)
 }
 
-func (bc *BlockChain) SaveData() {
-	bc.wg.Add(1)
-	defer bc.wg.Done()
-	// Make sure no inconsistent state is leaked during insertion
-	bc.mu.Lock()
-	defer bc.mu.Unlock()
+func (bc *BlockChain) saveData() {
 	// Ensure the state of a recent block is also stored to disk before exiting.
 	// We're writing three different states to catch different restart scenarios:
 	//  - HEAD:     So we don't need to reprocess any blocks in the general case
@@ -1011,7 +1006,7 @@ func (bc *BlockChain) Stop() {
 	close(bc.quit)
 	atomic.StoreInt32(&bc.procInterrupt, 1)
 	bc.wg.Wait()
-	bc.SaveData()
+	bc.saveData()
 	log.Info("Blockchain manager stopped")
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -557,10 +557,6 @@ func (e *Ethereum) Start(srvr *p2p.Server) error {
 	return nil
 }
 
-func (e *Ethereum) SaveData() {
-	e.blockchain.SaveData()
-}
-
 // Stop implements node.Service, terminating all internal goroutines used by the
 // Ethereum protocol.
 func (e *Ethereum) Stop() error {

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -179,8 +179,6 @@ func (s *Service) Start(server *p2p.Server) error {
 	log.Info("Stats daemon started")
 	return nil
 }
-func (s *Service) SaveData() {
-}
 
 // Stop implements node.Service, terminating the monitoring and reporting daemon.
 func (s *Service) Stop() error {

--- a/les/backend.go
+++ b/les/backend.go
@@ -228,10 +228,6 @@ func (s *LightEthereum) Start(srvr *p2p.Server) error {
 	return nil
 }
 
-func (s *LightEthereum) SaveData() {
-	s.blockchain.SaveData()
-}
-
 // Stop implements node.Service, terminating all internal goroutines used by the
 // Ethereum protocol.
 func (s *LightEthereum) Stop() error {

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -281,9 +281,6 @@ func (lc *LightChain) GetBlockByNumber(ctx context.Context, number uint64) (*typ
 	return lc.GetBlock(ctx, hash, number)
 }
 
-func (bc *LightChain) SaveData() {
-}
-
 // Stop stops the blockchain service. If any imports are currently in progress
 // it will abort them using the procInterrupt.
 func (lc *LightChain) Stop() {

--- a/node/node.go
+++ b/node/node.go
@@ -478,9 +478,6 @@ func (n *Node) Stop() error {
 		return ErrNodeStopped
 	}
 
-	for _, service := range n.services {
-		service.SaveData()
-	}
 	// Terminate the API, services and the p2p server.
 	n.stopWS()
 	n.stopHTTP()

--- a/node/node_example_test.go
+++ b/node/node_example_test.go
@@ -38,7 +38,6 @@ type SampleService struct{}
 func (s *SampleService) Protocols() []p2p.Protocol { return nil }
 func (s *SampleService) APIs() []rpc.API           { return nil }
 func (s *SampleService) Start(*p2p.Server) error   { fmt.Println("Service starting..."); return nil }
-func (s *SampleService) SaveData()                 {}
 func (s *SampleService) Stop() error               { fmt.Println("Service stopping..."); return nil }
 
 func ExampleService() {

--- a/node/service.go
+++ b/node/service.go
@@ -97,8 +97,7 @@ type Service interface {
 	// Start is called after all services have been constructed and the networking
 	// layer was also initialized to spawn any goroutines required by the service.
 	Start(server *p2p.Server) error
-	//Save data before stop
-	SaveData()
+
 	// Stop terminates all goroutines belonging to the service, blocking until they
 	// are all terminated.
 	Stop() error

--- a/node/utils_test.go
+++ b/node/utils_test.go
@@ -32,7 +32,6 @@ type NoopService struct{}
 func (s *NoopService) Protocols() []p2p.Protocol { return nil }
 func (s *NoopService) APIs() []rpc.API           { return nil }
 func (s *NoopService) Start(*p2p.Server) error   { return nil }
-func (s *NoopService) SaveData()                 {}
 func (s *NoopService) Stop() error               { return nil }
 
 func NewNoopService(*ServiceContext) (Service, error) { return new(NoopService), nil }
@@ -79,8 +78,7 @@ func (s *InstrumentedService) Start(server *p2p.Server) error {
 	}
 	return s.start
 }
-func (s *InstrumentedService) SaveData() {
-}
+
 func (s *InstrumentedService) Stop() error {
 	if s.stopHook != nil {
 		s.stopHook()

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -504,8 +504,6 @@ func (s *snapshotService) Start(*p2p.Server) error {
 	return nil
 }
 
-func (s *snapshotService) SaveData() {
-}
 func (s *snapshotService) Stop() error {
 	return nil
 }

--- a/p2p/simulations/examples/ping-pong.go
+++ b/p2p/simulations/examples/ping-pong.go
@@ -127,9 +127,6 @@ func (p *pingPongService) Start(server *p2p.Server) error {
 	return nil
 }
 
-func (p *pingPongService) SaveData() {
-}
-
 func (p *pingPongService) Stop() error {
 	p.log.Info("ping-pong service stopping")
 	return nil

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -117,8 +117,6 @@ func (t *testService) Start(server *p2p.Server) error {
 	return nil
 }
 
-func (t *testService) SaveData() {
-}
 func (t *testService) Stop() error {
 	return nil
 }

--- a/p2p/testing/protocoltester.go
+++ b/p2p/testing/protocoltester.go
@@ -145,9 +145,6 @@ func (tn *testNode) Start(server *p2p.Server) error {
 	return nil
 }
 
-func (tn *testNode) SaveData() {
-}
-
 func (tn *testNode) Stop() error {
 	return nil
 }
@@ -199,9 +196,6 @@ func (mn *mockNode) Trigger(trig *Trigger) error {
 func (mn *mockNode) Expect(exp ...Expect) error {
 	mn.expect <- exp
 	return <-mn.err
-}
-
-func (mn *mockNode) SaveData() {
 }
 
 func (mn *mockNode) Stop() error {


### PR DESCRIPTION
# Proposed changes

This PR removes the empty function `SaveData()` from all services except `BlockChain`. The function `SaveData()` is implemented by the `BlockChain` service only, and it is called in two places repeatedly when chain was stopped:

First:

```go
func (n *Node) Stop() error {
        ......
	for _, service := range n.services {
		service.SaveData()
	}
        ......
}
```

Second:

```go
func (bc *BlockChain) Stop() {
        ......
	bc.SaveData()
        ......
}
```

So we can call `SaveData()` only once in the function `Stop()` of `BlockChain`, and remove `SaveData()` in other services. 

```go
func (bc *BlockChain) SaveData() {
	bc.wg.Add(1)
	defer bc.wg.Done()
	bc.mu.Lock()
	defer bc.mu.Unlock()
        ......
```

Then the uses of `wg` and `mu` in the function of  `saveData()` can also be removed.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
