### PR TITLE
all: fix wrong genesis hash by set EIP-1559 number

### DIFF
--- a/cicd/devnet/genesis.json
+++ b/cicd/devnet/genesis.json
@@ -7,6 +7,7 @@
     "eip155Block": 0,
     "eip158Block": 0,
     "byzantiumBlock": 0,
+    "eip1559Block": 0,
     "XDPoS": {
       "period": 2,
       "epoch": 900,

--- a/cicd/testnet/genesis.json
+++ b/cicd/testnet/genesis.json
@@ -7,6 +7,7 @@
     "eip155Block": 3,
     "eip158Block": 3,
     "byzantiumBlock": 4,
+    "eip1559Block": 71550000,
     "XDPoS": {
       "period": 2,
       "epoch": 900,

--- a/cmd/XDC/chaincmd.go
+++ b/cmd/XDC/chaincmd.go
@@ -184,6 +184,10 @@ func initGenesis(ctx *cli.Context) error {
 		utils.Fatalf("invalid genesis json: %v", err)
 	}
 
+	if genesis.Config.ChainId != nil {
+		common.CopyConstans(genesis.Config.ChainId.Uint64())
+	}
+
 	// Open an initialise both full and light databases
 	stack, _ := makeFullNode(ctx)
 	defer stack.Close()
@@ -198,7 +202,7 @@ func initGenesis(ctx *cli.Context) error {
 		utils.Fatalf("Failed to write genesis block: %v", err)
 	}
 	chaindb.Close()
-	log.Info("Successfully wrote genesis state", "database", name, "hash", hash)
+	log.Info("Successfully wrote genesis state", "database", name, "hash", hash.String())
 	return nil
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -213,6 +213,10 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if g.Difficulty == nil {
 		head.Difficulty = params.GenesisDifficulty
 	}
+
+	// Notice: Eip1559Block affects the block hash, we must set:
+	//   1. g.Config.Eip1559Block
+	//   2. or common.Eip1559Block
 	if g.Config != nil && g.Config.IsEIP1559(common.Big0) {
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
@@ -220,6 +224,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		}
 	}
+
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 

--- a/genesis/devnet.json
+++ b/genesis/devnet.json
@@ -7,6 +7,7 @@
     "eip155Block": 0,
     "eip158Block": 0,
     "byzantiumBlock": 0,
+    "eip1559Block": 0,
     "XDPoS": {
       "period": 2,
       "epoch": 900,

--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -7,6 +7,7 @@
     "eip155Block": 3,
     "eip158Block": 3,
     "byzantiumBlock": 4,
+    "eip1559Block": 71550000,
     "XDPoS": {
       "period": 2,
       "epoch": 900,


### PR DESCRIPTION
# Proposed changes

This PR fixes the wrong genesis hash by set:

- `common.Eip1559Block`
- `eip1559Block` in genesis file for devnet and testnet

Any of the above methods can fix the issue.

Test:

```shell
make all
./build/bin/XDC init devnet
```

Result:

```text
INFO [03-13|11:12:52.989] Maximum peer count                       ETH=50 total=50
INFO [03-13|11:12:52.990] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [03-13|11:12:52.990] Set etherbase                            address=xdc000000000000000000000000000000000000ABcD
INFO [03-13|11:12:52.991] Set global gas cap                       cap=50,000,000
INFO [03-13|11:12:52.991] XDCX datadir                             path=/home/me/.XDC/XDCx
INFO [03-13|11:12:52.992] Allocated cache and file handles         database=/home/me/.XDC/XDCx cache=128.00MiB handles=1024
INFO [03-13|11:12:53.016] Allocated cache and file handles         database=/home/me/.XDC/XDC/chaindata cache=16.00MiB handles=16
INFO [03-13|11:12:53.022] Persisted trie from memory database      nodes=220 size=40.67KiB time="246.631µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=1 livesize=-314.00B
INFO [03-13|11:12:53.022] [configOrDefault] load orignal config    hash=977c7a..835daf
INFO [03-13|11:12:53.022] Successfully wrote genesis state         database=chaindata hash=0x977c7a1b4ecbc40acc3963c1778666b62a95940a7fba6fec5867f78702835daf
```

`0x977c7a1b4ecbc40acc3963c1778666b62a95940a7fba6fec5867f78702835daf` is the right genesis hash for devnet.

```shell
curl -s -X POST -H "Content-Type: application/json" https://devnetstats.hashlabs.apothem.network/devnet -d '{
  "jsonrpc": "2.0",
  "id": 6104,
  "method": "eth_getBlockByNumber",
  "params": [
    "0x0",
    false
  ]
}' | jq | grep hash
```

Output:

```text
    "hash": "0x977c7a1b4ecbc40acc3963c1778666b62a95940a7fba6fec5867f78702835daf",
```


TODO: set `eip1559Block` for mainnet later

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
