### PR TITLE
cmd/utils: change default value of some flags to simplify sync

### DIFF
--- a/cmd/XDC/consolecmd_test.go
+++ b/cmd/XDC/consolecmd_test.go
@@ -101,7 +101,7 @@ func TestHTTPAttachWelcome(t *testing.T) {
 	XDC := runXDC(t,
 		"--datadir", datadir, "--XDCx-datadir", datadir+"/XDCx",
 		"--port", "0", "--maxpeers", "0", "--nodiscover", "--nat", "none",
-		"--miner-etherbase", coinbase, "--http", "--http-port", port)
+		"--miner-etherbase", coinbase, "--http", "--http-port", port, "--http-api", "eth,net,rpc,web3")
 
 	time.Sleep(2 * time.Second) // Simple way to wait for the RPC endpoint to open
 	testAttachWelcome(t, XDC, "http://localhost:"+port, httpAPIs)
@@ -117,7 +117,7 @@ func TestWSAttachWelcome(t *testing.T) {
 	XDC := runXDC(t,
 		"--datadir", datadir, "--XDCx-datadir", datadir+"/XDCx",
 		"--port", "0", "--maxpeers", "0", "--nodiscover", "--nat", "none",
-		"--miner-etherbase", coinbase, "--ws", "--ws-port", port)
+		"--miner-etherbase", coinbase, "--ws", "--ws-port", port, "--ws-api", "eth,net,rpc,web3")
 
 	time.Sleep(2 * time.Second) // Simple way to wait for the RPC endpoint to open
 	testAttachWelcome(t, XDC, "ws://localhost:"+port, httpAPIs)


### PR DESCRIPTION
# Proposed changes

This PR changes the default value of some flag to simplify sync. So the users don't need to set many flags in the script. The change log is as follows:

|           flag |   old value |                                    new value |
| -------------: | ----------: | -------------------------------------------: |
|      etherbase |         "0" | "0x000000000000000000000000000000000000abcd" |
|            rpc |       false |                                         true |
|        rpcaddr | "localhost" |                                    "0.0.0.0" |
|         rpcapi |          "" | ""eth,debug,net,txpool,personal,web3,XDPoS"" |
|  rpccorsdomain |          "" |                                          "*" |
|      rpcvhosts | "localhost" |                                          "*" |
|             ws |       false |                                         true |
|         wsaddr | "localhsot" |                                    "0.0.0.0" |
|          wsapi |          "" | ""eth,debug,net,txpool,personal,web3,XDPoS"" |
|      wsorigins |          "" |                                          "*" |
|       gasprice |   0.25 gwei |                                        1 wei |
| targetgaslimit |    84000000 |                                     50000000 |

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
