### PR TITLE
cmd/utils: handle err returned by eth.New to fix panic

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -30,6 +30,9 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config, version string)
 			var lendingServ *XDCxlending.Lending
 			ctx.Service(&lendingServ)
 			fullNode, err := eth.New(ctx, cfg, XDCXServ, lendingServ)
+			if err != nil {
+				return nil, err
+			}
 			if fullNode != nil && cfg.LightServ > 0 {
 				ls, _ := les.NewLesServer(fullNode, cfg)
 				fullNode.AddLesServer(ls)


### PR DESCRIPTION
# Proposed changes

If the function `eth.New` returns `nil, err` and the caller does not handle err, then XDC will panic, such as:

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xef7cba]

goroutine 1 [running]:
github.com/XinFinOrg/XDPoSChain/eth.(*Ethereum).Protocols(...)
        /home/me/XDPoSChain/eth/backend.go:553
github.com/XinFinOrg/XDPoSChain/cmd/utils.RegisterEthService.func2(0xc000694200)
        /home/me/XDPoSChain/cmd/utils/utils.go:42 +0x15a
github.com/XinFinOrg/XDPoSChain/node.(*Node).Start(0xc0004b22c8)
        /home/me/XDPoSChain/node/node.go:226 +0x5ce
github.com/XinFinOrg/XDPoSChain/cmd/utils.StartNode(0xc0004b22c8)
        /home/me/XDPoSChain/cmd/utils/cmd.go:68 +0x1c
main.startNode(_, _, {{0x0, 0x141f, 0x0, 0x1, 0x0, 0x64, 0x0, 0x80000, ...}, ...})
        /home/me/XDPoSChain/cmd/XDC/main.go:268 +0x92
main.XDC(0xc00012d440)
        /home/me/XDPoSChain/cmd/XDC/main.go:258 +0x128
github.com/urfave/cli/v2.(*Command).Run(0xc0001b4420, 0xc00012d440, {0xc000004708, 0x32, 0x37})
        /home/me/go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:276 +0x97d
github.com/urfave/cli/v2.(*App).RunContext(0xc0001f6200, {0x187b2d0, 0x2394400}, {0xc000004708, 0x32, 0x37})
        /home/me/go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
        /home/me/go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:307
main.main()
        /home/me/XDPoSChain/cmd/XDC/main.go:246 +0x45
```

With this PR, XDC will report the accurate error information, then exit normally, such as:

```text
Fatal: Error starting protocol stack: database version is v7, not supports v6
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
