### PR TITLE
consensus, core, eth, trie: add a prefix to contract code

### DIFF
--- a/XDCx/tradingstate/XDCx_trie.go
+++ b/XDCx/tradingstate/XDCx_trie.go
@@ -147,8 +147,7 @@ func (t *XDCXTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	key, _ := t.trie.Db.Preimage(common.BytesToHash(shaKey))
-	return key
+	return t.trie.Db.Preimage(common.BytesToHash(shaKey))
 }
 
 // Commit writes all nodes and the secure hash pre-images to the trie's database.

--- a/XDCxlending/lendingstate/XDCx_trie.go
+++ b/XDCxlending/lendingstate/XDCx_trie.go
@@ -18,6 +18,7 @@ package lendingstate
 
 import (
 	"fmt"
+
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 
@@ -142,8 +143,7 @@ func (t *XDCXTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	key, _ := t.trie.Db.Preimage(common.BytesToHash(shaKey))
-	return key
+	return t.trie.Db.Preimage(common.BytesToHash(shaKey))
 }
 
 // Commit writes all nodes and the secure hash pre-images to the trie's database.

--- a/consensus/XDPoS/engines/engine_v1/engine.go
+++ b/consensus/XDPoS/engines/engine_v1/engine.go
@@ -25,6 +25,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 const (
@@ -849,7 +850,7 @@ func (x *XDPoS_v1) Finalize(chain consensus.ChainReader, header *types.Header, s
 	header.UncleHash = types.CalcUncleHash(nil)
 
 	// Assemble and return the final block for sealing
-	return types.NewBlock(header, txs, nil, receipts), nil
+	return types.NewBlock(header, txs, nil, receipts, new(trie.Trie)), nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -22,6 +22,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 type XDPoS_v2 struct {
@@ -414,7 +415,7 @@ func (x *XDPoS_v2) Finalize(chain consensus.ChainReader, header *types.Header, s
 	header.UncleHash = types.CalcUncleHash(nil)
 
 	// Assemble and return the final block for sealing
-	return types.NewBlock(header, txs, nil, receipts), nil
+	return types.NewBlock(header, txs, nil, receipts, new(trie.Trie)), nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks with.

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -40,6 +40,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	"github.com/XinFinOrg/XDPoSChain/rpc"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -588,7 +589,7 @@ func (c *Clique) Finalize(chain consensus.ChainReader, header *types.Header, sta
 	header.UncleHash = types.CalcUncleHash(nil)
 
 	// Assemble and return the final block for sealing
-	return types.NewBlock(header, txs, nil, receipts), nil
+	return types.NewBlock(header, txs, nil, receipts, new(trie.Trie)), nil
 }
 
 // Authorize injects a private key into the consensus engine to mint new blocks

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -32,6 +32,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 	mapset "github.com/deckarep/golang-set/v2"
 )
 
@@ -523,7 +524,7 @@ func (ethash *Ethash) Finalize(chain consensus.ChainReader, header *types.Header
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return
-	return types.NewBlock(header, txs, uncles, receipts), nil
+	return types.NewBlock(header, txs, uncles, receipts, new(trie.Trie)), nil
 }
 
 // Some weird constants to avoid constant memory allocs for them.

--- a/consensus/tests/engine_v1_tests/helper.go
+++ b/consensus/tests/engine_v1_tests/helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 type masterNodes map[string]big.Int
@@ -390,7 +391,7 @@ func createBlockFromHeader(bc *core.BlockChain, customHeader *types.Header, txs 
 		}
 
 		header.GasUsed = *gasUsed
-		block = types.NewBlock(&header, txs, nil, receipts)
+		block = types.NewBlock(&header, txs, nil, receipts, new(trie.Trie))
 	}
 
 	return block, nil

--- a/consensus/tests/engine_v2_tests/helper.go
+++ b/consensus/tests/engine_v2_tests/helper.go
@@ -29,6 +29,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -879,7 +880,7 @@ func createBlockFromHeader(bc *core.BlockChain, customHeader *types.Header, txs 
 		header.Coinbase = signerAddress
 		sealHeader(bc, &header, signerAddress, signerFunction)
 
-		block = types.NewBlock(&header, txs, nil, receipts)
+		block = types.NewBlock(&header, txs, nil, receipts, new(trie.Trie))
 	}
 
 	return block, nil

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 // BlockValidator is responsible for validating block headers, uncles and
@@ -67,7 +68,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if hash := types.CalcUncleHash(block.Uncles()); hash != header.UncleHash {
 		return fmt.Errorf("uncle root hash mismatch: have %x, want %x", hash, header.UncleHash)
 	}
-	if hash := types.DeriveSha(block.Transactions()); hash != header.TxHash {
+	if hash := types.DeriveSha(block.Transactions(), new(trie.Trie)); hash != header.TxHash {
 		return fmt.Errorf("transaction root hash mismatch: have %x, want %x", hash, header.TxHash)
 	}
 	if !v.bc.HasBlockAndFullState(block.ParentHash(), block.NumberU64()-1) {
@@ -95,7 +96,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 		return fmt.Errorf("invalid bloom (remote: %x  local: %x)", header.Bloom, rbloom)
 	}
 	// Tre receipt Trie's root (R = (Tr [[H1, R1], ... [Hn, R1]]))
-	receiptSha := types.DeriveSha(receipts)
+	receiptSha := types.DeriveSha(receipts, new(trie.Trie))
 	if receiptSha != header.ReceiptHash {
 		return fmt.Errorf("invalid receipt root hash (remote: %x local: %x)", header.ReceiptHash, receiptSha)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -115,7 +115,10 @@ const (
 	// - Version 6
 	//  The following incompatible database changes were added:
 	//    * Transaction lookup information stores the corresponding block number instead of block hash
-	BlockChainVersion uint64 = 6
+	// - Version 7
+	//  The following incompatible database changes were added:
+	//    * New scheme for contract code in order to separate the codes and trie nodes
+	BlockChainVersion uint64 = 7
 
 	// Maximum length of chain to cache by block's number
 	blocksHashCacheLimit = 900
@@ -995,10 +998,28 @@ func (bc *BlockChain) GetUnclesInChain(block *types.Block, length int) []*types.
 	return uncles
 }
 
-// TrieNode retrieves a blob of data associated with a trie node (or code hash)
+// TrieNode retrieves a blob of data associated with a trie node
 // either from ephemeral in-memory cache, or from persistent storage.
 func (bc *BlockChain) TrieNode(hash common.Hash) ([]byte, error) {
 	return bc.stateCache.TrieDB().Node(hash)
+}
+
+// ContractCode retrieves a blob of data associated with a contract hash
+// either from ephemeral in-memory cache, or from persistent storage.
+func (bc *BlockChain) ContractCode(hash common.Hash) ([]byte, error) {
+	return bc.stateCache.ContractCode(common.Hash{}, hash)
+}
+
+// ContractCodeWithPrefix retrieves a blob of data associated with a contract
+// hash either from ephemeral in-memory cache, or from persistent storage.
+//
+// If the code doesn't exist in the in-memory cache, check the storage with
+// new code scheme.
+func (bc *BlockChain) ContractCodeWithPrefix(hash common.Hash) ([]byte, error) {
+	type codeReader interface {
+		ContractCodeWithPrefix(addrHash, codeHash common.Hash) ([]byte, error)
+	}
+	return bc.stateCache.(codeReader).ContractCodeWithPrefix(common.Hash{}, hash)
 }
 
 func (bc *BlockChain) saveData() {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 // newCanonical creates a chain database, and injects a deterministic canonical
@@ -653,12 +654,12 @@ func TestFastVsFullChains(t *testing.T) {
 		}
 		if fblock, ablock := fast.GetBlockByHash(hash), archive.GetBlockByHash(hash); fblock.Hash() != ablock.Hash() {
 			t.Errorf("block #%d [%x]: block mismatch: have %v, want %v", num, hash, fblock, ablock)
-		} else if types.DeriveSha(fblock.Transactions()) != types.DeriveSha(ablock.Transactions()) {
+		} else if types.DeriveSha(fblock.Transactions(), new(trie.Trie)) != types.DeriveSha(ablock.Transactions(), new(trie.Trie)) {
 			t.Errorf("block #%d [%x]: transactions mismatch: have %v, want %v", num, hash, fblock.Transactions(), ablock.Transactions())
 		} else if types.CalcUncleHash(fblock.Uncles()) != types.CalcUncleHash(ablock.Uncles()) {
 			t.Errorf("block #%d [%x]: uncles mismatch: have %v, want %v", num, hash, fblock.Uncles(), ablock.Uncles())
 		}
-		if freceipts, areceipts := rawdb.ReadReceipts(fastDb, hash, *rawdb.ReadHeaderNumber(fastDb, hash), fast.Config()), rawdb.ReadReceipts(archiveDb, hash, *rawdb.ReadHeaderNumber(archiveDb, hash), fast.Config()); types.DeriveSha(freceipts) != types.DeriveSha(areceipts) {
+		if freceipts, areceipts := rawdb.ReadReceipts(fastDb, hash, *rawdb.ReadHeaderNumber(fastDb, hash), fast.Config()), rawdb.ReadReceipts(archiveDb, hash, *rawdb.ReadHeaderNumber(archiveDb, hash), fast.Config()); types.DeriveSha(freceipts, new(trie.Trie)) != types.DeriveSha(areceipts, new(trie.Trie)) {
 			t.Errorf("block #%d [%x]: receipts mismatch: have %v, want %v", num, hash, freceipts, areceipts)
 		}
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -32,6 +32,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 //go:generate go run github.com/fjl/gencodec -type Genesis -field-override genesisSpecMarshaling -out gen_genesis.go
@@ -228,7 +229,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 
-	return types.NewBlock(head, nil, nil, nil)
+	return types.NewBlock(head, nil, nil, nil, new(trie.Trie))
 }
 
 // Commit writes the block and state of a genesis specification to the database.

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -106,7 +106,7 @@ func TestBodyStorage(t *testing.T) {
 	WriteBody(db, hash, 0, body)
 	if entry := ReadBody(db, hash, 0); entry == nil {
 		t.Fatalf("Stored body not found")
-	} else if types.DeriveSha(types.Transactions(entry.Transactions)) != types.DeriveSha(types.Transactions(body.Transactions)) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(body.Uncles) {
+	} else if types.DeriveSha(types.Transactions(entry.Transactions), newHasher()) != types.DeriveSha(types.Transactions(body.Transactions), newHasher()) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(body.Uncles) {
 		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, body)
 	}
 	if entry := ReadBodyRLP(db, hash, 0); entry == nil {
@@ -160,7 +160,7 @@ func TestBlockStorage(t *testing.T) {
 	}
 	if entry := ReadBody(db, block.Hash(), block.NumberU64()); entry == nil {
 		t.Fatalf("Stored body not found")
-	} else if types.DeriveSha(types.Transactions(entry.Transactions)) != types.DeriveSha(block.Transactions()) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(block.Uncles()) {
+	} else if types.DeriveSha(types.Transactions(entry.Transactions), newHasher()) != types.DeriveSha(block.Transactions(), newHasher()) || types.CalcUncleHash(entry.Uncles) != types.CalcUncleHash(block.Uncles()) {
 		t.Fatalf("Retrieved body mismatch: have %v, want %v", entry, block.Body())
 	}
 	// Delete the block and verify the execution

--- a/core/rawdb/accessors_indexes_test.go
+++ b/core/rawdb/accessors_indexes_test.go
@@ -17,6 +17,7 @@
 package rawdb
 
 import (
+	"hash"
 	"math/big"
 	"testing"
 
@@ -24,7 +25,32 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
+	"golang.org/x/crypto/sha3"
 )
+
+// testHasher is the helper tool for transaction/receipt list hashing.
+// The original hasher is trie, in order to get rid of import cycle,
+// use the testing hasher instead.
+type testHasher struct {
+	hasher hash.Hash
+}
+
+func newHasher() *testHasher {
+	return &testHasher{hasher: sha3.NewLegacyKeccak256()}
+}
+
+func (h *testHasher) Reset() {
+	h.hasher.Reset()
+}
+
+func (h *testHasher) Update(key, val []byte) {
+	h.hasher.Write(key)
+	h.hasher.Write(val)
+}
+
+func (h *testHasher) Hash() common.Hash {
+	return common.BytesToHash(h.hasher.Sum(nil))
+}
 
 // Tests that positional lookup metadata can be stored and retrieved.
 func TestLookupStorage(t *testing.T) {
@@ -71,7 +97,7 @@ func TestLookupStorage(t *testing.T) {
 			tx3 := types.NewTransaction(3, common.BytesToAddress([]byte{0x33}), big.NewInt(333), 3333, big.NewInt(33333), []byte{0x33, 0x33, 0x33})
 			txs := []*types.Transaction{tx1, tx2, tx3}
 
-			block := types.NewBlock(&types.Header{Root: types.EmptyRootHash, Number: big.NewInt(314)}, txs, nil, nil)
+			block := types.NewBlock(&types.Header{Root: types.EmptyRootHash, Number: big.NewInt(314)}, txs, nil, nil, newHasher())
 
 			// Check that no transactions entries are in a pristine database
 			for i, tx := range txs {

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -83,20 +83,3 @@ func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg *params.Cha
 	}
 	return db.Put(configKey(hash), data)
 }
-
-// ReadPreimage returns a Database instance with the key prefix for preimage entries.
-func ReadPreimage(db ethdb.KeyValueReader, hash common.Hash) []byte {
-	data, _ := db.Get(preimageKey(hash))
-	return data
-}
-
-// WritePreimages writes the provided set of preimages to the database.
-func WritePreimages(db ethdb.KeyValueWriter, preimages map[common.Hash][]byte) {
-	for hash, preimage := range preimages {
-		if err := db.Put(preimageKey(hash), preimage); err != nil {
-			log.Crit("Failed to store trie preimage", "err", err)
-		}
-	}
-	preimageCounter.Inc(int64(len(preimages)))
-	preimageHitCounter.Inc(int64(len(preimages)))
-}

--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -1,0 +1,96 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package rawdb
+
+import (
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
+	"github.com/XinFinOrg/XDPoSChain/log"
+)
+
+// ReadPreimage retrieves a single preimage of the provided hash.
+func ReadPreimage(db ethdb.KeyValueReader, hash common.Hash) []byte {
+	data, _ := db.Get(preimageKey(hash))
+	return data
+}
+
+// WritePreimages writes the provided set of preimages to the database.
+func WritePreimages(db ethdb.KeyValueWriter, preimages map[common.Hash][]byte) {
+	for hash, preimage := range preimages {
+		if err := db.Put(preimageKey(hash), preimage); err != nil {
+			log.Crit("Failed to store trie preimage", "err", err)
+		}
+	}
+	preimageCounter.Inc(int64(len(preimages)))
+	preimageHitCounter.Inc(int64(len(preimages)))
+}
+
+// ReadCode retrieves the contract code of the provided code hash.
+func ReadCode(db ethdb.KeyValueReader, hash common.Hash) []byte {
+	// Try with the legacy code scheme first, if not then try with current
+	// scheme. Since most of the code will be found with legacy scheme.
+	//
+	// todo(rjl493456442) change the order when we forcibly upgrade the code
+	// scheme with snapshot.
+	data, _ := db.Get(hash[:])
+	if len(data) != 0 {
+		return data
+	}
+	return ReadCodeWithPrefix(db, hash)
+}
+
+// ReadCodeWithPrefix retrieves the contract code of the provided code hash.
+// The main difference between this function and ReadCode is this function
+// will only check the existence with latest scheme(with prefix).
+func ReadCodeWithPrefix(db ethdb.KeyValueReader, hash common.Hash) []byte {
+	data, _ := db.Get(codeKey(hash))
+	return data
+}
+
+// WriteCode writes the provided contract code database.
+func WriteCode(db ethdb.KeyValueWriter, hash common.Hash, code []byte) {
+	if err := db.Put(codeKey(hash), code); err != nil {
+		log.Crit("Failed to store contract code", "err", err)
+	}
+}
+
+// DeleteCode deletes the specified contract code from the database.
+func DeleteCode(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Delete(codeKey(hash)); err != nil {
+		log.Crit("Failed to delete contract code", "err", err)
+	}
+}
+
+// ReadTrieNode retrieves the trie node of the provided hash.
+func ReadTrieNode(db ethdb.KeyValueReader, hash common.Hash) []byte {
+	data, _ := db.Get(hash.Bytes())
+	return data
+}
+
+// WriteTrieNode writes the provided trie node database.
+func WriteTrieNode(db ethdb.KeyValueWriter, hash common.Hash, node []byte) {
+	if err := db.Put(hash.Bytes(), node); err != nil {
+		log.Crit("Failed to store trie node", "err", err)
+	}
+}
+
+// DeleteTrieNode deletes the specified trie node from the database.
+func DeleteTrieNode(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Delete(hash.Bytes()); err != nil {
+		log.Crit("Failed to delete trie node", "err", err)
+	}
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -143,6 +143,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		numHashPairing  common.StorageSize
 		hashNumPairing  common.StorageSize
 		trieSize        common.StorageSize
+		codeSize        common.StorageSize
 		txlookupSize    common.StorageSize
 		preimageSize    common.StorageSize
 		bloomBitsSize   common.StorageSize
@@ -195,6 +196,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			chtTrieNodes += size
 		case bytes.HasPrefix(key, []byte("blt-")) && len(key) == 4+common.HashLength:
 			bloomTrieNodes += size
+		case bytes.HasPrefix(key, codePrefix) && len(key) == len(codePrefix)+common.HashLength:
+			codeSize += size
 		case len(key) == common.HashLength:
 			trieSize += size
 		default:
@@ -234,6 +237,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Block hash->number", hashNumPairing.String()},
 		{"Key-Value store", "Transaction index", txlookupSize.String()},
 		{"Key-Value store", "Bloombit index", bloomBitsSize.String()},
+		{"Key-Value store", "Contract codes", codeSize.String()},
 		{"Key-Value store", "Trie nodes", trieSize.String()},
 		{"Key-Value store", "Trie preimages", preimageSize.String()},
 		{"Key-Value store", "Clique snapshots", cliqueSnapsSize.String()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -18,6 +18,7 @@
 package rawdb
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -52,6 +53,7 @@ var (
 
 	txLookupPrefix  = []byte("l") // txLookupPrefix + hash -> transaction/receipt lookup metadata
 	bloomBitsPrefix = []byte("B") // bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash -> bloom bits
+	codePrefix      = []byte("c") // codePrefix + code hash -> account code
 
 	// used by old db, now only used for conversion
 	oldReceiptsPrefix = []byte("receipts-")
@@ -154,6 +156,20 @@ func bloomBitsKey(bit uint, section uint64, hash common.Hash) []byte {
 // preimageKey = preimagePrefix + hash
 func preimageKey(hash common.Hash) []byte {
 	return append(preimagePrefix, hash.Bytes()...)
+}
+
+// codeKey = codePrefix + hash
+func codeKey(hash common.Hash) []byte {
+	return append(codePrefix, hash.Bytes()...)
+}
+
+// IsCodeKey reports whether the given byte slice is the key of contract code,
+// if so return the raw code hash as well.
+func IsCodeKey(key []byte) (bool, []byte) {
+	if bytes.HasPrefix(key, codePrefix) && len(key) == common.HashLength+len(codePrefix) {
+		return true, key[len(codePrefix):]
+	}
+	return false, nil
 }
 
 // configKey = configPrefix + hash

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -17,10 +17,12 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/lru"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 )
@@ -28,6 +30,9 @@ import (
 const (
 	// Number of codehash->size associations to keep.
 	codeSizeCacheSize = 100000
+
+	// Cache size granted for caching clean code.
+	codeCacheSize = 64 * 1024 * 1024
 )
 
 // Database wraps access to tries and contract code.
@@ -109,12 +114,14 @@ func NewDatabase(db ethdb.Database) Database {
 func NewDatabaseWithCache(db ethdb.Database, cache int) Database {
 	return &cachingDB{
 		db:            trie.NewDatabaseWithCache(db, cache),
+		codeCache:     lru.NewSizeConstrainedCache[common.Hash, []byte](codeCacheSize),
 		codeSizeCache: lru.NewCache[common.Hash, int](codeSizeCacheSize),
 	}
 }
 
 type cachingDB struct {
 	db            *trie.Database
+	codeCache     *lru.SizeConstrainedCache[common.Hash, []byte]
 	codeSizeCache *lru.Cache[common.Hash, int]
 }
 
@@ -140,11 +147,32 @@ func (db *cachingDB) CopyTrie(t Trie) Trie {
 
 // ContractCode retrieves a particular contract's code.
 func (db *cachingDB) ContractCode(addrHash, codeHash common.Hash) ([]byte, error) {
-	code, err := db.db.Node(codeHash)
-	if err == nil {
-		db.codeSizeCache.Add(codeHash, len(code))
+	if code, _ := db.codeCache.Get(codeHash); len(code) > 0 {
+		return code, nil
 	}
-	return code, err
+	code := rawdb.ReadCode(db.db.DiskDB(), codeHash)
+	if len(code) > 0 {
+		db.codeCache.Add(codeHash, code)
+		db.codeSizeCache.Add(codeHash, len(code))
+		return code, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// ContractCodeWithPrefix retrieves a particular contract's code. If the
+// code can't be found in the cache, then check the existence with **new**
+// db scheme.
+func (db *cachingDB) ContractCodeWithPrefix(addrHash, codeHash common.Hash) ([]byte, error) {
+	if code, _ := db.codeCache.Get(codeHash); len(code) > 0 {
+		return code, nil
+	}
+	code := rawdb.ReadCodeWithPrefix(db.db.DiskDB(), codeHash)
+	if len(code) > 0 {
+		db.codeCache.Add(codeHash, code)
+		db.codeSizeCache.Add(codeHash, len(code))
+		return code, nil
+	}
+	return nil, errors.New("not found")
 }
 
 // ContractCodeSize retrieves a particular contracts code's size.

--- a/core/state/iterator_test.go
+++ b/core/state/iterator_test.go
@@ -42,7 +42,10 @@ func TestNodeIteratorCoverage(t *testing.T) {
 	}
 	// Cross check the iterated hashes and the database/nodepool content
 	for hash := range hashes {
-		if _, err := db.TrieDB().Node(hash); err != nil {
+		if _, err = db.TrieDB().Node(hash); err != nil {
+			_, err = db.ContractCode(common.Hash{}, hash)
+		}
+		if err != nil {
 			t.Errorf("failed to retrieve reported node %x", hash)
 		}
 	}

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -34,7 +34,7 @@ func NewStateSync(root common.Hash, database ethdb.KeyValueReader, bloom *trie.S
 			return err
 		}
 		syncer.AddSubTrie(obj.Root, 64, parent, nil)
-		syncer.AddRawEntry(common.BytesToHash(obj.CodeHash), 64, parent)
+		syncer.AddCodeEntry(common.BytesToHash(obj.CodeHash), 64, parent)
 		return nil
 	}
 	syncer = trie.NewSync(root, database, callback, bloom)

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -133,13 +133,17 @@ func TestEmptyStateSync(t *testing.T) {
 
 // Tests that given a root hash, a state can sync iteratively on a single thread,
 // requesting retrieval tasks and returning all of them in one go.
-func TestIterativeStateSyncIndividual(t *testing.T) { testIterativeStateSync(t, 1) }
-func TestIterativeStateSyncBatched(t *testing.T)    { testIterativeStateSync(t, 100) }
+func TestIterativeStateSyncIndividual(t *testing.T)         { testIterativeStateSync(t, 1, false) }
+func TestIterativeStateSyncBatched(t *testing.T)            { testIterativeStateSync(t, 100, false) }
+func TestIterativeStateSyncIndividualFromDisk(t *testing.T) { testIterativeStateSync(t, 1, true) }
+func TestIterativeStateSyncBatchedFromDisk(t *testing.T)    { testIterativeStateSync(t, 100, true) }
 
-func testIterativeStateSync(t *testing.T, count int) {
+func testIterativeStateSync(t *testing.T, count int, commit bool) {
 	// Create a random state to copy
 	srcDb, srcRoot, srcAccounts := makeTestState()
-
+	if commit {
+		srcDb.TrieDB().Commit(srcRoot, false)
+	}
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
 	sched := NewStateSync(srcRoot, dstDb, trie.NewSyncBloom(1, dstDb))
@@ -150,12 +154,17 @@ func testIterativeStateSync(t *testing.T, count int) {
 		for i, hash := range queue {
 			data, err := srcDb.TrieDB().Node(hash)
 			if err != nil {
+				data, err = srcDb.ContractCode(common.Hash{}, hash)
+			}
+			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x", hash)
 			}
 			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -185,12 +194,17 @@ func TestIterativeDelayedStateSync(t *testing.T) {
 		for i, hash := range queue[:len(results)] {
 			data, err := srcDb.TrieDB().Node(hash)
 			if err != nil {
+				data, err = srcDb.ContractCode(common.Hash{}, hash)
+			}
+			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x", hash)
 			}
 			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -227,13 +241,18 @@ func testIterativeRandomStateSync(t *testing.T, count int) {
 		for hash := range queue {
 			data, err := srcDb.TrieDB().Node(hash)
 			if err != nil {
+				data, err = srcDb.ContractCode(common.Hash{}, hash)
+			}
+			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x", hash)
 			}
 			results = append(results, trie.SyncResult{Hash: hash, Data: data})
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -271,6 +290,9 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 
 			data, err := srcDb.TrieDB().Node(hash)
 			if err != nil {
+				data, err = srcDb.ContractCode(common.Hash{}, hash)
+			}
+			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x", hash)
 			}
 			results = append(results, trie.SyncResult{Hash: hash, Data: data})
@@ -280,8 +302,10 @@ func TestIterativeRandomDelayedStateSync(t *testing.T) {
 			}
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -302,6 +326,15 @@ func TestIncompleteStateSync(t *testing.T) {
 	// Create a random state to copy
 	srcDb, srcRoot, srcAccounts := makeTestState()
 
+	// isCode reports whether the hash is contract code hash.
+	isCode := func(hash common.Hash) bool {
+		for _, acc := range srcAccounts {
+			if hash == crypto.Keccak256Hash(acc.code) {
+				return true
+			}
+		}
+		return false
+	}
 	checkTrieConsistency(srcDb.TrieDB().DiskDB().(ethdb.Database), srcRoot)
 
 	// Create a destination state and sync with the scheduler
@@ -316,13 +349,18 @@ func TestIncompleteStateSync(t *testing.T) {
 		for i, hash := range queue {
 			data, err := srcDb.TrieDB().Node(hash)
 			if err != nil {
+				data, err = srcDb.ContractCode(common.Hash{}, hash)
+			}
+			if err != nil {
 				t.Fatalf("failed to retrieve node data for %x", hash)
 			}
 			results[i] = trie.SyncResult{Hash: hash, Data: data}
 		}
 		// Process each of the state nodes
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := dstDb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -333,12 +371,9 @@ func TestIncompleteStateSync(t *testing.T) {
 			added = append(added, result.Hash)
 		}
 		// Check that all known sub-tries added so far are complete or missing entirely.
-	checkSubtries:
 		for _, hash := range added {
-			for _, acc := range srcAccounts {
-				if hash == crypto.Keccak256Hash(acc.code) {
-					continue checkSubtries // skip trie check of code nodes.
-				}
+			if isCode(hash) {
+				continue
 			}
 			// Can't use checkStateConsistency here because subtrie keys may have odd
 			// length and crash in LeafKey.
@@ -351,13 +386,25 @@ func TestIncompleteStateSync(t *testing.T) {
 	}
 	// Sanity check that removing any node from the database is detected
 	for _, node := range added[1:] {
-		key := node.Bytes()
-		value, _ := dstDb.Get(key)
-
-		dstDb.Delete(key)
+		var (
+			key  = node.Bytes()
+			code = isCode(node)
+			val  []byte
+		)
+		if code {
+			val = rawdb.ReadCode(dstDb, node)
+			rawdb.DeleteCode(dstDb, node)
+		} else {
+			val = rawdb.ReadTrieNode(dstDb, node)
+			rawdb.DeleteTrieNode(dstDb, node)
+		}
 		if err := checkStateConsistency(dstDb, added[0]); err == nil {
 			t.Fatalf("trie inconsistency not caught, missing: %x", key)
 		}
-		dstDb.Put(key, value)
+		if code {
+			rawdb.WriteCode(dstDb, node, val)
+		} else {
+			rawdb.WriteTrieNode(dstDb, node, val)
+		}
 	}
 }

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -286,5 +287,5 @@ func GenerateBadBlock(t *testing.T, parent *types.Block, engine consensus.Engine
 	}
 	header.Root = common.BytesToHash(hasher.Sum(nil))
 	// Assemble and return the final block for sealing
-	return types.NewBlock(header, txs, nil, receipts)
+	return types.NewBlock(header, txs, nil, receipts, new(trie.Trie))
 }

--- a/core/txpool/txpool_test.go
+++ b/core/txpool/txpool_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/crypto"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 var (
@@ -82,7 +83,7 @@ func (bc *testBlockChain) CurrentBlock() *types.Block {
 	return types.NewBlock(&types.Header{
 		Root:     types.EmptyRootHash,
 		GasLimit: atomic.LoadUint64(&bc.gasLimit),
-	}, nil, nil, nil)
+	}, nil, nil, nil, new(trie.Trie))
 }
 
 func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -216,14 +216,14 @@ type storageblock struct {
 // The values of TxHash, UncleHash, ReceiptHash and Bloom in header
 // are ignored and set to values derived from the given txs, uncles
 // and receipts.
-func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*Receipt) *Block {
+func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*Receipt, hasher Hasher) *Block {
 	b := &Block{header: CopyHeader(header), td: new(big.Int)}
 
 	// TODO: panic if len(txs) != len(receipts)
 	if len(txs) == 0 {
 		b.header.TxHash = EmptyTxsHash
 	} else {
-		b.header.TxHash = DeriveSha(Transactions(txs))
+		b.header.TxHash = DeriveSha(Transactions(txs), hasher)
 		b.transactions = make(Transactions, len(txs))
 		copy(b.transactions, txs)
 	}
@@ -231,7 +231,7 @@ func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*
 	if len(receipts) == 0 {
 		b.header.ReceiptHash = EmptyReceiptsHash
 	} else {
-		b.header.ReceiptHash = DeriveSha(Receipts(receipts))
+		b.header.ReceiptHash = DeriveSha(Receipts(receipts), hasher)
 		b.header.Bloom = CreateBloom(receipts)
 	}
 

--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -211,5 +211,5 @@ func makeBenchBlock() *Block {
 			Extra:      []byte("benchmark uncle"),
 		}
 	}
-	return NewBlock(header, txs, uncles, receipts)
+	return NewBlock(header, txs, uncles, receipts, newHasher())
 }

--- a/core/types/derive_sha.go
+++ b/core/types/derive_sha.go
@@ -21,21 +21,28 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
-	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
+// DerivableList is the interface which can derive the hash.
 type DerivableList interface {
 	Len() int
 	GetRlp(i int) []byte
 }
 
-func DeriveSha(list DerivableList) common.Hash {
+// Hasher is the tool used to calculate the hash of derivable list.
+type Hasher interface {
+	Reset()
+	Update([]byte, []byte)
+	Hash() common.Hash
+}
+
+func DeriveSha(list DerivableList, hasher Hasher) common.Hash {
+	hasher.Reset()
 	keybuf := new(bytes.Buffer)
-	trie := new(trie.Trie)
 	for i := 0; i < list.Len(); i++ {
 		keybuf.Reset()
 		rlp.Encode(keybuf, uint(i))
-		trie.Update(keybuf.Bytes(), list.GetRlp(i))
+		hasher.Update(keybuf.Bytes(), list.GetRlp(i))
 	}
-	return trie.Hash()
+	return hasher.Hash()
 }

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -30,6 +30,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/metrics"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 var (
@@ -772,7 +773,7 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLi
 	defer q.lock.Unlock()
 
 	reconstruct := func(header *types.Header, index int, result *fetchResult) error {
-		if types.DeriveSha(types.Transactions(txLists[index])) != header.TxHash || types.CalcUncleHash(uncleLists[index]) != header.UncleHash {
+		if types.DeriveSha(types.Transactions(txLists[index]), new(trie.Trie)) != header.TxHash || types.CalcUncleHash(uncleLists[index]) != header.UncleHash {
 			return errInvalidBody
 		}
 		result.Transactions = txLists[index]
@@ -790,7 +791,7 @@ func (q *queue) DeliverReceipts(id string, receiptList [][]*types.Receipt) (int,
 	defer q.lock.Unlock()
 
 	reconstruct := func(header *types.Header, index int, result *fetchResult) error {
-		if types.DeriveSha(types.Receipts(receiptList[index])) != header.ReceiptHash {
+		if types.DeriveSha(types.Receipts(receiptList[index]), new(trie.Trie)) != header.ReceiptHash {
 			return errInvalidReceipt
 		}
 		result.Receipts = receiptList[index]

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 )
 
 const (
@@ -472,7 +473,7 @@ func (f *Fetcher) loop() {
 						announce.time = task.time
 
 						// If the block is empty (header only), short circuit into the final import queue
-						if header.TxHash == types.DeriveSha(types.Transactions{}) && header.UncleHash == types.CalcUncleHash([]*types.Header{}) {
+						if header.TxHash == types.DeriveSha(types.Transactions{}, new(trie.Trie)) && header.UncleHash == types.CalcUncleHash([]*types.Header{}) {
 							log.Trace("Block empty, skipping body retrieval", "peer", announce.origin, "number", header.Number, "hash", header.Hash())
 
 							block := types.NewBlockWithHeader(header)
@@ -534,7 +535,7 @@ func (f *Fetcher) loop() {
 
 				for hash, announce := range f.completing {
 					if f.queued[hash] == nil {
-						txnHash := types.DeriveSha(types.Transactions(task.transactions[i]))
+						txnHash := types.DeriveSha(types.Transactions(task.transactions[i]), new(trie.Trie))
 						uncleHash := types.CalcUncleHash(task.uncles[i])
 
 						if txnHash == announce.header.TxHash && uncleHash == announce.header.UncleHash && announce.origin == task.peer {

--- a/eth/fetcher/fetcher_test.go
+++ b/eth/fetcher/fetcher_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
@@ -39,7 +40,7 @@ var (
 	testKey, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	testAddress  = crypto.PubkeyToAddress(testKey.PublicKey)
 	genesis      = core.GenesisBlockForTesting(testdb, testAddress, big.NewInt(1000000000))
-	unknownBlock = types.NewBlock(&types.Header{Root: types.EmptyRootHash, GasLimit: params.GenesisGasLimit}, nil, nil, nil)
+	unknownBlock = types.NewBlock(&types.Header{Root: types.EmptyRootHash, GasLimit: params.GenesisGasLimit}, nil, nil, nil, new(trie.Trie))
 )
 
 // makeChain creates a chain of n blocks starting at and including parent.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -633,7 +633,14 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 				return errResp(ErrDecode, "msg %v: %v", msg, err)
 			}
 			// Retrieve the requested state entry, stopping if enough was found
-			if entry, err := pm.blockchain.TrieNode(hash); err == nil {
+			// todo now the code and trienode is mixed in the protocol level,
+			// separate these two types.
+			entry, err := pm.blockchain.TrieNode(hash)
+			if len(entry) == 0 || err != nil {
+				// Read the contract code with prefix only to save unnecessary lookups.
+				entry, err = pm.blockchain.ContractCodeWithPrefix(hash)
+			}
+			if err == nil && len(entry) > 0 {
 				data = append(data, entry)
 				bytes += len(entry)
 			}

--- a/internal/ethapi/trie_proof_test.go
+++ b/internal/ethapi/trie_proof_test.go
@@ -49,7 +49,7 @@ func TestTransactionProof(t *testing.T) {
 	transactions := types.Transactions([]*types.Transaction{t1, t2, t3, t4})
 	tr := deriveTrie(transactions)
 	// for verifying the proof
-	root := types.DeriveSha(transactions)
+	root := types.DeriveSha(transactions, new(trie.Trie))
 	for i := 0; i < transactions.Len(); i++ {
 		var proof proofPairList
 		keybuf := new(bytes.Buffer)
@@ -82,7 +82,7 @@ func TestReceiptProof(t *testing.T) {
 	receipts := types.Receipts([]*types.Receipt{r1, r2, r3, r4})
 	tr := deriveTrie(receipts)
 	// for verifying the proof
-	root := types.DeriveSha(receipts)
+	root := types.DeriveSha(receipts, new(trie.Trie))
 	for i := 0; i < receipts.Len(); i++ {
 		var proof proofPairList
 		keybuf := new(bytes.Buffer)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -43,6 +43,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/trie"
 	mapset "github.com/deckarep/golang-set/v2"
 )
 
@@ -536,6 +537,7 @@ func (w *worker) updateSnapshot() {
 		w.current.txs,
 		nil,
 		w.current.receipts,
+		new(trie.Trie),
 	)
 	w.snapshotReceipts = copyReceipts(w.current.receipts)
 	w.snapshotState = w.current.state.Copy()

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -130,8 +130,7 @@ func (t *SecureTrie) GetKey(shaKey []byte) []byte {
 	if key, ok := t.getSecKeyCache()[string(shaKey)]; ok {
 		return key
 	}
-	key, _ := t.trie.Db.Preimage(common.BytesToHash(shaKey))
-	return key
+	return t.trie.Db.Preimage(common.BytesToHash(shaKey))
 }
 
 // Commit writes all nodes and the secure hash pre-images to the trie's database.

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/common/prque"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 )
 
@@ -37,7 +38,7 @@ var ErrAlreadyProcessed = errors.New("already processed")
 type request struct {
 	hash common.Hash // Hash of the Node data content to retrieve
 	data []byte      // Data content of the Node, cached until all subtrees complete
-	raw  bool        // Whether this is a raw entry (code) or a trie Node
+	code bool        // Whether this is a code entry
 
 	parents []*request // Parent state nodes referencing this entry (notify all upon completion)
 	depth   int        // Depth level within the trie the Node is located to prioritise DFS
@@ -46,8 +47,7 @@ type request struct {
 	callback LeafCallback // Callback to invoke if a leaf Node it reached on this branch
 }
 
-// SyncResult is a simple list to return missing nodes along with their request
-// hashes.
+// SyncResult is a response with requested data along with it's hash.
 type SyncResult struct {
 	Hash common.Hash // Hash of the originally unknown trie Node
 	Data []byte      // Data content of the retrieved Node
@@ -56,14 +56,28 @@ type SyncResult struct {
 // syncMemBatch is an in-memory buffer of successfully downloaded but not yet
 // persisted data items.
 type syncMemBatch struct {
-	batch map[common.Hash][]byte // In-memory membatch of recently completed items
+	nodes map[common.Hash][]byte // In-memory membatch of recently completed nodes
+	codes map[common.Hash][]byte // In-memory membatch of recently completed codes
 }
 
 // newSyncMemBatch allocates a new memory-buffer for not-yet persisted trie nodes.
 func newSyncMemBatch() *syncMemBatch {
 	return &syncMemBatch{
-		batch: make(map[common.Hash][]byte),
+		nodes: make(map[common.Hash][]byte),
+		codes: make(map[common.Hash][]byte),
 	}
+}
+
+// hasNode reports the trie node with specific hash is already cached.
+func (batch *syncMemBatch) hasNode(hash common.Hash) bool {
+	_, ok := batch.nodes[hash]
+	return ok
+}
+
+// hasCode reports the contract code with specific hash is already cached.
+func (batch *syncMemBatch) hasCode(hash common.Hash) bool {
+	_, ok := batch.codes[hash]
+	return ok
 }
 
 // Sync is the main state trie synchronisation scheduler, which provides yet
@@ -72,9 +86,10 @@ func newSyncMemBatch() *syncMemBatch {
 type Sync struct {
 	database ethdb.KeyValueReader     // Persistent database to check for existing entries
 	membatch *syncMemBatch            // Memory buffer to avoid frequent database writes
-	requests map[common.Hash]*request // Pending requests pertaining to a key hash
+	nodeReqs map[common.Hash]*request // Pending requests pertaining to a trie node hash
+	codeReqs map[common.Hash]*request // Pending requests pertaining to a code hash
 	queue    *prque.Prque[int64, any] // Priority queue with the pending requests
-	bloom    *SyncBloom               // Bloom filter for fast Node existence checks
+	bloom    *SyncBloom               // Bloom filter for fast state existence checks
 }
 
 // NewSync creates a new trie data download scheduler.
@@ -82,7 +97,8 @@ func NewSync(root common.Hash, database ethdb.KeyValueReader, callback LeafCallb
 	ts := &Sync{
 		database: database,
 		membatch: newSyncMemBatch(),
-		requests: make(map[common.Hash]*request),
+		nodeReqs: make(map[common.Hash]*request),
+		codeReqs: make(map[common.Hash]*request),
 		queue:    prque.New[int64, any](nil), // Ugh, can contain both string and hash, whyyy
 		bloom:    bloom,
 	}
@@ -96,13 +112,15 @@ func (s *Sync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callb
 	if root == emptyRoot {
 		return
 	}
-	if _, ok := s.membatch.batch[root]; ok {
+	if s.membatch.hasNode(root) {
 		return
 	}
-	if s.bloom.Contains(root[:]) {
-		// Bloom filter says this might be a duplicate, double check
-		blob, _ := s.database.Get(root[:])
-		if local, err := decodeNode(root[:], blob); local != nil && err == nil {
+	if s.bloom == nil || s.bloom.Contains(root[:]) {
+		// Bloom filter says this might be a duplicate, double check.
+		// If database says yes, then at least the trie node is present
+		// and we hold the assumption that it's NOT legacy contract code.
+		blob := rawdb.ReadTrieNode(s.database, root)
+		if len(blob) > 0 {
 			return
 		}
 		// False positive, bump fault meter
@@ -116,7 +134,7 @@ func (s *Sync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callb
 	}
 	// If this sub-trie has a designated parent, link them together
 	if parent != (common.Hash{}) {
-		ancestor := s.requests[parent]
+		ancestor := s.nodeReqs[parent]
 		if ancestor == nil {
 			panic(fmt.Sprintf("sub-trie ancestor not found: %x", parent))
 		}
@@ -126,21 +144,25 @@ func (s *Sync) AddSubTrie(root common.Hash, depth int, parent common.Hash, callb
 	s.schedule(req)
 }
 
-// AddRawEntry schedules the direct retrieval of a state entry that should not be
-// interpreted as a trie Node, but rather accepted and stored into the database
-// as is. This method's goal is to support misc state metadata retrievals (e.g.
-// contract code).
-func (s *Sync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) {
+// AddCodeEntry schedules the direct retrieval of a contract code that should not
+// be interpreted as a trie node, but rather accepted and stored into the database
+// as is.
+func (s *Sync) AddCodeEntry(hash common.Hash, depth int, parent common.Hash) {
 	// Short circuit if the entry is empty or already known
 	if hash == emptyState {
 		return
 	}
-	if _, ok := s.membatch.batch[hash]; ok {
+	if s.membatch.hasCode(hash) {
 		return
 	}
 	if s.bloom.Contains(hash[:]) {
-		// Bloom filter says this might be a duplicate, double check
-		if ok, _ := s.database.Has(hash[:]); ok {
+		// Bloom filter says this might be a duplicate, double check.
+		// If database says yes, the blob is present for sure.
+		// Note we only check the existence with new code scheme, fast
+		// sync is expected to run with a fresh new node. Even there
+		// exists the code with legacy format, fetch and store with
+		// new scheme anyway.
+		if blob := rawdb.ReadCodeWithPrefix(s.database, hash); len(blob) > 0 {
 			return
 		}
 		// False positive, bump fault meter
@@ -149,12 +171,12 @@ func (s *Sync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) {
 	// Assemble the new sub-trie sync request
 	req := &request{
 		hash:  hash,
-		raw:   true,
+		code:  true,
 		depth: depth,
 	}
 	// If this sub-trie has a designated parent, link them together
 	if parent != (common.Hash{}) {
-		ancestor := s.requests[parent]
+		ancestor := s.nodeReqs[parent] // the parent of codereq can ONLY be nodereq
 		if ancestor == nil {
 			panic(fmt.Sprintf("raw-entry ancestor not found: %x", parent))
 		}
@@ -173,61 +195,64 @@ func (s *Sync) Missing(max int) []common.Hash {
 	return requests
 }
 
-// Process injects a batch of retrieved trie nodes data, returning if something
-// was committed to the database and also the index of an entry if its processing
-// failed.
-func (s *Sync) Process(results []SyncResult) (bool, int, error) {
-	committed := false
-
-	for i, item := range results {
-		// If the item was not requested, bail out
-		request := s.requests[item.Hash]
-		if request == nil {
-			return committed, i, ErrNotRequested
-		}
-		if request.data != nil {
-			return committed, i, ErrAlreadyProcessed
-		}
-		// If the item is a raw entry request, commit directly
-		if request.raw {
-			request.data = item.Data
-			s.commit(request)
-			committed = true
-			continue
-		}
+// Process injects the received data for requested item. Note it can
+// happpen that the single response commits two pending requests(e.g.
+// there are two requests one for code and one for node but the hash
+// is same). In this case the second response for the same hash will
+// be treated as "non-requested" item or "already-processed" item but
+// there is no downside.
+func (s *Sync) Process(result SyncResult) error {
+	// If the item was not requested either for code or node, bail out
+	if s.nodeReqs[result.Hash] == nil && s.codeReqs[result.Hash] == nil {
+		return ErrNotRequested
+	}
+	// There is an pending code request for this data, commit directly
+	var filled bool
+	if req := s.codeReqs[result.Hash]; req != nil && req.data == nil {
+		filled = true
+		req.data = result.Data
+		s.commit(req)
+	}
+	// There is an pending node request for this data, fill it.
+	if req := s.nodeReqs[result.Hash]; req != nil && req.data == nil {
+		filled = true
 		// Decode the Node data content and update the request
-		node, err := decodeNode(item.Hash[:], item.Data)
+		node, err := decodeNode(result.Hash[:], result.Data)
 		if err != nil {
-			return committed, i, err
+			return err
 		}
-		request.data = item.Data
+		req.data = result.Data
 
 		// Create and schedule a request for all the children nodes
-		requests, err := s.children(request, node)
+		requests, err := s.children(req, node)
 		if err != nil {
-			return committed, i, err
+			return err
 		}
-		if len(requests) == 0 && request.deps == 0 {
-			s.commit(request)
-			committed = true
-			continue
-		}
-		request.deps += len(requests)
-		for _, child := range requests {
-			s.schedule(child)
+		if len(requests) == 0 && req.deps == 0 {
+			s.commit(req)
+		} else {
+			req.deps += len(requests)
+			for _, child := range requests {
+				s.schedule(child)
+			}
 		}
 	}
-	return committed, 0, nil
+	if !filled {
+		return ErrAlreadyProcessed
+	}
+	return nil
 }
 
 // Commit flushes the data stored in the internal membatch out to persistent
 // storage, returning any occurred error.
 func (s *Sync) Commit(dbw ethdb.Batch) error {
 	// Dump the membatch into a database dbw
-	for key, value := range s.membatch.batch {
-		if err := dbw.Put(key[:], value); err != nil {
-			return err
-		}
+	for key, value := range s.membatch.nodes {
+		rawdb.WriteTrieNode(dbw, key, value)
+		s.bloom.Add(key[:])
+	}
+	for key, value := range s.membatch.codes {
+		rawdb.WriteCode(dbw, key, value)
 		s.bloom.Add(key[:])
 	}
 	// Drop the membatch data and return
@@ -237,21 +262,30 @@ func (s *Sync) Commit(dbw ethdb.Batch) error {
 
 // Pending returns the number of state entries currently pending for download.
 func (s *Sync) Pending() int {
-	return len(s.requests)
+	return len(s.nodeReqs) + len(s.codeReqs)
 }
 
 // schedule inserts a new state retrieval request into the fetch queue. If there
 // is already a pending request for this Node, the new request will be discarded
 // and only a parent reference added to the old one.
 func (s *Sync) schedule(req *request) {
-	// If we're already requesting this Node, add a new reference and stop
-	if old, ok := s.requests[req.hash]; ok {
+	var reqset = s.nodeReqs
+	if req.code {
+		reqset = s.codeReqs
+	}
+	// If we're already requesting this node, add a new reference and stop
+	if old, ok := reqset[req.hash]; ok {
 		old.parents = append(old.parents, req.parents...)
 		return
 	}
-	// Schedule the request for future retrieval
+	reqset[req.hash] = req
+
+	// Schedule the request for future retrieval. This queue is shared
+	// by both node requests and code requests. It can happen that there
+	// is a trie node and code has same hash. In this case two elements
+	// with same hash and same or different depth will be pushed. But it's
+	// ok the worst case is the second response will be treated as duplicated.
 	s.queue.Push(req.hash, int64(req.depth))
-	s.requests[req.hash] = req
 }
 
 // children retrieves all the missing children of a state trie entry for future
@@ -297,12 +331,14 @@ func (s *Sync) children(req *request, object Node) ([]*request, error) {
 		if node, ok := (child.node).(HashNode); ok {
 			// Try to resolve the Node from the local database
 			hash := common.BytesToHash(node)
-			if _, ok := s.membatch.batch[hash]; ok {
+			if s.membatch.hasNode(hash) {
 				continue
 			}
-			if s.bloom.Contains(node) {
-				// Bloom filter says this might be a duplicate, double check
-				if ok, _ := s.database.Has(node); ok {
+			if s.bloom == nil || s.bloom.Contains(node) {
+				// Bloom filter says this might be a duplicate, double check.
+				// If database says yes, then at least the trie node is present
+				// and we hold the assumption that it's NOT legacy contract code.
+				if blob := rawdb.ReadTrieNode(s.database, common.BytesToHash(node)); len(blob) > 0 {
 					continue
 				}
 				// False positive, bump fault meter
@@ -325,10 +361,13 @@ func (s *Sync) children(req *request, object Node) ([]*request, error) {
 // committed themselves.
 func (s *Sync) commit(req *request) (err error) {
 	// Write the Node content to the membatch
-	s.membatch.batch[req.hash] = req.data
-
-	delete(s.requests, req.hash)
-
+	if req.code {
+		s.membatch.codes[req.hash] = req.data
+		delete(s.codeReqs, req.hash)
+	} else {
+		s.membatch.nodes[req.hash] = req.data
+		delete(s.nodeReqs, req.hash)
+	}
 	// Check all parents for completion
 	for _, parent := range req.parents {
 		parent.deps--

--- a/trie/sync_bloom.go
+++ b/trie/sync_bloom.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/metrics"
@@ -41,8 +42,8 @@ var (
 )
 
 // syncBloomHasher is a wrapper around a byte blob to satisfy the interface API
-// requirements of the bloom library used. It's used to convert a trie hash into
-// a 64 bit mini hash.
+// requirements of the bloom library used. It's used to convert a trie hash or
+// contract code hash into a 64 bit mini hash.
 type syncBloomHasher []byte
 
 func (f syncBloomHasher) Write(p []byte) (n int, err error) { panic("not implemented") }
@@ -53,9 +54,9 @@ func (f syncBloomHasher) Size() int                         { return 8 }
 func (f syncBloomHasher) Sum64() uint64                     { return binary.BigEndian.Uint64(f) }
 
 // SyncBloom is a bloom filter used during fast sync to quickly decide if a trie
-// Node already exists on disk or not. It self populates from the provided disk
-// database on creation in a background thread and will only start returning live
-// results once that's finished.
+// node or contract code already exists on disk or not. It self populates from the
+// provided disk database on creation in a background thread and will only start
+// returning live results once that's finished.
 type SyncBloom struct {
 	bloom  *bloomfilter.Filter
 	inited uint32
@@ -107,8 +108,14 @@ func (b *SyncBloom) init(database ethdb.Iteratee) {
 	)
 	for it.Next() && atomic.LoadUint32(&b.closed) == 0 {
 		// If the database entry is a trie Node, add it to the bloom
-		if key := it.Key(); len(key) == common.HashLength {
+		key := it.Key()
+		if len(key) == common.HashLength {
 			b.bloom.Add(syncBloomHasher(key))
+			bloomLoadMeter.Mark(1)
+		}
+		// If the database entry is a contract code, add it to the bloom
+		if ok, hash := rawdb.IsCodeKey(key); ok {
+			b.bloom.Add(syncBloomHasher(hash))
 			bloomLoadMeter.Mark(1)
 		}
 		// If enough time elapsed since the last iterator swap, restart

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -124,8 +124,10 @@ func testIterativeSync(t *testing.T, count int) {
 			}
 			results[i] = SyncResult{hash, data}
 		}
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := diskdb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -160,8 +162,10 @@ func TestIterativeDelayedSync(t *testing.T) {
 			}
 			results[i] = SyncResult{hash, data}
 		}
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := diskdb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -204,8 +208,10 @@ func testIterativeRandomSync(t *testing.T, count int) {
 			results = append(results, SyncResult{hash, data})
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := diskdb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -251,8 +257,10 @@ func TestIterativeRandomDelayedSync(t *testing.T) {
 			}
 		}
 		// Feed the retrieved results back and queue new tasks
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := diskdb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -298,8 +306,10 @@ func TestDuplicateAvoidanceSync(t *testing.T) {
 
 			results[i] = SyncResult{hash, data}
 		}
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := diskdb.NewBatch()
 		if err := sched.Commit(batch); err != nil {
@@ -336,8 +346,10 @@ func TestIncompleteSync(t *testing.T) {
 			results[i] = SyncResult{hash, data}
 		}
 		// Process each of the trie nodes
-		if _, index, err := sched.Process(results); err != nil {
-			t.Fatalf("failed to process result #%d: %v", index, err)
+		for _, result := range results {
+			if err := sched.Process(result); err != nil {
+				t.Fatalf("failed to process result %v", err)
+			}
 		}
 		batch := diskdb.NewBatch()
 		if err := sched.Commit(batch); err != nil {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -579,7 +579,7 @@ func (t *Trie) resolveHash(n HashNode, prefix []byte) (Node, error) {
 // Hash returns the root hash of the trie. It does not write to the
 // database and can be used even if the trie doesn't have one.
 func (t *Trie) Hash() common.Hash {
-	hash, cached, _ := t.hashRoot(nil)
+	hash, cached, _ := t.hashRoot()
 	t.root = cached
 	return common.BytesToHash(hash.(HashNode))
 }
@@ -630,7 +630,7 @@ func (t *Trie) Commit(onleaf LeafCallback) (root common.Hash, err error) {
 }
 
 // hashRoot calculates the root hash of the given trie
-func (t *Trie) hashRoot(db *Database) (Node, Node, error) {
+func (t *Trie) hashRoot() (Node, Node, error) {
 	if t.root == nil {
 		return HashNode(emptyRoot.Bytes()), nil, nil
 	}
@@ -640,4 +640,10 @@ func (t *Trie) hashRoot(db *Database) (Node, Node, error) {
 	hashed, cached := h.hash(t.root, true)
 	t.unhashed = 0
 	return hashed, cached, nil
+}
+
+// Reset drops the referenced root node and cleans all internal state.
+func (t *Trie) Reset() {
+	t.root = nil
+	t.unhashed = 0
 }


### PR DESCRIPTION
# Proposed changes

This PR adds a prefix for contract code in leveldb.

Ref: #21080

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
