### PR TITLE
cmd/XDC: add db commands: stats, compact, put, get, delete

### DIFF
--- a/cmd/XDC/dbcmd.go
+++ b/cmd/XDC/dbcmd.go
@@ -1,0 +1,259 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/cmd/utils"
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
+	"github.com/XinFinOrg/XDPoSChain/console"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
+	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	removedbCommand = &cli.Command{
+		Action:    removeDB,
+		Name:      "removedb",
+		Usage:     "Remove blockchain and state databases",
+		ArgsUsage: " ",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+			utils.XDCXDataDirFlag,
+			utils.LightModeFlag,
+		},
+		Description: `
+Remove blockchain and state databases`,
+	}
+	dbCommand = &cli.Command{
+		Name:      "db",
+		Usage:     "Low level database operations",
+		ArgsUsage: "",
+		Subcommands: []*cli.Command{
+			dbStatCmd,
+			dbCompactCmd,
+			dbGetCmd,
+			dbDeleteCmd,
+			dbPutCmd,
+		},
+	}
+	dbStatCmd = &cli.Command{
+		Action: dbStats,
+		Name:   "stats",
+		Usage:  "Print leveldb statistics",
+	}
+	dbCompactCmd = &cli.Command{
+		Action: dbCompact,
+		Name:   "compact",
+		Usage:  "Compact leveldb database. WARNING: May take a very long time",
+		Description: `This command performs a database compaction.
+WARNING: This operation may take a very long time to finish, and may cause database
+corruption if it is aborted during execution'!`,
+	}
+	dbGetCmd = &cli.Command{
+		Action:      dbGet,
+		Name:        "get",
+		Usage:       "Show the value of a database key",
+		ArgsUsage:   "<hex-encoded key>",
+		Description: "This command looks up the specified database key from the database.",
+	}
+	dbDeleteCmd = &cli.Command{
+		Action:    dbDelete,
+		Name:      "delete",
+		Usage:     "Delete a database key (WARNING: may corrupt your database)",
+		ArgsUsage: "<hex-encoded key>",
+		Description: `This command deletes the specified database key from the database.
+WARNING: This is a low-level operation which may cause database corruption!`,
+	}
+	dbPutCmd = &cli.Command{
+		Action:    dbPut,
+		Name:      "put",
+		Usage:     "Set the value of a database key (WARNING: may corrupt your database)",
+		ArgsUsage: "<hex-encoded key> <hex-encoded value>",
+		Description: `This command sets a given database key to the given value.
+WARNING: This is a low-level operation which may cause database corruption!`,
+	}
+)
+
+func removeDB(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	for _, name := range []string{"chaindata", "lightchaindata"} {
+		// Ensure the database exists in the first place
+		logger := log.New("database", name)
+
+		dbdir := stack.ResolvePath(name)
+		if !common.FileExist(dbdir) {
+			logger.Info("Database doesn't exist, skipping", "path", dbdir)
+			continue
+		}
+		confirmAndRemoveDB(dbdir, name)
+	}
+	return nil
+}
+
+// confirmAndRemoveDB prompts the user for a last confirmation and removes the
+// folder if accepted.
+func confirmAndRemoveDB(database string, kind string) {
+	confirm, err := console.Stdin.PromptConfirm(fmt.Sprintf("Remove %s (%s)?", kind, database))
+	switch {
+	case err != nil:
+		utils.Fatalf("%v", err)
+	case !confirm:
+		log.Warn("Database deletion aborted", "path", database)
+	default:
+		start := time.Now()
+		os.RemoveAll(database)
+		log.Info("Database successfully deleted", "path", database, "elapsed", common.PrettyDuration(time.Since(start)))
+	}
+}
+
+func showLeveldbStats(db ethdb.Stater) {
+	if stats, err := db.Stat("leveldb.stats"); err != nil {
+		log.Warn("Failed to read database stats", "error", err)
+	} else {
+		fmt.Println(stats)
+	}
+	if ioStats, err := db.Stat("leveldb.iostats"); err != nil {
+		log.Warn("Failed to read database iostats", "error", err)
+	} else {
+		fmt.Println(ioStats)
+	}
+}
+
+func dbStats(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, true)
+	defer db.Close()
+
+	showLeveldbStats(db)
+	return nil
+}
+
+func dbCompact(ctx *cli.Context) error {
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, false)
+	defer db.Close()
+
+	log.Info("Stats before compaction")
+	showLeveldbStats(db)
+
+	log.Info("Triggering compaction")
+	if err := db.Compact(nil, nil); err != nil {
+		log.Info("Compact err", "error", err)
+		return err
+	}
+
+	log.Info("Stats after compaction")
+	showLeveldbStats(db)
+	return nil
+}
+
+// dbGet shows the value of a given database key
+func dbGet(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, true)
+	defer db.Close()
+
+	key, err := common.ParseHexOrString(ctx.Args().Get(0))
+	if err != nil {
+		log.Info("Could not decode the key", "error", err)
+		return err
+	}
+
+	data, err := db.Get(key)
+	if err != nil {
+		log.Info("Get operation failed", "key", fmt.Sprintf("%#x", key), "error", err)
+		return err
+	}
+	fmt.Printf("key %#x:\n\t%#x\n", key, data)
+	return nil
+}
+
+// dbDelete deletes a key from the database
+func dbDelete(ctx *cli.Context) error {
+	if ctx.NArg() != 1 {
+		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, false)
+	defer db.Close()
+
+	key, err := common.ParseHexOrString(ctx.Args().Get(0))
+	if err != nil {
+		log.Info("Could not decode the key", "error", err)
+		return err
+	}
+	data, err := db.Get(key)
+	if err == nil {
+		fmt.Printf("Previous value: %#x\n", data)
+	}
+	if err = db.Delete(key); err != nil {
+		log.Info("Delete operation returned an error", "key", fmt.Sprintf("%#x", key), "error", err)
+		return err
+	}
+	return nil
+}
+
+// dbPut overwrite a value in the database
+func dbPut(ctx *cli.Context) error {
+	if ctx.NArg() != 2 {
+		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
+	}
+	stack, _ := makeConfigNode(ctx)
+	defer stack.Close()
+
+	db := utils.MakeChainDatabase(ctx, stack, false)
+	defer db.Close()
+
+	var (
+		key   []byte
+		value []byte
+		data  []byte
+		err   error
+	)
+	key, err = common.ParseHexOrString(ctx.Args().Get(0))
+	if err != nil {
+		log.Info("Could not decode the key", "error", err)
+		return err
+	}
+	value, err = hexutil.Decode(ctx.Args().Get(1))
+	if err != nil {
+		log.Info("Could not decode the value", "error", err)
+		return err
+	}
+	data, err = db.Get(key)
+	if err == nil {
+		fmt.Printf("Previous value:\n%#x\n", data)
+	}
+	return db.Put(key, value)
+}

--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -188,6 +188,8 @@ func init() {
 		initCommand,
 		importCommand,
 		exportCommand,
+		importPreimagesCommand,
+		exportPreimagesCommand,
 		removedbCommand,
 		dumpCommand,
 		// See accountcmd.go:
@@ -198,9 +200,16 @@ func init() {
 		attachCommand,
 		javascriptCommand,
 		// See misccmd.go:
+		makecacheCommand,
+		makedagCommand,
 		versionCommand,
+		licenseCommand,
 		// See config.go
 		dumpConfigCommand,
+		// see dbcmd.go
+		dbCommand,
+		// See cmd/utils/flags_legacy.go
+		utils.ShowDeprecated,
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 


### PR DESCRIPTION
# Proposed changes

This PR introduces:

- `db.put`: put a value into the database
- `db.get`: read a value from the database
- `db.delete`: delete a value from the database
- `db.stats`: check compaction info from the database
- `db.compact`: trigger a db compaction

Ref: #22014

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
