### PR TITLE
cmd: deprecate the `--mine` flag

### DIFF
--- a/cmd/XDC/config.go
+++ b/cmd/XDC/config.go
@@ -92,16 +92,15 @@ type Bootnodes struct {
 }
 
 type XDCConfig struct {
-	Eth         ethconfig.Config
-	Node        node.Config
-	Ethstats    ethstatsConfig
-	Metrics     metrics.Config
-	XDCX        XDCx.Config
-	Account     account
-	StakeEnable bool
-	Bootnodes   Bootnodes
-	Verbosity   int
-	NAT         string
+	Eth       ethconfig.Config
+	Node      node.Config
+	Ethstats  ethstatsConfig
+	Metrics   metrics.Config
+	XDCX      XDCx.Config
+	Account   account
+	Bootnodes Bootnodes
+	Verbosity int
+	NAT       string
 }
 
 func loadConfig(file string, cfg *XDCConfig) error {
@@ -132,13 +131,12 @@ func defaultNodeConfig() node.Config {
 func makeConfigNode(ctx *cli.Context) (*node.Node, XDCConfig) {
 	// Load defaults.
 	cfg := XDCConfig{
-		Eth:         ethconfig.Defaults,
-		XDCX:        XDCx.DefaultConfig,
-		Node:        defaultNodeConfig(),
-		Metrics:     metrics.DefaultConfig,
-		StakeEnable: true,
-		Verbosity:   3,
-		NAT:         "",
+		Eth:       ethconfig.Defaults,
+		XDCX:      XDCx.DefaultConfig,
+		Node:      defaultNodeConfig(),
+		Metrics:   metrics.DefaultConfig,
+		Verbosity: 3,
+		NAT:       "",
 	}
 	// Load config file.
 	if file := ctx.String(configFileFlag.Name); file != "" {
@@ -147,7 +145,7 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, XDCConfig) {
 		}
 	}
 	if ctx.IsSet(utils.MiningEnabledFlag.Name) {
-		cfg.StakeEnable = ctx.Bool(utils.MiningEnabledFlag.Name)
+		log.Warn("The flag --mine is deprecated and will be removed")
 	}
 	// if !ctx.IsSet(debug.VerbosityFlag.Name) {
 	// 	debug.Verbosity(log.Lvl(cfg.Verbosity))

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -334,11 +334,6 @@ var (
 	}
 
 	// Miner settings
-	MiningEnabledFlag = &cli.BoolFlag{
-		Name:     "mine",
-		Usage:    "Enable mining",
-		Category: flags.MinerCategory,
-	}
 	MinerThreadsFlag = &cli.IntFlag{
 		Name:     "miner-threads",
 		Aliases:  []string{"minerthreads"},

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -37,6 +37,7 @@ var DeprecatedFlags = []cli.Flag{
 	NoUSBFlag,
 	LogBacktraceAtFlag,
 	LogDebugFlag,
+	MiningEnabledFlag,
 }
 
 var (
@@ -72,6 +73,12 @@ var (
 	MetricsEnabledExpensiveFlag = &cli.BoolFlag{
 		Name:     "metrics-expensive",
 		Usage:    "Enable expensive metrics collection and reporting (deprecated)",
+		Category: flags.DeprecatedCategory,
+	}
+	// Deprecated February 2025
+	MiningEnabledFlag = &cli.BoolFlag{
+		Name:     "mine",
+		Usage:    "Enable mining (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 )


### PR DESCRIPTION
# Proposed changes

This PR deprecates the flag `--mine`. This flag is not used really.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [X] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
