### PR TITLE
cmd, common, eth: copy constants after get chain id

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1447,7 +1447,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.Bool(XDCTestnetFlag.Name) {
 		cfg.NetworkId = 51
 	}
-	common.CopyConstans(cfg.NetworkId)
 
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheDatabaseFlag.Name) {
 		cfg.DatabaseCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheDatabaseFlag.Name) / 100

--- a/common/constants.go
+++ b/common/constants.go
@@ -143,8 +143,8 @@ var (
 	LendingRegistrationSMC        = MaintnetConstant.lendingRegistrationSMC
 	LendingRegistrationSMCTestnet = MaintnetConstant.lendingRegistrationSMCTestnet
 
-	ignoreSignerCheckBlockArray = map[uint64]struct{}{}
-	blacklist                   = map[Address]struct{}{}
+	ignoreSignerCheckBlockArray = MaintnetConstant.ignoreSignerCheckBlockArray
+	blacklist                   = MaintnetConstant.blacklist
 )
 
 func IsIgnoreSignerCheckBlock(blockNumber uint64) bool {
@@ -160,12 +160,13 @@ func IsInBlacklist(address *Address) bool {
 	return ok
 }
 
+// CopyConstans only handles testnet, devnet, local. It does not
+// handles mainnet since the default value is from mainnet.
 func CopyConstans(chainID uint64) {
 	var c *constant
-	if chainID == MaintnetConstant.chainID {
-		c = &MaintnetConstant
-	} else if chainID == TestnetConstant.chainID {
+	if chainID == TestnetConstant.chainID {
 		c = &TestnetConstant
+		IsTestnet = true
 	} else if chainID == DevnetConstant.chainID {
 		c = &DevnetConstant
 	} else if chainID == localConstant.chainID {

--- a/common/constants/constants.go.devnet
+++ b/common/constants/constants.go.devnet
@@ -143,8 +143,8 @@ var (
 	LendingRegistrationSMC        = MaintnetConstant.lendingRegistrationSMC
 	LendingRegistrationSMCTestnet = MaintnetConstant.lendingRegistrationSMCTestnet
 
-	ignoreSignerCheckBlockArray = map[uint64]struct{}{}
-	blacklist                   = map[Address]struct{}{}
+	ignoreSignerCheckBlockArray = MaintnetConstant.ignoreSignerCheckBlockArray
+	blacklist                   = MaintnetConstant.blacklist
 )
 
 func IsIgnoreSignerCheckBlock(blockNumber uint64) bool {
@@ -160,12 +160,13 @@ func IsInBlacklist(address *Address) bool {
 	return ok
 }
 
+// CopyConstans only handles testnet, devnet, local. It does not
+// handles mainnet since the default value is from mainnet.
 func CopyConstans(chainID uint64) {
 	var c *constant
-	if chainID == MaintnetConstant.chainID {
-		c = &MaintnetConstant
-	} else if chainID == TestnetConstant.chainID {
+	if chainID == TestnetConstant.chainID {
 		c = &TestnetConstant
+		IsTestnet = true
 	} else if chainID == DevnetConstant.chainID {
 		c = &DevnetConstant
 	} else if chainID == localConstant.chainID {

--- a/common/constants/constants.go.local
+++ b/common/constants/constants.go.local
@@ -143,8 +143,8 @@ var (
 	LendingRegistrationSMC        = MaintnetConstant.lendingRegistrationSMC
 	LendingRegistrationSMCTestnet = MaintnetConstant.lendingRegistrationSMCTestnet
 
-	ignoreSignerCheckBlockArray = map[uint64]struct{}{}
-	blacklist                   = map[Address]struct{}{}
+	ignoreSignerCheckBlockArray = MaintnetConstant.ignoreSignerCheckBlockArray
+	blacklist                   = MaintnetConstant.blacklist
 )
 
 func IsIgnoreSignerCheckBlock(blockNumber uint64) bool {
@@ -160,12 +160,13 @@ func IsInBlacklist(address *Address) bool {
 	return ok
 }
 
+// CopyConstans only handles testnet, devnet, local. It does not
+// handles mainnet since the default value is from mainnet.
 func CopyConstans(chainID uint64) {
 	var c *constant
-	if chainID == MaintnetConstant.chainID {
-		c = &MaintnetConstant
-	} else if chainID == TestnetConstant.chainID {
+	if chainID == TestnetConstant.chainID {
 		c = &TestnetConstant
+		IsTestnet = true
 	} else if chainID == DevnetConstant.chainID {
 		c = &DevnetConstant
 	} else if chainID == localConstant.chainID {

--- a/common/constants/constants.go.testnet
+++ b/common/constants/constants.go.testnet
@@ -143,8 +143,8 @@ var (
 	LendingRegistrationSMC        = MaintnetConstant.lendingRegistrationSMC
 	LendingRegistrationSMCTestnet = MaintnetConstant.lendingRegistrationSMCTestnet
 
-	ignoreSignerCheckBlockArray = map[uint64]struct{}{}
-	blacklist                   = map[Address]struct{}{}
+	ignoreSignerCheckBlockArray = MaintnetConstant.ignoreSignerCheckBlockArray
+	blacklist                   = MaintnetConstant.blacklist
 )
 
 func IsIgnoreSignerCheckBlock(blockNumber uint64) bool {
@@ -160,12 +160,13 @@ func IsInBlacklist(address *Address) bool {
 	return ok
 }
 
+// CopyConstans only handles testnet, devnet, local. It does not
+// handles mainnet since the default value is from mainnet.
 func CopyConstans(chainID uint64) {
 	var c *constant
-	if chainID == MaintnetConstant.chainID {
-		c = &MaintnetConstant
-	} else if chainID == TestnetConstant.chainID {
+	if chainID == TestnetConstant.chainID {
 		c = &TestnetConstant
+		IsTestnet = true
 	} else if chainID == DevnetConstant.chainID {
 		c = &DevnetConstant
 	} else if chainID == localConstant.chainID {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -131,16 +131,18 @@ func New(ctx *node.ServiceContext, config *ethconfig.Config, XDCXServ *XDCx.XDCX
 		return nil, genesisErr
 	}
 
+	networkID := config.NetworkId
+	if networkID == 0 {
+		networkID = chainConfig.ChainId.Uint64()
+	}
+	common.CopyConstans(networkID)
+
 	log.Info(strings.Repeat("-", 153))
 	for _, line := range strings.Split(chainConfig.Description(), "\n") {
 		log.Info(line)
 	}
 	log.Info(strings.Repeat("-", 153))
 
-	networkID := config.NetworkId
-	if networkID == 0 {
-		networkID = chainConfig.ChainId.Uint64()
-	}
 	eth := &Ethereum{
 		config:         config,
 		chainDb:        chainDb,


### PR DESCRIPTION
# Proposed changes

The PR #850 sets network ID automatically. And the PR #846 copy constants during XDC startup. But when the flag `NetworkIdFlag` is not provide by script, the function `common.CopyConstans` in `SetEthConfig` does not work. So I move it  into the function `New` in the file `eth/backend.go` after networkID has been determined.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
