### PR TITLE
core/types: remove generate directive for gen_tx_json.go

### DIFF
--- a/core/types/lending_transaction.go
+++ b/core/types/lending_transaction.go
@@ -27,8 +27,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
 
-//go:generate gencodec -type txdata -field-override txdataMarshaling -out gen_tx_json.go
-
 var (
 	// ErrInvalidLengdingSig invalidate signer
 	ErrInvalidLengdingSig = errors.New("invalid transaction v, r, s values")

--- a/core/types/order_transaction.go
+++ b/core/types/order_transaction.go
@@ -27,8 +27,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
 
-//go:generate gencodec -type txdata -field-override txdataMarshaling -out gen_tx_json.go
-
 var (
 	// ErrInvalidOrderSig invalidate signer
 	ErrInvalidOrderSig = errors.New("invalid transaction v, r, s values")

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -32,7 +32,6 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
 
-//go:generate gencodec -type txdata -field-override txdataMarshaling -out gen_tx_json.go
 var (
 	ErrInvalidSig           = errors.New("invalid transaction v, r, s values")
 	ErrUnexpectedProtection = errors.New("transaction type does not supported EIP-155 protected signatures")


### PR DESCRIPTION
# Proposed changes

The file `core/types/gen_access_tuple.go` has been deleted in the PR #526. But the go generate directive was forgotten to be deleted.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
