### PR TITLE
core/vm: implement the BLOBHASH opcode 0x49

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -256,11 +256,36 @@ func opMcopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 	return nil, nil
 }
 
+// opBlobHash implements the BLOBHASH opcode
+func opBlobHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	index := scope.Stack.peek()
+	// xdc chain have no blob hash, so len(interpreter.evm.TxContext.BlobHashes) is always 0
+	// and index.LtUint64(uint64(len(interpreter.evm.TxContext.BlobHashes))) is always false
+	// if index.LtUint64(uint64(len(interpreter.evm.TxContext.BlobHashes))) {
+	// 	blobHash := interpreter.evm.TxContext.BlobHashes[index.Uint64()]
+	// 	index.SetBytes32(blobHash[:])
+	// } else {
+	// 	index.Clear()
+	// }
+	index.Clear()
+	return nil, nil
+}
+
 // opBlobBaseFee implements BLOBBASEFEE opcode
 func opBlobBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	blobBaseFee := new(uint256.Int)
 	scope.Stack.push(blobBaseFee)
 	return nil, nil
+}
+
+// enable4844 applies EIP-4844 (BLOBHASH opcode)
+func enable4844(jt *JumpTable) {
+	jt[BLOBHASH] = &operation{
+		execute:     opBlobHash,
+		constantGas: GasFastestStep,
+		minStack:    minStack(1, 1),
+		maxStack:    maxStack(1, 1),
+	}
 }
 
 // enable7516 applies EIP-7516 (BLOBBASEFEE opcode)

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -82,6 +82,7 @@ func validate(jt JumpTable) JumpTable {
 
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newEip1559InstructionSet()
+	enable4844(&instructionSet) // EIP-4844 (BLOBHASH opcode)
 	enable7516(&instructionSet) // EIP-7516 (BLOBBASEFEE opcode)
 	enable1153(&instructionSet) // EIP-1153 "Transient Storage"
 	enable5656(&instructionSet) // EIP-5656 (MCOPY opcode)

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -100,6 +100,7 @@ const (
 	CHAINID     OpCode = 0x46
 	SELFBALANCE OpCode = 0x47
 	BASEFEE     OpCode = 0x48
+	BLOBHASH    OpCode = 0x49
 	BLOBBASEFEE OpCode = 0x4a
 )
 
@@ -285,6 +286,7 @@ var opCodeToString = [256]string{
 	CHAINID:     "CHAINID",
 	SELFBALANCE: "SELFBALANCE",
 	BASEFEE:     "BASEFEE",
+	BLOBHASH:    "BLOBHASH",
 	BLOBBASEFEE: "BLOBBASEFEE",
 
 	// 0x50 range - 'storage' and execution.
@@ -460,6 +462,7 @@ var stringToOp = map[string]OpCode{
 	"GASLIMIT":       GASLIMIT,
 	"SELFBALANCE":    SELFBALANCE,
 	"BASEFEE":        BASEFEE,
+	"BLOBHASH":       BLOBHASH,
 	"BLOBBASEFEE":    BLOBBASEFEE,
 	"POP":            POP,
 	"MLOAD":          MLOAD,


### PR DESCRIPTION
# Proposed changes

This PR implements the `BLOBHASH` opcode 0x49 for EIP-4844.

Ref: #27356

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
