### PR TITLE
node: warn when using deprecated config/resource files

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -674,12 +674,12 @@ func (n *Node) OpenDatabase(name string, cache, handles int, namespace string, r
 	if n.config.DataDir == "" {
 		return rawdb.NewMemoryDatabase(), nil
 	}
-	return rawdb.NewLevelDBDatabase(n.config.resolvePath(name), cache, handles, namespace, readonly)
+	return rawdb.NewLevelDBDatabase(n.config.ResolvePath(name), cache, handles, namespace, readonly)
 }
 
 // ResolvePath returns the absolute path of a resource in the instance directory.
 func (n *Node) ResolvePath(x string) string {
-	return n.config.resolvePath(x)
+	return n.config.ResolvePath(x)
 }
 
 // apis returns the collection of RPC descriptors this node offers.

--- a/node/service.go
+++ b/node/service.go
@@ -44,7 +44,7 @@ func (ctx *ServiceContext) OpenDatabase(name string, cache int, handles int, nam
 	if ctx.config.DataDir == "" {
 		return rawdb.NewMemoryDatabase(), nil
 	}
-	db, err := rawdb.NewLevelDBDatabase(ctx.config.resolvePath(name), cache, handles, namespace, readonly)
+	db, err := rawdb.NewLevelDBDatabase(ctx.config.ResolvePath(name), cache, handles, namespace, readonly)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (ctx *ServiceContext) OpenDatabase(name string, cache int, handles int, nam
 // and if the user actually uses persistent storage. It will return an empty string
 // for emphemeral storage and the user's own input for absolute paths.
 func (ctx *ServiceContext) ResolvePath(path string) string {
-	return ctx.config.resolvePath(path)
+	return ctx.config.ResolvePath(path)
 }
 
 // Service retrieves a currently running service registered of a specific type.


### PR DESCRIPTION
# Proposed changes

This PR applies geth PR #18199.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
