### PR TITLE
add limit to high resource demand api

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -334,6 +334,9 @@ func (api *API) GetEpochNumbersBetween(begin, end *rpc.BlockNumber) ([]uint64, e
 	if beginHeader.Number.Cmp(endHeader.Number) > 0 {
 		return nil, errors.New("illegal begin and end block number, begin > end")
 	}
+	if big.NewInt(50_000).Cmp(new(big.Int).Sub(endHeader.Number, beginHeader.Number)) < 0 {
+		return nil, errors.New("block range over limit of 50,000 blocks")
+	}
 	epochSwitchInfos, err := api.XDPoS.GetEpochSwitchInfoBetween(api.chain, beginHeader, endHeader)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Proposed changes
add request range limit to not over burden the RPC
from testing XDPoS_getEpochNumbersBetween takes longer than 30s around 50,000 block range 


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
