### PR TITLE
rpc: fix eth_getBlockReceipts when using block numbers or labels #28358

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -235,6 +235,16 @@ func (bnh *BlockNumberOrHash) Number() (BlockNumber, bool) {
 	return BlockNumber(0), false
 }
 
+func (bnh *BlockNumberOrHash) String() string {
+	if bnh.BlockNumber != nil {
+		return bnh.BlockNumber.String()
+	}
+	if bnh.BlockHash != nil {
+		return bnh.BlockHash.String()
+	}
+	return "nil"
+}
+
 func (bnh *BlockNumberOrHash) Hash() (common.Hash, bool) {
 	if bnh.BlockHash != nil {
 		return *bnh.BlockHash, true

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -155,3 +155,24 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockNumberOrHash_StringAndUnmarshal(t *testing.T) {
+	tests := []BlockNumberOrHash{
+		BlockNumberOrHashWithNumber(math.MaxInt64),
+		BlockNumberOrHashWithNumber(PendingBlockNumber),
+		BlockNumberOrHashWithNumber(LatestBlockNumber),
+		BlockNumberOrHashWithNumber(EarliestBlockNumber),
+		BlockNumberOrHashWithNumber(32),
+		BlockNumberOrHashWithHash(common.Hash{0xaa}, false),
+	}
+	for _, want := range tests {
+		marshalled, _ := json.Marshal(want.String())
+		var have BlockNumberOrHash
+		if err := json.Unmarshal(marshalled, &have); err != nil {
+			t.Fatalf("cannot unmarshal (%v): %v", string(marshalled), err)
+		}
+		if !reflect.DeepEqual(want, have) {
+			t.Fatalf("wrong result: have %v, want %v", have, want)
+		}
+	}
+}


### PR DESCRIPTION
# Proposed changes

The String() version of BlockNumberOrHash uses decimal for all block numbers, including negative ones used to indicate labels. Switch to using BlockNumber.String() which encodes it correctly for use in the JSON-RPC API.

geth: #28358

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
