### PR TITLE
build: add command `make quick-test` to save test time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ all:
 test: all
 	go run build/ci.go test
 
+#? quick-test: Run the tests except time-consuming tests.
+quick-test: all
+	go run build/ci.go test --quick
+
 #? lint: Run certain pre-selected linters.
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint

--- a/build/ci.go
+++ b/build/ci.go
@@ -219,10 +219,10 @@ func goToolArch(arch string, cc string, subcmd string, args ...string) *exec.Cmd
 // Running The Tests
 //
 // "tests" also includes static analysis tools such as vet.
-
 func doTest(cmdline []string) {
 	coverage := flag.Bool("coverage", false, "Whether to record code coverage")
 	verbose := flag.Bool("v", false, "Whether to log verbosely")
+	quick := flag.Bool("quick", false, "Whether to skip long time test")
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
 
@@ -231,7 +231,7 @@ func doTest(cmdline []string) {
 		packages = flag.CommandLine.Args()
 	} else {
 		// added all files in all packages (except vendor) to coverage report files count, even there is no test file in the package
-		packages = build.ExpandPackagesNoVendor(packages)
+		packages = build.ExpandPackages(packages, *quick)
 	}
 
 	// Run analysis tools before the tests.

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -136,9 +136,9 @@ func GoTool(tool string, args ...string) *exec.Cmd {
 	return exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), args...)
 }
 
-// ExpandPackagesNoVendor expands a cmd/go import path pattern, skipping
-// vendored packages.
-func ExpandPackagesNoVendor(patterns []string) []string {
+// ExpandPackages expands a cmd/go import path pattern, skip vendor
+// packages, and skip time-consuming tests according to quick flag.
+func ExpandPackages(patterns []string, quick bool) []string {
 	expand := false
 	for _, pkg := range patterns {
 		if strings.Contains(pkg, "...") {
@@ -153,9 +153,14 @@ func ExpandPackagesNoVendor(patterns []string) []string {
 		}
 		var packages []string
 		for _, line := range strings.Split(string(out), "\n") {
-			if !strings.Contains(line, "/vendor/") {
-				packages = append(packages, strings.TrimSpace(line))
+			if strings.Contains(line, "/vendor/") {
+				continue
 			}
+			if quick && strings.Contains(line, "/consensus/tests/engine_v2_tests") {
+				continue
+			}
+			packages = append(packages, strings.TrimSpace(line))
+
 		}
 		return packages
 	}


### PR DESCRIPTION
# Proposed changes

This PR adds a new command `make quick-test` to skip time-consuming tests. This command saves much test time during development.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
