### PR TITLE
cmd/XDC: make authrpc listening address settable from command line #24522

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -123,6 +123,7 @@ var (
 		utils.EnableXDCPrefixFlag,
 		utils.NetworkIdFlag,
 		utils.HTTPCORSDomainFlag,
+		utils.AuthHostFlag,
 		utils.AuthPortFlag,
 		utils.JWTSecretFlag,
 		utils.HTTPVirtualHostsFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -392,7 +392,13 @@ var (
 		Value:    ethconfig.Defaults.RPCTxFeeCap,
 		Category: flags.APICategory,
 	}
-	// Authenticated port settings
+	// Authenticated RPC HTTP settings
+	AuthHostFlag = &cli.StringFlag{
+		Name:     "authrpc.host",
+		Usage:    "Listening address for authenticated APIs",
+		Value:    node.DefaultConfig.AuthHost,
+		Category: flags.APICategory,
+	}
 	AuthPortFlag = &cli.IntFlag{
 		Name:     "authrpc.port",
 		Usage:    "Listening port for authenticated APIs",
@@ -1015,6 +1021,9 @@ func setHTTP(ctx *cli.Context, cfg *node.Config) {
 
 	if ctx.IsSet(HTTPPortFlag.Name) {
 		cfg.HTTPPort = ctx.Int(HTTPPortFlag.Name)
+	}
+	if ctx.IsSet(AuthHostFlag.Name) {
+		cfg.AuthHost = ctx.String(AuthHostFlag.Name)
 	}
 	if ctx.IsSet(AuthPortFlag.Name) {
 		cfg.AuthPort = ctx.Int(AuthPortFlag.Name)

--- a/node/config.go
+++ b/node/config.go
@@ -109,9 +109,6 @@ type Config struct {
 	// for ephemeral nodes).
 	HTTPPort int `toml:",omitempty"`
 
-	// Authport is the port number on which the authenticated API is provided.
-	AuthPort int `toml:",omitempty"`
-
 	// HTTPCors is the Cross-Origin Resource Sharing header to send to requesting
 	// clients. Please be aware that CORS is a browser enforced security, it's fully
 	// useless for custom HTTP clients.
@@ -137,6 +134,12 @@ type Config struct {
 
 	// HTTPPathPrefix specifies a path prefix on which http-rpc is to be served.
 	HTTPPathPrefix string `toml:",omitempty"`
+
+	// AuthHost is the listening address on which authenticated APIs are provided.
+	AuthHost string `toml:",omitempty"`
+
+	// AuthPort is the port number on which authenticated APIs are provided.
+	AuthPort int `toml:",omitempty"`
 
 	// WSHost is the host interface on which to start the websocket RPC server. If
 	// this field is empty, no websocket API endpoint will be started.

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -48,6 +48,7 @@ var (
 var DefaultConfig = Config{
 	DataDir:          DefaultDataDir(),
 	HTTPPort:         DefaultHTTPPort,
+	AuthHost:         DefaultAuthHost,
 	AuthPort:         DefaultAuthPort,
 	HTTPModules:      []string{"net", "web3"},
 	HTTPVirtualHosts: []string{"localhost"},

--- a/node/node.go
+++ b/node/node.go
@@ -446,7 +446,7 @@ func (n *Node) startRPC() error {
 	initAuth := func(apis []rpc.API, port int, secret []byte) error {
 		// Enable auth via HTTP
 		server := n.httpAuth
-		if err := server.setListenAddr(DefaultAuthHost, port); err != nil {
+		if err := server.setListenAddr(n.config.AuthHost, port); err != nil {
 			return err
 		}
 		if err := server.enableRPC(apis, httpConfig{
@@ -461,7 +461,7 @@ func (n *Node) startRPC() error {
 		servers = append(servers, server)
 		// Enable auth via WS
 		server = n.wsServerForPort(port, true)
-		if err := server.setListenAddr(DefaultAuthHost, port); err != nil {
+		if err := server.setListenAddr(n.config.AuthHost, port); err != nil {
 			return err
 		}
 		if err := server.enableWS(apis, wsConfig{


### PR DESCRIPTION
# Proposed changes
The default listening address "localhost" is not sufficient when running XDC in Docker.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
