### PR TITLE
rpc: support keyword `finalized` as block number

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -78,7 +78,8 @@ func (b *EthApiBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNum
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock().Header(), nil
-	} else if blockNr == rpc.CommittedBlockNumber {
+	}
+	if blockNr == rpc.CommittedBlockNumber {
 		if b.eth.chainConfig.XDPoS == nil {
 			return nil, errors.New("PoW does not support confirmed block lookup")
 		}
@@ -131,7 +132,8 @@ func (b *EthApiBackend) BlockByNumber(ctx context.Context, blockNr rpc.BlockNumb
 	// Otherwise resolve and return the block
 	if blockNr == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
-	} else if blockNr == rpc.CommittedBlockNumber {
+	}
+	if blockNr == rpc.CommittedBlockNumber {
 		if b.eth.chainConfig.XDPoS == nil {
 			return nil, errors.New("PoW does not support confirmed block lookup")
 		}

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3696,7 +3696,7 @@ var outputBigNumberFormatter = function (number) {
 };
 
 var isPredefinedBlockNumber = function (blockNumber) {
-    return ['latest','pending','earliest','committed'].indexOf(blockNumber) >= 0;
+    return ['latest','pending','earliest','committed', 'finalized'].indexOf(blockNumber) >= 0;
 };
 
 var inputDefaultBlockNumberFormatter = function (blockNumber) {

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -101,7 +101,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "pending":
 		*bn = PendingBlockNumber
 		return nil
-	case "committed":
+	case "committed", "finalized":
 		*bn = CommittedBlockNumber
 		return nil
 	}
@@ -181,7 +181,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		bn := PendingBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
-	case "committed":
+	case "committed", "finalized":
 		bn := CommittedBlockNumber
 		bnh.BlockNumber = &bn
 		return nil


### PR DESCRIPTION
# Proposed changes

This PR accepts `finalized` as block number as geth. This keyword is same as `committed` in our codebase.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
