### PR TITLE
internal/ethapi: disable sending of non eip155 replay protected tx #22339

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -161,6 +161,7 @@ var (
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
 		utils.RPCGlobalTxFeeCap,
+		utils.AllowUnprotectedTxs,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -546,6 +546,11 @@ var (
 		Usage:    "Comma separated list of JavaScript files to preload into the console",
 		Category: flags.APICategory,
 	}
+	AllowUnprotectedTxs = &cli.BoolFlag{
+		Name:     "rpc.allow-unprotected-txs",
+		Usage:    "Allow for unprotected (non EIP155 signed) transactions to be submitted via RPC",
+		Category: flags.APICategory,
+	}
 
 	// Network Settings
 	MaxPeersFlag = &cli.IntFlag{
@@ -1013,6 +1018,9 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.IsSet(HTTPIdleTimeoutFlag.Name) {
 		cfg.HTTPTimeouts.IdleTimeout = ctx.Duration(HTTPIdleTimeoutFlag.Name)
+	}
+	if ctx.IsSet(AllowUnprotectedTxs.Name) {
+		cfg.AllowUnprotectedTxs = ctx.Bool(AllowUnprotectedTxs.Name)
 	}
 	cfg.HTTPCors = SplitAndTrim(ctx.String(HTTPCORSDomainFlag.Name))
 	cfg.HTTPModules = SplitAndTrim(ctx.String(HTTPApiFlag.Name))

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -54,9 +54,10 @@ import (
 
 // EthAPIBackend implements ethapi.Backend for full nodes
 type EthAPIBackend struct {
-	eth   *Ethereum
-	gpo   *gasprice.Oracle
-	XDPoS *XDPoS.XDPoS
+	allowUnprotectedTxs bool
+	eth                 *Ethereum
+	gpo                 *gasprice.Oracle
+	XDPoS               *XDPoS.XDPoS
 }
 
 func (b *EthAPIBackend) ChainConfig() *params.ChainConfig {
@@ -367,6 +368,10 @@ func (b *EthAPIBackend) ChainDb() ethdb.Database {
 
 func (b *EthAPIBackend) EventMux() *event.TypeMux {
 	return b.eth.EventMux()
+}
+
+func (b *EthAPIBackend) UnprotectedAllowed() bool {
+	return b.allowUnprotectedTxs
 }
 
 func (b *EthAPIBackend) RPCGasCap() uint64 {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -244,21 +244,17 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	eth.miner = miner.New(eth, eth.chainConfig, eth.EventMux(), eth.engine, stack.Config().AnnounceTxs)
 	eth.miner.SetExtra(makeExtraData(config.ExtraData))
 
+	var xdpService *XDPoS.XDPoS
 	if eth.chainConfig.XDPoS != nil {
-		eth.ApiBackend = &EthAPIBackend{
-			allowUnprotectedTxs: stack.Config().AllowUnprotectedTxs,
-			eth:                 eth,
-			gpo:                 nil,
-			XDPoS:               eth.engine.(*XDPoS.XDPoS),
-		}
-	} else {
-		eth.ApiBackend = &EthAPIBackend{
-			allowUnprotectedTxs: stack.Config().AllowUnprotectedTxs,
-			eth:                 eth,
-			gpo:                 nil,
-			XDPoS:               nil,
-		}
+		xdpService = eth.engine.(*XDPoS.XDPoS)
 	}
+	eth.ApiBackend = &EthAPIBackend{
+		allowUnprotectedTxs: stack.Config().AllowUnprotectedTxs,
+		eth:                 eth,
+		gpo:                 nil,
+		XDPoS:               xdpService,
+	}
+
 	if eth.ApiBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -244,15 +244,15 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	eth.miner = miner.New(eth, eth.chainConfig, eth.EventMux(), eth.engine, stack.Config().AnnounceTxs)
 	eth.miner.SetExtra(makeExtraData(config.ExtraData))
 
-	var xdpService *XDPoS.XDPoS
+	var xdPoS *XDPoS.XDPoS = nil
 	if eth.chainConfig.XDPoS != nil {
-		xdpService = eth.engine.(*XDPoS.XDPoS)
+		xdPoS = eth.engine.(*XDPoS.XDPoS)
 	}
 	eth.ApiBackend = &EthAPIBackend{
 		allowUnprotectedTxs: stack.Config().AllowUnprotectedTxs,
 		eth:                 eth,
 		gpo:                 nil,
-		XDPoS:               xdpService,
+		XDPoS:               xdPoS,
 	}
 
 	if eth.ApiBackend.allowUnprotectedTxs {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -245,9 +245,22 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	eth.miner.SetExtra(makeExtraData(config.ExtraData))
 
 	if eth.chainConfig.XDPoS != nil {
-		eth.ApiBackend = &EthAPIBackend{eth, nil, eth.engine.(*XDPoS.XDPoS)}
+		eth.ApiBackend = &EthAPIBackend{
+			allowUnprotectedTxs: stack.Config().AllowUnprotectedTxs,
+			eth:                 eth,
+			gpo:                 nil,
+			XDPoS:               eth.engine.(*XDPoS.XDPoS),
+		}
 	} else {
-		eth.ApiBackend = &EthAPIBackend{eth, nil, nil}
+		eth.ApiBackend = &EthAPIBackend{
+			allowUnprotectedTxs: stack.Config().AllowUnprotectedTxs,
+			eth:                 eth,
+			gpo:                 nil,
+			XDPoS:               nil,
+		}
+	}
+	if eth.ApiBackend.allowUnprotectedTxs {
+		log.Info("Unprotected transactions allowed")
 	}
 	eth.ApiBackend.gpo = gasprice.NewOracle(eth.ApiBackend, config.GPO, config.GasPrice)
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2304,6 +2304,10 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), b.RPCTxFeeCap()); err != nil {
 		return common.Hash{}, err
 	}
+	if !b.UnprotectedAllowed() && !tx.Protected() {
+		// Ensure only eip155 signed transactions are submitted if EIP155Required is set.
+		return common.Hash{}, errors.New("only replay-protected (EIP-155) transactions allowed over RPC")
+	}
 	if err := b.SendTx(ctx, tx); err != nil {
 		return common.Hash{}, err
 	}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -51,8 +51,10 @@ type Backend interface {
 	BlobBaseFee(ctx context.Context) *big.Int
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
-	RPCGasCap() uint64    // global gas cap for eth_call over rpc: DoS protection
-	RPCTxFeeCap() float64 // global tx fee cap for all transaction related APIs
+	RPCGasCap() uint64        // global gas cap for eth_call over rpc: DoS protection
+	RPCTxFeeCap() float64     // global tx fee cap for all transaction related APIs
+	UnprotectedAllowed() bool // allows only for EIP155 transactions.
+
 	XDCxService() *XDCx.XDCX
 	LendingService() *XDCxlending.Lending
 

--- a/node/config.go
+++ b/node/config.go
@@ -171,6 +171,9 @@ type Config struct {
 	oldGethResourceWarning bool
 
 	AnnounceTxs bool `toml:",omitempty"`
+
+	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
+	AllowUnprotectedTxs bool `toml:",omitempty"`
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -258,7 +258,7 @@ func baseRpcRequest(t *testing.T, url, bodyStr string, extraHeaders ...string) *
 
 	// Create the request.
 	body := bytes.NewReader([]byte(bodyStr))
-	req, err := http.NewRequest("POST", url, body)
+	req, err := http.NewRequest(http.MethodPost, url, body)
 	if err != nil {
 		t.Fatal("could not create http request:", err)
 	}


### PR DESCRIPTION
# Proposed changes

This PR prevents users from submitting transactions without EIP-155 enabled.
Replay protection is important so we should gently force our users to use it.

It changes the JSON-RPC API quite significantly, so if you see the "only replay-protected (EIP-155) transactions allowed over RPC" error, you know that you need to update your signer.

## Test

my test script
```javascript
import { ethers } from "ethers";

async function testTransaction() {
  const provider = new ethers.providers.JsonRpcProvider("http://0.0.0.0"); //  replace with your RPC address
  const wallet = new ethers.Wallet("your private key", provider); // replace with your private key

  const nonce = await provider.getTransactionCount(wallet.address);
  const currentGasPrice = await provider.getGasPrice();

  const fakeTx = {
    nonce: nonce,
    gasLimit: 21000,
    gasPrice: currentGasPrice.mul(ethers.BigNumber.from(2)),
    to: "your destination address",
    value: ethers.utils.parseEther("1.0"),
    data: "0x",
  };

  // sign the transaction without EIP-155
  try {
    const noneipTx = await wallet.signTransaction(fakeTx);
    await provider.sendTransaction(noneipTx);
  } catch (error) {
    console.error("Transaction failed:");
    console.error("Details:", JSON.parse(error.error.body)); // expect output "only replay-protected (EIP-155) transactions allowed over RPC"
  }

  // sign the transaction with EIP-155
  const eip155Tx = {
    ...fakeTx,
    chainId: 54858,
  };

  try {
    const eip155SignedTx = await wallet.signTransaction(eip155Tx);
    const txResponse = await provider.sendTransaction(eip155SignedTx);
    console.log("Transaction sented! Hash:", txResponse.hash);
  } catch (error) {
    console.error("Transaction failed:", error);
  }
}

testTransaction();

```

**Result**

```
Transaction failed:
Details: {
  jsonrpc: '2.0',
  id: 50,
  error: {
    code: -32000,
    message: 'only replay-protected (EIP-155) transactions allowed over RPC'
  }
}
Transaction sented! Hash: 0x9c67fa1a8eba723332d41f0ccfea3cc71dff74e9bf0626ba97d9009a4ff8c584
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
