### PR TITLE
p2p: measure subprotocol bandwidth usage

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -38,9 +38,13 @@ import (
 // separate Msg with a bytes.Reader as Payload for each send.
 type Msg struct {
 	Code       uint64
-	Size       uint32 // size of the paylod
+	Size       uint32 // Size of the raw payload
 	Payload    io.Reader
 	ReceivedAt time.Time
+
+	meterCap  Cap    // Protocol name and version for egress metering
+	meterCode uint64 // Message within protocol for egress metering
+	meterSize uint32 // Compressed message size for ingress metering
 }
 
 // Decode parses the RLP content of a message into

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -26,8 +26,10 @@ import (
 )
 
 var (
-	ingressTrafficMeter = metrics.NewRegisteredMeter("p2p/InboundTraffic", nil)
-	egressTrafficMeter  = metrics.NewRegisteredMeter("p2p/OutboundTraffic", nil)
+	MetricsInboundTraffic  = "p2p/ingress" // Name for the registered inbound traffic meter
+	MetricsOutboundTraffic = "p2p/egress"  // Name for the registered outbound traffic meter
+	ingressTrafficMeter    = metrics.NewRegisteredMeter("p2p/InboundTraffic", nil)
+	egressTrafficMeter     = metrics.NewRegisteredMeter("p2p/OutboundTraffic", nil)
 )
 
 var (


### PR DESCRIPTION
# Proposed changes

This PR aims to fix issue #862 by adding and improving monitoring metrics related to block and transaction propagation in blockchain networks. Specifically, it introduces new metrics to better monitor Snappy compressed wire traffic for different subprotocols, down to the message type level. The new metrics include:

- `p2p/{ingress|egress}/eth/{version}/{msgCode}`: These are message type level metrics from `xdcpos` and other protocols.

These metrics help the team understand data flow in the network more clearly, optimizing blockchain performance and stability. The metrics are also displayed in the monitor for real-time tracking and analysis.

Here is how these metrics appear in the monitor
![Pasted image 20250313135804](https://github.com/user-attachments/assets/e51896e1-568b-461e-aaad-eaeb1b7203c4)


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [x] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [x] N/A
