### PR TITLE
common: enable cancun after 1800 blocks in eip1559 on testnet

### DIFF
--- a/common/constants.testnet.go
+++ b/common/constants.testnet.go
@@ -9,27 +9,27 @@ var TestnetConstant = constant{
 	blackListHFNumber: 23779191,
 	maxMasternodesV2:  15,
 
-	tip2019Block:                  big.NewInt(1),
-	tipSigning:                    big.NewInt(3000000),
-	tipRandomize:                  big.NewInt(3464000),
-	tipNoHalvingMNReward:          big.NewInt(23779191), // hardfork no halving masternodes reward
-	tipXDCX:                       big.NewInt(23779191),
-	tipXDCXLending:                big.NewInt(23779191),
-	tipXDCXCancellationFee:        big.NewInt(23779191),
-	tipTRC21Fee:                   big.NewInt(23779191),
-	tipIncreaseMasternodes:        big.NewInt(5000000),
-	blockNumberGas50x:             big.NewInt(56828700), // Target 13rd Nov 2023
-	TIPV2SwitchBlock:              big.NewInt(56828700), // Target 13rd Nov 2023
-	berlinBlock:                   big.NewInt(61290000), // Target 31st March 2024
-	londonBlock:                   big.NewInt(61290000), // Target 31st March 2024
-	mergeBlock:                    big.NewInt(61290000), // Target 31st March 2024
-	shanghaiBlock:                 big.NewInt(61290000), // Target 31st March 2024
-	tipXDCXMinerDisable:           big.NewInt(61290000), // Target 31st March 2024
-	tipXDCXReceiverDisable:        big.NewInt(66825000), // Target 26 Aug 2024
-	eip1559Block:                  big.NewInt(71550000), // Target 14th Feb 2025
-	cancunBlock:                   big.NewInt(71550000),
-	tipUpgradeReward:              big.NewInt(9999999999),
-	tipEpochHalving:               big.NewInt(9999999999),
+	tip2019Block:           big.NewInt(1),
+	tipSigning:             big.NewInt(3000000),
+	tipRandomize:           big.NewInt(3464000),
+	tipNoHalvingMNReward:   big.NewInt(23779191), // hardfork no halving masternodes reward
+	tipXDCX:                big.NewInt(23779191),
+	tipXDCXLending:         big.NewInt(23779191),
+	tipXDCXCancellationFee: big.NewInt(23779191),
+	tipTRC21Fee:            big.NewInt(23779191),
+	tipIncreaseMasternodes: big.NewInt(5000000),
+	blockNumberGas50x:      big.NewInt(56828700), // Target 13rd Nov 2023
+	TIPV2SwitchBlock:       big.NewInt(56828700), // Target 13rd Nov 2023
+	berlinBlock:            big.NewInt(61290000), // Target 31st March 2024
+	londonBlock:            big.NewInt(61290000), // Target 31st March 2024
+	mergeBlock:             big.NewInt(61290000), // Target 31st March 2024
+	shanghaiBlock:          big.NewInt(61290000), // Target 31st March 2024
+	tipXDCXMinerDisable:    big.NewInt(61290000), // Target 31st March 2024
+	tipXDCXReceiverDisable: big.NewInt(66825000), // Target 26 Aug 2024
+	eip1559Block:           big.NewInt(71550000), // Target 14th Feb 2025
+	cancunBlock:            big.NewInt(71551800),
+	tipUpgradeReward:       big.NewInt(9999999999),
+	tipEpochHalving:        big.NewInt(9999999999),
 
 	trc21IssuerSMC:         HexToAddress("0x0E2C88753131CE01c7551B726b28BFD04e44003F"),
 	xdcxListingSMC:         HexToAddress("0x14B2Bf043b9c31827A472CE4F94294fE9a6277e0"),


### PR DESCRIPTION
# Proposed changes

change `cancunBlock` from 71550000 to 71551800 for testnet which is 1800 blocks after eip1559Block

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
