### PR TITLE
node: change JWT error status to 401 Unauthorized #25629

### DIFF
--- a/node/jwt_handler.go
+++ b/node/jwt_handler.go
@@ -51,7 +51,7 @@ func (handler *jwtHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 		strToken = strings.TrimPrefix(auth, "Bearer ")
 	}
 	if len(strToken) == 0 {
-		http.Error(out, "missing token", http.StatusForbidden)
+		http.Error(out, "missing token", http.StatusUnauthorized)
 		return
 	}
 	// We explicitly set only HS256 allowed, and also disables the
@@ -63,17 +63,17 @@ func (handler *jwtHandler) ServeHTTP(out http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case err != nil:
-		http.Error(out, err.Error(), http.StatusForbidden)
+		http.Error(out, err.Error(), http.StatusUnauthorized)
 	case !token.Valid:
-		http.Error(out, "invalid token", http.StatusForbidden)
+		http.Error(out, "invalid token", http.StatusUnauthorized)
 	case !claims.VerifyExpiresAt(time.Now(), false): // optional
-		http.Error(out, "token is expired", http.StatusForbidden)
+		http.Error(out, "token is expired", http.StatusUnauthorized)
 	case claims.IssuedAt == nil:
-		http.Error(out, "missing issued-at", http.StatusForbidden)
+		http.Error(out, "missing issued-at", http.StatusUnauthorized)
 	case time.Since(claims.IssuedAt.Time) > jwtExpiryTimeout:
-		http.Error(out, "stale token", http.StatusForbidden)
+		http.Error(out, "stale token", http.StatusUnauthorized)
 	case time.Until(claims.IssuedAt.Time) > jwtExpiryTimeout:
-		http.Error(out, "future token", http.StatusForbidden)
+		http.Error(out, "future token", http.StatusUnauthorized)
 	default:
 		handler.next.ServeHTTP(out, r)
 	}

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -412,7 +412,7 @@ func TestJWT(t *testing.T) {
 
 		token = tokenFn()
 		resp := rpcRequest(t, htUrl, testMethod, "Authorization", token)
-		if resp.StatusCode != http.StatusForbidden {
+		if resp.StatusCode != http.StatusUnauthorized {
 			t.Errorf("tc %d-http, token '%v': expected not to allow,  got %v", i, token, resp.StatusCode)
 		}
 	}


### PR DESCRIPTION
# Proposed changes
`http.StatusUnauthorized` seems more suitable.

Use `401 Unauthorized` for JWT auth failures (missing/invalid/expired tokens) because it means "invalid credentials."  

`403 Forbidden` means "no permission," not auth failure. So `401` is more accurate.  

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
