### PR TITLE
cmd: disable prefetch next block state by default

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -98,7 +98,7 @@ var (
 		utils.CacheDatabaseFlag,
 		utils.CacheTrieFlag,
 		utils.CacheGCFlag,
-		utils.CacheNoPrefetchFlag,
+		utils.CachePrefetchFlag,
 		//utils.TrieCacheGenFlag,
 		utils.CacheLogSizeFlag,
 		utils.FDLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -290,7 +290,8 @@ var (
 		Category: flags.PerfCategory,
 	}
 	CacheTrieFlag = &cli.IntFlag{
-		Name:     "cache.trie",
+		Name:     "cache-trie",
+		Aliases:  []string{"cache.trie"},
 		Usage:    "Percentage of cache memory allowance to use for trie caching (default = 15% full mode, 30% archive mode)",
 		Value:    15,
 		Category: flags.PerfCategory,
@@ -302,9 +303,9 @@ var (
 		Value:    25,
 		Category: flags.PerfCategory,
 	}
-	CacheNoPrefetchFlag = &cli.BoolFlag{
-		Name:     "cache.noprefetch",
-		Usage:    "Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)",
+	CachePrefetchFlag = &cli.BoolFlag{
+		Name:     "cache-prefetch",
+		Usage:    "Enable heuristic state prefetch during block import",
 		Category: flags.PerfCategory,
 	}
 	CacheLogSizeFlag = &cli.IntFlag{
@@ -1511,7 +1512,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
 	}
 	cfg.NoPruning = ctx.String(GCModeFlag.Name) == "archive"
-	cfg.NoPrefetch = ctx.Bool(CacheNoPrefetchFlag.Name)
+	cfg.NoPrefetch = !ctx.Bool(CachePrefetchFlag.Name)
 
 	if ctx.IsSet(CacheFlag.Name) || ctx.IsSet(CacheTrieFlag.Name) {
 		cfg.TrieCleanCache = ctx.Int(CacheFlag.Name) * ctx.Int(CacheTrieFlag.Name) / 100
@@ -1775,7 +1776,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readonly bool) (chain *core.B
 	}
 	cache := &core.CacheConfig{
 		TrieCleanLimit:      ethconfig.Defaults.TrieCleanCache,
-		TrieCleanNoPrefetch: ctx.Bool(CacheNoPrefetchFlag.Name),
+		TrieCleanNoPrefetch: !ctx.Bool(CachePrefetchFlag.Name),
 		TrieDirtyLimit:      ethconfig.Defaults.TrieDirtyCache,
 		TrieDirtyDisabled:   ctx.String(GCModeFlag.Name) == "archive",
 		TrieTimeLimit:       ethconfig.Defaults.TrieTimeout,


### PR DESCRIPTION
# Proposed changes

PR #997 prefetches next block state concurrently. But this feature has a slight conflict with our current consensus algorithm. It produces `ErrUnknownAncestor` during sync, disconnect and reconnect peer.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
