### PR TITLE
cmd/utils: deprecate flag `--XDCx-datadir`

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -785,13 +785,6 @@ var (
 		Usage:    "Enable the XDCX protocol",
 		Category: flags.XdcxCategory,
 	}
-	XDCXDataDirFlag = &flags.DirectoryFlag{
-		Name:     "XDCx-datadir",
-		Aliases:  []string{"XDCx.datadir"},
-		Usage:    "Data directory for the XDCX databases",
-		Value:    flags.DirectoryString(filepath.Join(DataDirFlag.Value.String(), "XDCx")),
-		Category: flags.XdcxCategory,
-	}
 	XDCXDBEngineFlag = &cli.StringFlag{
 		Name:     "XDCx-dbengine",
 		Aliases:  []string{"XDCx.dbengine"},
@@ -1375,19 +1368,10 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 
 func SetXDCXConfig(ctx *cli.Context, cfg *XDCx.Config, XDCDataDir string) {
 	if ctx.IsSet(XDCXDataDirFlag.Name) {
-		cfg.DataDir = ctx.String(XDCXDataDirFlag.Name)
-	} else {
-		// default XDCx datadir: DATADIR/XDCx
-		defaultXDCXDataDir := filepath.Join(XDCDataDir, "XDCx")
-
-		filesInXDCXDefaultDir, _ := WalkMatch(defaultXDCXDataDir, "*.ldb")
-		filesInNodeDefaultDir, _ := WalkMatch(node.DefaultDataDir(), "*.ldb")
-		if len(filesInXDCXDefaultDir) == 0 && len(filesInNodeDefaultDir) > 0 {
-			cfg.DataDir = node.DefaultDataDir()
-		} else {
-			cfg.DataDir = defaultXDCXDataDir
-		}
+		log.Warn("The flag XDCx-datadir or XDCx.datadir is deprecated, please remove this flag")
 	}
+	// XDCx datadir: XDCDataDir/XDCx
+	cfg.DataDir = filepath.Join(XDCDataDir, "XDCx")
 	log.Info("XDCX datadir", "path", cfg.DataDir)
 	if ctx.IsSet(XDCXDBEngineFlag.Name) {
 		cfg.DBEngine = ctx.String(XDCXDBEngineFlag.Name)

--- a/cmd/utils/flags_legacy.go
+++ b/cmd/utils/flags_legacy.go
@@ -38,6 +38,7 @@ var DeprecatedFlags = []cli.Flag{
 	LogBacktraceAtFlag,
 	LogDebugFlag,
 	MiningEnabledFlag,
+	XDCXDataDirFlag,
 }
 
 var (
@@ -79,6 +80,12 @@ var (
 	MiningEnabledFlag = &cli.BoolFlag{
 		Name:     "mine",
 		Usage:    "Enable mining (deprecated)",
+		Category: flags.DeprecatedCategory,
+	}
+	XDCXDataDirFlag = &flags.DirectoryFlag{
+		Name:     "XDCx-datadir",
+		Aliases:  []string{"XDCx.datadir"},
+		Usage:    "Data directory for the XDCX databases (deprecated)",
 		Category: flags.DeprecatedCategory,
 	}
 )


### PR DESCRIPTION
# Proposed changes

This PR deprecates flag `--XDCx-datadir` since this directory is always `<node_data_dir>/XDCx`.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
