### PR TITLE
cmd/utils: not set Etherbase when flag `--unlock` is set

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1095,7 +1095,10 @@ func setEtherbase(ctx *cli.Context, ks *keystore.KeyStore, cfg *ethconfig.Config
 		}
 		cfg.Etherbase = account.Address
 	} else {
-		cfg.Etherbase = common.HexToAddress(ctx.String(MinerEtherbaseFlag.Name))
+		if !ctx.IsSet(UnlockedAccountFlag.Name) {
+			cfg.Etherbase = common.HexToAddress(ctx.String(MinerEtherbaseFlag.Name))
+			log.Info("Set etherbase", "address", cfg.Etherbase.Hex())
+		}
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

This PR fixes a bug about `Etherbase` which is introduced in PR #855. The `Etherbase` is set to the default value `0x000000000000000000000000000000000000abcd` only for the purpose of sync when the flag `--etherbase` is not set. But this new feature conflicts with the flag `--unlock`. We should not set `Etherbase` to any value when the flag `--etherbase` is set and  `--etherbase` is not set.

TODO: #30737

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [X] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
