### PR TITLE
cmd, common, core:  optimize rollback by flag

### DIFF
--- a/cmd/XDC/config.go
+++ b/cmd/XDC/config.go
@@ -170,16 +170,6 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, XDCConfig) {
 		common.Enable0xPrefix = false
 	}
 
-	// Rewound
-	if rewound := ctx.Int(utils.RewoundFlag.Name); rewound != 0 {
-		common.Rewound = uint64(rewound)
-	}
-
-	// Check rollback hash exist.
-	if rollbackHash := ctx.String(utils.RollbackFlag.Name); rollbackHash != "" {
-		common.RollbackHash = common.HexToHash(rollbackHash)
-	}
-
 	// Check GasPrice
 	common.MinGasPrice = big.NewInt(common.DefaultMinGasPrice)
 	if ctx.IsSet(utils.MinerGasPriceFlag.Name) {

--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -121,7 +121,6 @@ var (
 		//utils.VMEnableDebugFlag,
 		utils.Enable0xPrefixFlag,
 		utils.EnableXDCPrefixFlag,
-		utils.RewoundFlag,
 		utils.NetworkIdFlag,
 		utils.HTTPCORSDomainFlag,
 		utils.HTTPVirtualHostsFlag,
@@ -138,7 +137,7 @@ var (
 		utils.LogBacktraceAtFlag,
 		utils.AnnounceTxsFlag,
 		utils.StoreRewardFlag,
-		utils.RollbackFlag,
+		utils.SetHeadFlag,
 		utils.XDCSlaveModeFlag,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -738,10 +738,10 @@ var (
 	}
 
 	// MISC settings
-	RollbackFlag = &cli.StringFlag{
-		Name:     "rollback",
-		Usage:    "Rollback chain at hash",
-		Value:    "",
+	SetHeadFlag = &cli.Uint64Flag{
+		Name:     "set-head",
+		Usage:    "Rollback chain to block number",
+		Value:    0,
 		Category: flags.MiscCategory,
 	}
 	AnnounceTxsFlag = &cli.BoolFlag{
@@ -754,12 +754,6 @@ var (
 		Name:     "store-reward",
 		Usage:    "Store reward to file",
 		Value:    false,
-		Category: flags.MiscCategory,
-	}
-	RewoundFlag = &cli.IntFlag{
-		Name:     "rewound",
-		Usage:    "Rewound blocks",
-		Value:    0,
 		Category: flags.MiscCategory,
 	}
 
@@ -1491,6 +1485,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			os.Mkdir(common.StoreRewardFolder, os.ModePerm)
 		}
 	}
+	if ctx.IsSet(SetHeadFlag.Name) {
+		common.RollbackNumber = ctx.Uint64(SetHeadFlag.Name)
+		if common.RollbackNumber == 0 {
+			Fatalf("the flag --%s must be greater than 0", SetHeadFlag.Name)
+		}
+	}
+
 	// Override any default configs for hard coded networks.
 	switch {
 	case ctx.Bool(MainnetFlag.Name):

--- a/common/constants.all.go
+++ b/common/constants.all.go
@@ -10,9 +10,7 @@ var (
 	IsTestnet      bool = false
 	Enable0xPrefix bool = true
 
-	Rewound = uint64(0)
-
-	RollbackHash Hash
+	RollbackNumber = uint64(0)
 
 	StoreRewardFolder string
 


### PR DESCRIPTION
# Proposed changes

This PR:
- removes the flags  `rewound` and `rollback` because they are used rarely
- introduces a new flag `set-head` to rollback quicker, usage: `XDC --set-head 48` or `XDC --set-head 0x30`

**Notice: the value of `set-head` must be greater than 0.**

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
