### PR TITLE
all: use types.EmptyRootHash instead of null

### DIFF
--- a/XDCx/order_processor_test.go
+++ b/XDCx/order_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/XDCx/tradingstate"
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 )
 
 func Test_getCancelFeeV1(t *testing.T) {
@@ -92,7 +93,7 @@ func Test_getCancelFee(t *testing.T) {
 	XDCx := New(&DefaultConfig)
 	db := rawdb.NewMemoryDatabase()
 	stateCache := tradingstate.NewDatabase(db)
-	tradingStateDb, _ := tradingstate.New(common.Hash{}, stateCache)
+	tradingStateDb, _ := tradingstate.New(types.EmptyRootHash, stateCache)
 
 	testTokenA := common.HexToAddress("0x1000000000000000000000000000000000000002")
 	testTokenB := common.HexToAddress("0x1100000000000000000000000000000000000003")

--- a/XDCx/tradingstate/XDCx_trie_test.go
+++ b/XDCx/tradingstate/XDCx_trie_test.go
@@ -2,19 +2,21 @@ package tradingstate
 
 import (
 	"fmt"
-	"github.com/XinFinOrg/XDPoSChain/common"
-	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"math/big"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 )
 
 func TestXDCxTrieTest(t *testing.T) {
 	t.SkipNow()
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	trie, _ := stateCache.OpenStorageTrie(EmptyHash, EmptyHash)
+	trie, _ := stateCache.OpenStorageTrie(EmptyHash, types.EmptyRootHash)
 	max := 1000000
 	for i := 1; i < max; i++ {
 		k := common.BigToHash(big.NewInt(int64(i))).Bytes()

--- a/XDCx/tradingstate/state_lendingbook.go
+++ b/XDCx/tradingstate/state_lendingbook.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 )
@@ -80,7 +81,7 @@ func (s *stateLendingBook) getTrie(db Database) Trie {
 		var err error
 		s.trie, err = db.OpenStorageTrie(s.lendingBook, s.data.Root)
 		if err != nil {
-			s.trie, _ = db.OpenStorageTrie(s.price, EmptyHash)
+			s.trie, _ = db.OpenStorageTrie(s.price, types.EmptyRootHash)
 			s.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
 	}

--- a/XDCx/tradingstate/state_liquidationprice.go
+++ b/XDCx/tradingstate/state_liquidationprice.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/trie"
@@ -103,7 +104,7 @@ func (l *liquidationPriceState) getTrie(db Database) Trie {
 		var err error
 		l.trie, err = db.OpenStorageTrie(l.liquidationPrice, l.data.Root)
 		if err != nil {
-			l.trie, _ = db.OpenStorageTrie(l.liquidationPrice, EmptyHash)
+			l.trie, _ = db.OpenStorageTrie(l.liquidationPrice, types.EmptyRootHash)
 			l.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
 	}

--- a/XDCx/tradingstate/state_orderList.go
+++ b/XDCx/tradingstate/state_orderList.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
 
@@ -91,7 +92,7 @@ func (c *stateOrderList) getTrie(db Database) Trie {
 		var err error
 		c.trie, err = db.OpenStorageTrie(c.price, c.data.Root)
 		if err != nil {
-			c.trie, _ = db.OpenStorageTrie(c.price, EmptyHash)
+			c.trie, _ = db.OpenStorageTrie(c.price, types.EmptyRootHash)
 			c.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
 	}

--- a/XDCx/tradingstate/state_orderbook.go
+++ b/XDCx/tradingstate/state_orderbook.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
@@ -135,7 +136,7 @@ func (te *tradingExchanges) getAsksTrie(db Database) Trie {
 		var err error
 		te.asksTrie, err = db.OpenStorageTrie(te.orderBookHash, te.data.AskRoot)
 		if err != nil {
-			te.asksTrie, _ = db.OpenStorageTrie(te.orderBookHash, EmptyHash)
+			te.asksTrie, _ = db.OpenStorageTrie(te.orderBookHash, types.EmptyRootHash)
 			te.setError(fmt.Errorf("can't create asks trie: %v", err))
 		}
 	}
@@ -147,7 +148,7 @@ func (te *tradingExchanges) getOrdersTrie(db Database) Trie {
 		var err error
 		te.ordersTrie, err = db.OpenStorageTrie(te.orderBookHash, te.data.OrderRoot)
 		if err != nil {
-			te.ordersTrie, _ = db.OpenStorageTrie(te.orderBookHash, EmptyHash)
+			te.ordersTrie, _ = db.OpenStorageTrie(te.orderBookHash, types.EmptyRootHash)
 			te.setError(fmt.Errorf("can't create asks trie: %v", err))
 		}
 	}
@@ -265,7 +266,7 @@ func (te *tradingExchanges) getBidsTrie(db Database) Trie {
 		var err error
 		te.bidsTrie, err = db.OpenStorageTrie(te.orderBookHash, te.data.BidRoot)
 		if err != nil {
-			te.bidsTrie, _ = db.OpenStorageTrie(te.orderBookHash, EmptyHash)
+			te.bidsTrie, _ = db.OpenStorageTrie(te.orderBookHash, types.EmptyRootHash)
 			te.setError(fmt.Errorf("can't create bids trie: %v", err))
 		}
 	}
@@ -636,7 +637,7 @@ func (t *tradingExchanges) getLiquidationPriceTrie(db Database) Trie {
 		var err error
 		t.liquidationPriceTrie, err = db.OpenStorageTrie(t.orderBookHash, t.data.LiquidationPriceRoot)
 		if err != nil {
-			t.liquidationPriceTrie, _ = db.OpenStorageTrie(t.orderBookHash, EmptyHash)
+			t.liquidationPriceTrie, _ = db.OpenStorageTrie(t.orderBookHash, types.EmptyRootHash)
 			t.setError(fmt.Errorf("can't create liquidation liquidationPrice trie: %v", err))
 		}
 	}

--- a/XDCx/tradingstate/statedb_test.go
+++ b/XDCx/tradingstate/statedb_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 )
 
 func TestEchangeStates(t *testing.T) {
@@ -42,7 +43,7 @@ func TestEchangeStates(t *testing.T) {
 	// Create an empty statedb database
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	statedb, _ := New(common.Hash{}, stateCache)
+	statedb, _ := New(types.EmptyRootHash, stateCache)
 
 	// Update it with some exchanges
 	for i := 0; i < numberOrder; i++ {
@@ -172,7 +173,7 @@ func TestRevertStates(t *testing.T) {
 	// Create an empty statedb database
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	statedb, _ := New(common.Hash{}, stateCache)
+	statedb, _ := New(types.EmptyRootHash, stateCache)
 
 	// Update it with some exchanges
 	for i := 0; i < numberOrder; i++ {
@@ -277,7 +278,7 @@ func TestDumpState(t *testing.T) {
 	// Create an empty statedb database
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	statedb, _ := New(common.Hash{}, stateCache)
+	statedb, _ := New(types.EmptyRootHash, stateCache)
 
 	for i := 0; i < len(orderItems); i++ {
 		orderIdHash := common.BigToHash(new(big.Int).SetUint64(orderItems[i].OrderID))

--- a/XDCxlending/lendingstate/lendingitem_test.go
+++ b/XDCxlending/lendingstate/lendingitem_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
 	"golang.org/x/crypto/sha3"
@@ -174,7 +175,7 @@ func SetCollateralDetail(statedb *state.StateDB, token common.Address, depositRa
 
 func TestVerifyBalance(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	relayer := common.HexToAddress("0x0D3ab14BBaD3D99F4203bd7a11aCB94882050E7e")
 	uAddr := common.HexToAddress("0xDeE6238780f98c0ca2c2C28453149bEA49a3Abc9")
 	lendingToken := common.HexToAddress("0xd9bb01454c85247B2ef35BB5BE57384cC275a8cf")    // USD

--- a/XDCxlending/lendingstate/state_itemList.go
+++ b/XDCxlending/lendingstate/state_itemList.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
 
@@ -79,7 +80,7 @@ func (il *itemListState) getTrie(db Database) Trie {
 		var err error
 		il.trie, err = db.OpenStorageTrie(il.key, il.data.Root)
 		if err != nil {
-			il.trie, _ = db.OpenStorageTrie(il.key, EmptyHash)
+			il.trie, _ = db.OpenStorageTrie(il.key, types.EmptyRootHash)
 			il.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
 	}

--- a/XDCxlending/lendingstate/state_lendingbook.go
+++ b/XDCxlending/lendingstate/state_lendingbook.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
@@ -128,7 +129,7 @@ func (le *lendingExchangeState) getLendingItemTrie(db Database) Trie {
 		var err error
 		le.lendingItemTrie, err = db.OpenStorageTrie(le.lendingBook, le.data.LendingItemRoot)
 		if err != nil {
-			le.lendingItemTrie, _ = db.OpenStorageTrie(le.lendingBook, EmptyHash)
+			le.lendingItemTrie, _ = db.OpenStorageTrie(le.lendingBook, types.EmptyRootHash)
 			le.setError(fmt.Errorf("can't create Lendings trie: %v", err))
 		}
 	}
@@ -140,7 +141,7 @@ func (le *lendingExchangeState) getLendingTradeTrie(db Database) Trie {
 		var err error
 		le.lendingTradeTrie, err = db.OpenStorageTrie(le.lendingBook, le.data.LendingTradeRoot)
 		if err != nil {
-			le.lendingTradeTrie, _ = db.OpenStorageTrie(le.lendingBook, EmptyHash)
+			le.lendingTradeTrie, _ = db.OpenStorageTrie(le.lendingBook, types.EmptyRootHash)
 			le.setError(fmt.Errorf("can't create Lendings trie: %v", err))
 		}
 	}
@@ -152,7 +153,7 @@ func (le *lendingExchangeState) getInvestingTrie(db Database) Trie {
 		var err error
 		le.investingTrie, err = db.OpenStorageTrie(le.lendingBook, le.data.InvestingRoot)
 		if err != nil {
-			le.investingTrie, _ = db.OpenStorageTrie(le.lendingBook, EmptyHash)
+			le.investingTrie, _ = db.OpenStorageTrie(le.lendingBook, types.EmptyRootHash)
 			le.setError(fmt.Errorf("can't create Lendings trie: %v", err))
 		}
 	}
@@ -164,7 +165,7 @@ func (le *lendingExchangeState) getBorrowingTrie(db Database) Trie {
 		var err error
 		le.borrowingTrie, err = db.OpenStorageTrie(le.lendingBook, le.data.BorrowingRoot)
 		if err != nil {
-			le.borrowingTrie, _ = db.OpenStorageTrie(le.lendingBook, EmptyHash)
+			le.borrowingTrie, _ = db.OpenStorageTrie(le.lendingBook, types.EmptyRootHash)
 			le.setError(fmt.Errorf("can't create bids trie: %v", err))
 		}
 	}
@@ -176,7 +177,7 @@ func (le *lendingExchangeState) getLiquidationTimeTrie(db Database) Trie {
 		var err error
 		le.liquidationTimeTrie, err = db.OpenStorageTrie(le.lendingBook, le.data.LiquidationTimeRoot)
 		if err != nil {
-			le.liquidationTimeTrie, _ = db.OpenStorageTrie(le.lendingBook, EmptyHash)
+			le.liquidationTimeTrie, _ = db.OpenStorageTrie(le.lendingBook, types.EmptyRootHash)
 			le.setError(fmt.Errorf("can't create bids trie: %v", err))
 		}
 	}

--- a/XDCxlending/lendingstate/state_liquidationtime.go
+++ b/XDCxlending/lendingstate/state_liquidationtime.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 )
@@ -78,7 +79,7 @@ func (lt *liquidationTimeState) getTrie(db Database) Trie {
 		var err error
 		lt.trie, err = db.OpenStorageTrie(lt.lendingBook, lt.data.Root)
 		if err != nil {
-			lt.trie, _ = db.OpenStorageTrie(lt.time, EmptyHash)
+			lt.trie, _ = db.OpenStorageTrie(lt.time, types.EmptyRootHash)
 			lt.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
 	}

--- a/XDCxlending/lendingstate/statedb_test.go
+++ b/XDCxlending/lendingstate/statedb_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 )
 
 func TestEchangeStates(t *testing.T) {
@@ -40,7 +41,7 @@ func TestEchangeStates(t *testing.T) {
 	// Create an empty statedb database
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	statedb, _ := New(common.Hash{}, stateCache)
+	statedb, _ := New(types.EmptyRootHash, stateCache)
 
 	// Update it with some lenddinges
 	for i := 0; i < numberOrder; i++ {
@@ -127,7 +128,7 @@ func TestRevertStates(t *testing.T) {
 	// Create an empty statedb database
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	statedb, _ := New(common.Hash{}, stateCache)
+	statedb, _ := New(types.EmptyRootHash, stateCache)
 
 	// Update it with some lenddinges
 	for i := 0; i < numberOrder; i++ {
@@ -234,7 +235,7 @@ func TestDumpStates(t *testing.T) {
 	// Create an empty statedb database
 	db := rawdb.NewMemoryDatabase()
 	stateCache := NewDatabase(db)
-	statedb, _ := New(common.Hash{}, stateCache)
+	statedb, _ := New(types.EmptyRootHash, stateCache)
 	for i := 0; i < len(orderItems); i++ {
 		orderIdHash := common.BigToHash(new(big.Int).SetUint64(orderItems[i].LendingId))
 		statedb.InsertLendingItem(orderBook, orderIdHash, orderItems[i])

--- a/XDCxlending/order_processor_test.go
+++ b/XDCxlending/order_processor_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/XDCxlending/lendingstate"
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 )
 
 func Test_getCancelFeeV1(t *testing.T) {
@@ -97,7 +98,7 @@ func Test_getCancelFee(t *testing.T) {
 	XDCx := XDCx.New(&XDCx.DefaultConfig)
 	db := rawdb.NewMemoryDatabase()
 	stateCache := tradingstate.NewDatabase(db)
-	tradingStateDb, _ := tradingstate.New(common.Hash{}, stateCache)
+	tradingStateDb, _ := tradingstate.New(types.EmptyRootHash, stateCache)
 
 	testTokenA := common.HexToAddress("0x1200000000000000000000000000000000000002")
 	testTokenB := common.HexToAddress("0x1300000000000000000000000000000000000003")

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -32,6 +32,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/core/vm/runtime"
 	"github.com/XinFinOrg/XDPoSChain/internal/flags"
@@ -102,7 +103,7 @@ func runCmd(ctx *cli.Context) error {
 		chainConfig = gen.Config
 	} else {
 		db := rawdb.NewMemoryDatabase()
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		statedb, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 	}
 	if ctx.String(SenderFlag.Name) != "" {
 		sender = common.HexToAddress(ctx.String(SenderFlag.Name))

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -185,7 +185,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if db == nil {
 		db = rawdb.NewMemoryDatabase()
 	}
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	for addr, account := range g.Alloc {
 		statedb.AddBalance(addr, account.Balance)
 		statedb.SetCode(addr, account.Code)

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -71,7 +71,7 @@ func TestLookupStorage(t *testing.T) {
 			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 			txs := []*types.Transaction{tx1, tx2, tx3}
 
-			block := types.NewBlock(&types.Header{Number: big.NewInt(314)}, txs, nil, nil)
+			block := types.NewBlock(&types.Header{Root: types.EmptyRootHash, Number: big.NewInt(314)}, txs, nil, nil)
 
 			// Check that no transactions entries are in a pristine database
 			for i, tx := range txs {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -169,7 +169,7 @@ func (s *stateObject) getTrie(db Database) Trie {
 		var err error
 		s.trie, err = db.OpenStorageTrie(s.addrHash, s.data.Root)
 		if err != nil {
-			s.trie, _ = db.OpenStorageTrie(s.addrHash, common.Hash{})
+			s.trie, _ = db.OpenStorageTrie(s.addrHash, types.EmptyRootHash)
 			s.setError(fmt.Errorf("can't create storage trie: %v", err))
 		}
 	}

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	checker "gopkg.in/check.v1"
@@ -89,7 +90,7 @@ func (s *StateSuite) TestDump(c *checker.C) {
 
 func (s *StateSuite) SetUpTest(c *checker.C) {
 	s.db = rawdb.NewMemoryDatabase()
-	s.state, _ = New(common.Hash{}, NewDatabase(s.db))
+	s.state, _ = New(types.EmptyRootHash, NewDatabase(s.db))
 }
 
 func (s *StateSuite) TestNull(c *checker.C) {
@@ -135,7 +136,7 @@ func (s *StateSuite) TestSnapshotEmpty(c *checker.C) {
 // printing/logging in tests (-check.vv does not work)
 func TestSnapshot2(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
-	state, _ := New(common.Hash{}, NewDatabase(db))
+	state, _ := New(types.EmptyRootHash, NewDatabase(db))
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -39,7 +39,7 @@ import (
 func TestUpdateLeaks(t *testing.T) {
 	// Create an empty state database
 	db := rawdb.NewMemoryDatabase()
-	state, _ := New(common.Hash{}, NewDatabase(db))
+	state, _ := New(types.EmptyRootHash, NewDatabase(db))
 
 	// Update it with some accounts
 	for i := byte(0); i < 255; i++ {
@@ -69,8 +69,8 @@ func TestIntermediateLeaks(t *testing.T) {
 	// Create two state databases, one transitioning to the final state, the other final from the beginning
 	transDb := rawdb.NewMemoryDatabase()
 	finalDb := rawdb.NewMemoryDatabase()
-	transState, _ := New(common.Hash{}, NewDatabase(transDb))
-	finalState, _ := New(common.Hash{}, NewDatabase(finalDb))
+	transState, _ := New(types.EmptyRootHash, NewDatabase(transDb))
+	finalState, _ := New(types.EmptyRootHash, NewDatabase(finalDb))
 
 	modify := func(state *StateDB, addr common.Address, i, tweak byte) {
 		state.SetBalance(addr, big.NewInt(int64(11*i)+int64(tweak)))
@@ -128,7 +128,7 @@ func TestIntermediateLeaks(t *testing.T) {
 func TestCopy(t *testing.T) {
 	// Create a random state test to copy and modify "independently"
 	db := rawdb.NewMemoryDatabase()
-	orig, _ := New(common.Hash{}, NewDatabase(db))
+	orig, _ := New(types.EmptyRootHash, NewDatabase(db))
 
 	for i := byte(0); i < 255; i++ {
 		obj := orig.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
@@ -364,7 +364,7 @@ func (test *snapshotTest) run() bool {
 	// Run all actions and create snapshots.
 	var (
 		db           = rawdb.NewMemoryDatabase()
-		state, _     = New(common.Hash{}, NewDatabase(db))
+		state, _     = New(types.EmptyRootHash, NewDatabase(db))
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
 	)
@@ -378,7 +378,7 @@ func (test *snapshotTest) run() bool {
 	// Revert all snapshots in reverse order. Each revert must yield a state
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
-		checkstate, _ := New(common.Hash{}, state.Database())
+		checkstate, _ := New(types.EmptyRootHash, state.Database())
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)
 		}
@@ -462,7 +462,7 @@ func TestStateDBAccessList(t *testing.T) {
 
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db)
+	state, _ := New(types.EmptyRootHash, db)
 	state.accessList = newAccessList()
 
 	verifyAddrs := func(astrings ...string) {
@@ -628,7 +628,7 @@ func TestStateDBAccessList(t *testing.T) {
 func TestStateDBTransientStorage(t *testing.T) {
 	memDb := rawdb.NewMemoryDatabase()
 	db := NewDatabase(memDb)
-	state, _ := New(common.Hash{}, db)
+	state, _ := New(types.EmptyRootHash, db)
 
 	key := common.Hash{0x01}
 	value := common.Hash{0x02}

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -42,7 +42,7 @@ type testAccount struct {
 func makeTestState() (Database, common.Hash, []*testAccount) {
 	// Create an empty state
 	db := NewDatabase(rawdb.NewMemoryDatabase())
-	state, _ := New(common.Hash{}, db)
+	state, _ := New(types.EmptyRootHash, db)
 
 	// Fill it with some arbitrary data
 	accounts := []*testAccount{}

--- a/core/txpool/txpool_test.go
+++ b/core/txpool/txpool_test.go
@@ -80,6 +80,7 @@ func (bc *testBlockChain) Config() *params.ChainConfig {
 
 func (bc *testBlockChain) CurrentBlock() *types.Block {
 	return types.NewBlock(&types.Header{
+		Root:     types.EmptyRootHash,
 		GasLimit: atomic.LoadUint64(&bc.gasLimit),
 	}, nil, nil, nil)
 }
@@ -134,7 +135,7 @@ func setupPool() (*TxPool, *ecdsa.PrivateKey) {
 
 func setupPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateKey) {
 	diskdb := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(diskdb))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(diskdb))
 	blockchain := &testBlockChain{statedb, 10000000, new(event.Feed)}
 
 	key, _ := crypto.GenerateKey()
@@ -224,7 +225,7 @@ func (c *testChain) State() (*state.StateDB, error) {
 	stdb := c.statedb
 	if *c.trigger {
 		db := rawdb.NewMemoryDatabase()
-		c.statedb, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		c.statedb, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 		// simulate that the new head block included tx0 and tx1
 		c.statedb.SetNonce(c.address, 2)
 		c.statedb.SetBalance(c.address, new(big.Int).SetUint64(params.Ether))
@@ -243,7 +244,7 @@ func TestStateChangeDuringReset(t *testing.T) {
 		db         = rawdb.NewMemoryDatabase()
 		key, _     = crypto.GenerateKey()
 		address    = crypto.PubkeyToAddress(key.PublicKey)
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		statedb, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 		trigger    = false
 	)
 
@@ -442,7 +443,7 @@ func TestChainFork(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
 		db := rawdb.NewMemoryDatabase()
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 		statedb.AddBalance(addr, big.NewInt(100000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
@@ -472,7 +473,7 @@ func TestDoubleNonce(t *testing.T) {
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	resetState := func() {
 		db := rawdb.NewMemoryDatabase()
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 		statedb.AddBalance(addr, big.NewInt(100000000000000))
 
 		pool.chain = &testBlockChain{statedb, 1000000, new(event.Feed)}
@@ -673,7 +674,7 @@ func TestPostponing(t *testing.T) {
 
 	// Create the pool to test the postponing with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -887,7 +888,7 @@ func testQueueGlobalLimiting(t *testing.T, nolocals bool) {
 
 	// Create the pool to test the limit enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -980,7 +981,7 @@ func testQueueTimeLimiting(t *testing.T, nolocals bool) {
 
 	// Create the pool to test the non-expiration enforcement
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1166,7 +1167,7 @@ func TestPendingGlobalLimiting(t *testing.T) {
 
 	// Create the pool to test the limit enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1269,7 +1270,7 @@ func TestCapClearsFromAll(t *testing.T) {
 
 	// Create the pool to test the limit enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1304,7 +1305,7 @@ func TestPendingMinimumAllowance(t *testing.T) {
 
 	// Create the pool to test the limit enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1353,7 +1354,7 @@ func TestRepricing(t *testing.T) {
 
 	// Create the pool to test the pricing enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -1602,7 +1603,7 @@ func TestRepricingKeepsLocals(t *testing.T) {
 
 	// Create the pool to test the pricing enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
@@ -1677,7 +1678,7 @@ func TestPoolUnderpricing(t *testing.T) {
 
 	// Create the pool to test the pricing enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -1784,7 +1785,7 @@ func TestPoolStableUnderpricing(t *testing.T) {
 
 	// Create the pool to test the pricing enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -2017,7 +2018,7 @@ func TestDeduplication(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the pricing enforcement with
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -2084,7 +2085,7 @@ func TestReplacement(t *testing.T) {
 
 	// Create the pool to test the pricing enforcement with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
@@ -2290,7 +2291,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 
 	// Create the original pool to inject transaction into the journal
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	config := testTxPoolConfig
@@ -2389,7 +2390,7 @@ func TestStatusCheck(t *testing.T) {
 
 	// Create the pool to test the status retrievals with
 	db := rawdb.NewMemoryDatabase()
-	statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
 	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -23,14 +23,11 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/XDCx/tradingstate"
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/holiman/uint256"
 )
-
-// emptyCodeHash is used by create to ensure deployment is disallowed to already
-// deployed contract addresses (relevant after the account abstraction).
-var emptyCodeHash = crypto.Keccak256Hash(nil)
 
 type (
 	// CanTransferFunc is the signature of a transfer guard function
@@ -440,7 +437,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	}
 	// Ensure there's no existing contract already at the designated address
 	contractHash := evm.StateDB.GetCodeHash(address)
-	if evm.StateDB.GetNonce(address) != 0 || (contractHash != (common.Hash{}) && contractHash != emptyCodeHash) {
+	if evm.StateDB.GetNonce(address) != 0 || (contractHash != (common.Hash{}) && contractHash != types.EmptyCodeHash) {
 		return nil, common.Address{}, 0, ErrContractAddressCollision
 	}
 	// Create a new account on the state

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/hexutil"
@@ -84,7 +85,7 @@ func TestEIP2200(t *testing.T) {
 	for i, tt := range eip2200Tests {
 		address := common.BytesToAddress([]byte("contract"))
 		db := rawdb.NewMemoryDatabase()
-		statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+		statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 		statedb.CreateAccount(address)
 		statedb.SetCode(address, hexutil.MustDecode(tt.input))
 		statedb.SetState(address, common.Hash{}, common.BytesToHash([]byte{tt.original}))
@@ -135,7 +136,7 @@ func TestCreateGas(t *testing.T) {
 		var gasUsed = uint64(0)
 		doCheck := func(testGas int) bool {
 			address := common.BytesToAddress([]byte("contract"))
-			statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+			statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()))
 			statedb.CreateAccount(address)
 			statedb.SetCode(address, hexutil.MustDecode(tt.code))
 			statedb.Finalise(true)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -487,7 +487,7 @@ func opRandom(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 	if interpreter.evm.Context.Random != nil {
 		v = new(uint256.Int).SetBytes((interpreter.evm.Context.Random.Bytes()))
 	} else { // if context random is not set, use emptyCodeHash as default
-		v = new(uint256.Int).SetBytes(emptyCodeHash.Bytes())
+		v = new(uint256.Int).SetBytes(types.EmptyCodeHash.Bytes())
 	}
 	scope.Stack.push(v)
 	return nil, nil

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -732,7 +732,7 @@ func TestRandom(t *testing.T) {
 	for _, tt := range []testcase{
 		{name: "empty hash", random: common.Hash{}},
 		{name: "1", random: common.Hash{0}},
-		{name: "emptyCodeHash", random: emptyCodeHash},
+		{name: "emptyCodeHash", random: types.EmptyCodeHash},
 		{name: "hash(0x010203)", random: crypto.Keccak256Hash([]byte{0x01, 0x02, 0x03})},
 	} {
 		var (

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/common/math"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/holiman/uint256"
@@ -588,7 +589,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 
 func TestOpTstore(t *testing.T) {
 	var (
-		statedb, _     = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+		statedb, _     = state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()))
 		env            = NewEVM(BlockContext{}, TxContext{}, statedb, nil, params.TestChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -113,7 +114,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 
 	if cfg.State == nil {
 		db := rawdb.NewMemoryDatabase()
-		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		cfg.State, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 	}
 	var (
 		address = common.BytesToAddress([]byte("contract"))
@@ -149,7 +150,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 
 	if cfg.State == nil {
 		db := rawdb.NewMemoryDatabase()
-		cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		cfg.State, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 	}
 	var (
 		vmenv  = NewEnv(cfg)

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -102,7 +102,7 @@ func TestExecute(t *testing.T) {
 
 func TestCall(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
-	state, _ := state.New(common.Hash{}, state.NewDatabase(db))
+	state, _ := state.New(types.EmptyRootHash, state.NewDatabase(db))
 	address := common.HexToAddress("0x0a")
 	state.SetCode(address, []byte{
 		byte(vm.PUSH1), 10,
@@ -159,7 +159,7 @@ func BenchmarkCall(b *testing.B) {
 func benchmarkEVM_Create(bench *testing.B, code string) {
 	var (
 		db         = rawdb.NewMemoryDatabase()
-		statedb, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		statedb, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 		sender     = common.BytesToAddress([]byte("sender"))
 		receiver   = common.BytesToAddress([]byte("receiver"))
 	)
@@ -335,7 +335,7 @@ func TestBlockhash(t *testing.T) {
 func benchmarkNonModifyingCode(gas uint64, code []byte, name string, b *testing.B) {
 	cfg := new(Config)
 	setDefaults(cfg)
-	cfg.State, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()))
+	cfg.State, _ = state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()))
 	cfg.GasLimit = gas
 	var (
 		destination = common.BytesToAddress([]byte("contract"))

--- a/eth/api_test.go
+++ b/eth/api_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
@@ -33,7 +34,7 @@ func TestStorageRangeAt(t *testing.T) {
 	// Create a state where account 0x010000... has a few storage entries.
 	var (
 		db       = rawdb.NewMemoryDatabase()
-		state, _ = state.New(common.Hash{}, state.NewDatabase(db))
+		state, _ = state.New(types.EmptyRootHash, state.NewDatabase(db))
 		addr     = common.Address{0x01}
 		keys     = []common.Hash{ // hashes of Keys of storage
 			common.HexToHash("340dd630ad21bf010b4e676dbfa9ba9a02175262d1fa356232cfde6cb5b47ef2"),

--- a/eth/fetcher/fetcher_test.go
+++ b/eth/fetcher/fetcher_test.go
@@ -39,7 +39,7 @@ var (
 	testKey, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	testAddress  = crypto.PubkeyToAddress(testKey.PublicKey)
 	genesis      = core.GenesisBlockForTesting(testdb, testAddress, big.NewInt(1000000000))
-	unknownBlock = types.NewBlock(&types.Header{GasLimit: params.GenesisGasLimit}, nil, nil, nil)
+	unknownBlock = types.NewBlock(&types.Header{Root: types.EmptyRootHash, GasLimit: params.GenesisGasLimit}, nil, nil, nil)
 )
 
 // makeChain creates a chain of n blocks starting at and including parent.

--- a/les/request_test.go
+++ b/les/request_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
@@ -79,7 +80,7 @@ func tfCodeAccess(db ethdb.Database, bhash common.Hash, num uint64) light.OdrReq
 		return nil
 	}
 	sti := light.StateTrieID(header)
-	ci := light.StorageTrieID(sti, crypto.Keccak256Hash(testContractAddr[:]), common.Hash{})
+	ci := light.StorageTrieID(sti, crypto.Keccak256Hash(testContractAddr[:]), types.EmptyRootHash)
 	return &light.CodeRequest{Id: ci, Hash: crypto.Keccak256Hash(testContractCodeDeployed)}
 }
 

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -147,7 +147,7 @@ func NewChtIndexer(db ethdb.Database, clientMode bool) *core.ChainIndexer {
 
 // Reset implements core.ChainIndexerBackend
 func (c *ChtIndexerBackend) Reset(section uint64, lastSectionHead common.Hash) error {
-	var root common.Hash
+	root := types.EmptyRootHash
 	if section > 0 {
 		root = GetChtRoot(c.diskdb, section-1, lastSectionHead)
 	}
@@ -245,7 +245,7 @@ func NewBloomTrieIndexer(db ethdb.Database, clientMode bool) *core.ChainIndexer 
 
 // Reset implements core.ChainIndexerBackend
 func (b *BloomTrieIndexerBackend) Reset(section uint64, lastSectionHead common.Hash) error {
-	var root common.Hash
+	root := types.EmptyRootHash
 	if section > 0 {
 		root = GetBloomTrieRoot(b.diskdb, section-1, lastSectionHead)
 	}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -187,7 +187,7 @@ func (t *StateTest) gasLimit(subtest StateSubtest) uint64 {
 
 func MakePreState(db ethdb.Database, accounts types.GenesisAlloc) *state.StateDB {
 	sdb := state.NewDatabase(db)
-	statedb, _ := state.New(common.Hash{}, sdb)
+	statedb, _ := state.New(types.EmptyRootHash, sdb)
 	for addr, a := range accounts {
 		statedb.SetCode(addr, a.Code)
 		statedb.SetNonce(addr, a.Nonce)

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -295,7 +295,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	diskdb := memorydb.New()
 	triedb := NewDatabase(diskdb)
 
-	tr, _ := New(common.Hash{}, triedb)
+	tr, _ := New(emptyRoot, triedb)
 	for _, val := range testdata1 {
 		tr.Update([]byte(val.k), []byte(val.v))
 	}
@@ -386,7 +386,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	diskdb := memorydb.New()
 	triedb := NewDatabase(diskdb)
 
-	ctr, _ := New(common.Hash{}, triedb)
+	ctr, _ := New(emptyRoot, triedb)
 	for _, val := range testdata1 {
 		ctr.Update([]byte(val.k), []byte(val.v))
 	}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -419,7 +419,7 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 	// Special case, there is no edge proof at all. The given range is expected
 	// to be the whole leaf-set in the trie.
 	if firstProof == nil && lastProof == nil {
-		emptytrie, err := New(common.Hash{}, NewDatabase(memorydb.New()))
+		emptytrie, err := New(emptyRoot, NewDatabase(memorydb.New()))
 		if err != nil {
 			return err, false
 		}

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -28,7 +28,7 @@ import (
 func makeTestTrie() (*Database, *Trie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(memorydb.New())
-	trie, _ := New(common.Hash{}, triedb)
+	trie, _ := New(emptyRoot, triedb)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -90,7 +90,7 @@ func checkTrieConsistency(db *Database, root common.Hash) error {
 func TestEmptySync(t *testing.T) {
 	dbA := NewDatabase(memorydb.New())
 	dbB := NewDatabase(memorydb.New())
-	emptyA, _ := New(common.Hash{}, dbA)
+	emptyA, _ := New(emptyRoot, dbA)
 	emptyB, _ := New(emptyRoot, dbB)
 
 	for i, trie := range []*Trie{emptyA, emptyB} {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -28,7 +28,9 @@ import (
 )
 
 var (
-	// TODO: remove file core/types/derive_sha.go, then remove emptyRoot and emptyState
+	// TODO(daniel):
+	// 1. remove file core/types/derive_sha.go, Ref: #21502
+	// 2. then replace emptyRoot, emptyState with types.EmptyRootHash, types.EmptyCodeHash, Ref: #26718
 
 	// emptyRoot is the known root hash of an empty trie.
 	emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -44,7 +44,7 @@ func init() {
 
 // Used for testing
 func newEmpty() *Trie {
-	trie, _ := New(common.Hash{}, NewDatabase(memorydb.New()))
+	trie, _ := New(emptyRoot, NewDatabase(memorydb.New()))
 	return trie
 }
 
@@ -84,7 +84,7 @@ func testMissingNode(t *testing.T, memonly bool) {
 	diskdb := memorydb.New()
 	triedb := NewDatabase(diskdb)
 
-	trie, _ := New(common.Hash{}, triedb)
+	trie, _ := New(emptyRoot, triedb)
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
 	root, _ := trie.Commit(nil)
@@ -424,7 +424,7 @@ func runRandTestBool(rt randTest) bool {
 func runRandTest(rt randTest) error {
 	triedb := NewDatabase(memorydb.New())
 
-	tr, _ := New(common.Hash{}, triedb)
+	tr, _ := New(emptyRoot, triedb)
 	values := make(map[string]string) // tracks content of the trie
 
 	for i, step := range rt {
@@ -460,7 +460,7 @@ func runRandTest(rt randTest) error {
 			}
 			tr = newtr
 		case opItercheckhash:
-			checktr, _ := New(common.Hash{}, triedb)
+			checktr, _ := New(emptyRoot, triedb)
 			it := NewIterator(tr.NodeIterator(nil))
 			for it.Next() {
 				checktr.Update(it.Key, it.Value)
@@ -497,7 +497,7 @@ func benchGet(b *testing.B, commit bool) {
 	trie := new(Trie)
 	if commit {
 		tmpdb := tempDB(b)
-		trie, _ = New(common.Hash{}, tmpdb)
+		trie, _ = New(emptyRoot, tmpdb)
 	}
 	k := make([]byte, 32)
 	for i := 0; i < benchElemCount; i++ {
@@ -624,7 +624,7 @@ func TestTinyTrie(t *testing.T) {
 		t.Fatalf("3: got %x, exp %x", root, exp)
 	}
 
-	checktr, _ := New(common.Hash{}, trie.Db)
+	checktr, _ := New(emptyRoot, trie.Db)
 	it := NewIterator(trie.NodeIterator(nil))
 	for it.Next() {
 		checktr.Update(it.Key, it.Value)


### PR DESCRIPTION
# Proposed changes

This PR fixes the empty trie initialization by using `types.EmptyRootHash` and eliminates `emptyCodeHash` in package `core/vm`. While the `common.Hash{}` is still accepted in case we still use it somewhere else.

Ref: 
- #27230
- #27729

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
