### PR TITLE
build: support auto-completion for bash

### DIFF
--- a/build/deb/completions/bash_autocomplete
+++ b/build/deb/completions/bash_autocomplete
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+    COMPREPLY=()
+    _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+_cli_bash_autocomplete() {
+    if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+        local cur opts base words
+        COMPREPLY=()
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        if declare -F _init_completion >/dev/null 2>&1; then
+            _init_completion -n "=:" || return
+        else
+            _cli_init_completion -n "=:" || return
+        fi
+        words=("${words[@]:0:$cword}")
+        if [[ "$cur" == "-"* ]]; then
+            requestComp="${words[*]} ${cur} --generate-bash-completion"
+        else
+            requestComp="${words[*]} --generate-bash-completion"
+        fi
+        opts=$(eval "${requestComp}" 2>/dev/null)
+        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+        return 0
+    fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/build/deb/completions/install.sh
+++ b/build/deb/completions/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eo pipefail
+
+PROFILE="${HOME}/.bashrc"
+SRC_DIR="$(dirname "$0")"
+DEST_DIR="${HOME}/.bash_completion.d"
+XDC_PATH="\${HOME}/XDPoSChain/build/bin"
+CMD_STR="PROG=XDC source \${HOME}/.bash_completion.d/xdc.sh"
+
+mkdir -p ${DEST_DIR}
+cp ${SRC_DIR}/bash_autocomplete "${DEST_DIR}/xdc.sh"
+cp ${SRC_DIR}/zsh_autocomplete "${DEST_DIR}/xdc.zsh"
+
+if ! grep PATH ${PROFILE} | grep ${XDC_PATH} &>/dev/null; then
+    echo "export PATH=\${PATH}:${XDC_PATH}" >>"${PROFILE}"
+fi
+if ! grep -q "${CMD_STR}" "${PROFILE}"; then
+    echo "${CMD_STR}" >>"${PROFILE}"
+fi
+
+echo "please login again or run: source \${HOME}/.bashrc"

--- a/build/deb/completions/zsh_autocomplete
+++ b/build/deb/completions/zsh_autocomplete
@@ -1,0 +1,20 @@
+#compdef $PROG
+
+_cli_zsh_autocomplete() {
+  local -a opts
+  local cur
+  cur=${words[-1]}
+  if [[ "$cur" == "-"* ]]; then
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+  else
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+}
+
+compdef _cli_zsh_autocomplete $PROG


### PR DESCRIPTION
# Proposed changes

supports auto-completion for bash. 

## Install

command:

```bash
./XDPoSChain/build/deb/completions/install.sh
```

output:

![image](https://github.com/user-attachments/assets/3a7e73d8-31e4-471d-97ee-bf409ca4748b)

## Usage:

example 1:

```bash
XDC [TAB]
```

output:

![image](https://github.com/user-attachments/assets/f238bcbe-0f95-43a8-866e-f88db8707f72)

---

example 2:

```bash
XDC a[TAB]
```

output:

![image](https://github.com/user-attachments/assets/b5799d03-52f0-4119-948c-b27590ef91af)


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
