### PR TITLE
cmd/XDC: improve init genesis

### DIFF
--- a/cmd/XDC/chaincmd.go
+++ b/cmd/XDC/chaincmd.go
@@ -155,48 +155,30 @@ Use "ethereum dump 0" to dump the genesis block.`,
 // initGenesis will initialise the given JSON format genesis file and writes it as
 // the zero'd block (i.e. genesis) or will fail hard if it can't succeed.
 func initGenesis(ctx *cli.Context) error {
-	utils.CheckExclusive(ctx, utils.MainnetFlag, utils.TestnetFlag, utils.DevnetFlag)
+	if ctx.Args().Len() != 1 {
+		utils.Fatalf("need the genesis.json file or the network name [ mainnet | testnet | devnet ] as the only argument")
+	}
 
 	var err error
 	genesis := new(core.Genesis)
-	if ctx.Bool(utils.MainnetFlag.Name) {
-		if ctx.Args().Len() > 0 {
-			utils.Fatalf("The mainnet flag and genesis file can't be used at the same time")
-		}
-		err = json.Unmarshal(xdc_genesis.TestnetGenesis, &genesis)
-	} else if ctx.Bool(utils.TestnetFlag.Name) {
-		if ctx.Args().Len() > 0 {
-			utils.Fatalf("The testnet flag and genesis file can't be used at the same time")
-		}
-		err = json.Unmarshal(xdc_genesis.TestnetGenesis, &genesis)
-	} else if ctx.Bool(utils.DevnetFlag.Name) {
-		if ctx.Args().Len() > 0 {
-			utils.Fatalf("The devnet flag and genesis file can't be used at the same time")
-		}
-		err = json.Unmarshal(xdc_genesis.TestnetGenesis, &genesis)
+	genesisPath := ctx.Args().First()
+	if genesisPath == "mainnet" || genesisPath == "xinfin" {
+		err = json.Unmarshal(xdc_genesis.MainnetGenesis, genesis)
+	} else if genesisPath == "testnet" || genesisPath == "apothem" {
+		err = json.Unmarshal(xdc_genesis.TestnetGenesis, genesis)
+	} else if genesisPath == "devnet" {
+		err = json.Unmarshal(xdc_genesis.DevnetGenesis, genesis)
 	} else {
-		if ctx.Args().Len() != 1 {
-			utils.Fatalf("need the genesis.json file or the network name [ mainnet | testnet | devnet ] as the only argument")
+		if len(genesisPath) == 0 {
+			utils.Fatalf("invalid path to genesis file")
 		}
-		genesisPath := ctx.Args().First()
-		if genesisPath == "mainnet" || genesisPath == "xinfin" {
-			err = json.Unmarshal(xdc_genesis.MainnetGenesis, &genesis)
-		} else if genesisPath == "testnet" || genesisPath == "apothem" {
-			err = json.Unmarshal(xdc_genesis.TestnetGenesis, &genesis)
-		} else if genesisPath == "devnet" {
-			err = json.Unmarshal(xdc_genesis.DevnetGenesis, &genesis)
-		} else {
-			if len(genesisPath) == 0 {
-				utils.Fatalf("invalid path to genesis file")
-			}
-			var file *os.File
-			file, err = os.Open(genesisPath)
-			if err != nil {
-				utils.Fatalf("Failed to read genesis file: %v", err)
-			}
-			defer file.Close()
-			err = json.NewDecoder(file).Decode(genesis)
+		var file *os.File
+		file, err = os.Open(genesisPath)
+		if err != nil {
+			utils.Fatalf("Failed to read genesis file: %v", err)
 		}
+		defer file.Close()
+		err = json.NewDecoder(file).Decode(genesis)
 	}
 	if err != nil {
 		utils.Fatalf("invalid genesis json: %v", err)


### PR DESCRIPTION
# Proposed changes

This PR does not handle the network flag when init genesis. We can support network name and genesis file as parameter now.

Before this PR, we can init genesis by the network flag, such as:

```shell
XDC init --devnet
```

But the above way does not report error if the data dir has been initialize:

```shell
rm -rf ~/.XDC/
XDC init --mainnet
XDC init --devnet
```

![image](https://github.com/user-attachments/assets/4dbf6f90-f3b7-4fbf-be1c-28012060fb2e)


If we don't use network flag, then the result is as expected:

```shell
rm -rf ~/.XDC/
XDC init mainnet
XDC init devnet
```

![image](https://github.com/user-attachments/assets/65f00aef-df88-4940-bc8d-7878dd5713a3)


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
