### PR TITLE
build: add 'go mod tidy' checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ test: all
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint
 
+#? check_tidy: Verify go.mod and go.sum by 'go mod tidy'
+check_tidy: ## Run 'go mod tidy'.
+	$(GORUN) build/ci.go check_tidy
+
 #? clean: Clean go cache, built executables, and the auto generated folder.
 clean:
 	rm -fr build/_workspace/pkg/ $(GOBIN)/*

--- a/internal/build/file.go
+++ b/internal/build/file.go
@@ -1,0 +1,102 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package build
+
+import (
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FileExist checks if a file exists at path.
+func FileExist(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// HashFiles iterates the provided set of files, computing the hash of each.
+func HashFiles(files []string) (map[string][32]byte, error) {
+	res := make(map[string][32]byte)
+	for _, filePath := range files {
+		f, err := os.OpenFile(filePath, os.O_RDONLY, 0666)
+		if err != nil {
+			return nil, err
+		}
+		hasher := sha256.New()
+		if _, err := io.Copy(hasher, f); err != nil {
+			return nil, err
+		}
+		res[filePath] = [32]byte(hasher.Sum(nil))
+	}
+	return res, nil
+}
+
+// HashFolder iterates all files under the given directory, computing the hash
+// of each.
+func HashFolder(folder string, exlude []string) (map[string][32]byte, error) {
+	res := make(map[string][32]byte)
+	err := filepath.WalkDir(folder, func(path string, d os.DirEntry, _ error) error {
+		// Skip anything that's exluded or not a regular file
+		for _, skip := range exlude {
+			if strings.HasPrefix(path, filepath.FromSlash(skip)) {
+				return filepath.SkipDir
+			}
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		// Regular file found, hash it
+		f, err := os.OpenFile(path, os.O_RDONLY, 0666)
+		if err != nil {
+			return err
+		}
+		hasher := sha256.New()
+		if _, err := io.Copy(hasher, f); err != nil {
+			return err
+		}
+		res[path] = [32]byte(hasher.Sum(nil))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// DiffHashes compares two maps of file hashes and returns the changed files.
+func DiffHashes(a map[string][32]byte, b map[string][32]byte) []string {
+	var updates []string
+
+	for file := range a {
+		if _, ok := b[file]; !ok || a[file] != b[file] {
+			updates = append(updates, file)
+		}
+	}
+	for file := range b {
+		if _, ok := a[file]; !ok {
+			updates = append(updates, file)
+		}
+	}
+	sort.Strings(updates)
+	return updates
+}


### PR DESCRIPTION
# Proposed changes

This PR add a checker for  'go mod tidy' which can be called by `make check_tidy`.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
