### PR TITLE
all: update to go version 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: '1.22.x'
+          go-version: '1.23.x'
       - name: Run tests
         run: ${{ matrix.script }}
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile.bootnode
+++ b/Dockerfile.bootnode
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers
 

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 GOBIN = $(shell pwd)/build/bin
 GOFMT = gofmt
-GO ?= 1.22.10
+GO ?= 1.23.6
 GORUN = go run
 GO_PACKAGES = .
 GO_FILES := $(shell find $(shell go list -f '{{.Dir}}' $(GO_PACKAGES)) -name \*.go)

--- a/build/ci.go
+++ b/build/ci.go
@@ -121,9 +121,9 @@ func doInstall(cmdline []string) {
 		var minor int
 		fmt.Sscanf(strings.TrimPrefix(runtime.Version(), "go1."), "%d", &minor)
 
-		if minor < 21 {
+		if minor < 23 {
 			log.Println("You have Go version", runtime.Version())
-			log.Println("XDC requires at least Go version 1.22 and cannot")
+			log.Println("XDC requires at least Go version 1.23 and cannot")
 			log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
 			os.Exit(1)
 		}

--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as builder
+FROM golang:1.23-alpine as builder
 
 RUN apk add make build-base linux-headers
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/XinFinOrg/XDPoSChain
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.2


### PR DESCRIPTION
# Proposed changes

Go 1.23 has brought many performance improvements and stability fixes, including issue mentioned in #832. With Go 1.24 coming out soon (expected in February 2025), upgrading to Go 1.23 now will help us prepare for future version changes. So this PR upgrades the codebase to Go 1.23 to make the code more reliable and easier to maintain.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [x] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
