### PR TITLE
core/vm: fix invalid merkle root caused by PR #627

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -366,7 +366,9 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	// This doesn't matter on Mainnet, where all empties are gone at the time of Byzantium,
 	// but is the correct thing to do and matters on other networks, in tests, and potential
 	// future scenarios
-	evm.StateDB.AddBalance(addr, big0)
+	if evm.ChainConfig().IsTIPXDCXCancellationFee(evm.Context.BlockNumber) {
+		evm.StateDB.AddBalance(addr, big0)
+	}
 
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {


### PR DESCRIPTION
# Proposed changes

This PR fixes the bug of `invalid merkle root` which is introduced in PR #627. When we sync with mainnet from genesis, the progress is stuck at block 34059322:

```text
ERROR[05-07|09:44:23.105] 
########## BAD BLOCK #########
Number: 34059322
Hash: 0x27cad6c05e6881288549064ee071941e99bbc235552cc93e6ad5896a387a90ff
Round: 0
Error: invalid merkle root (remote: f2a379074af51d343d0a6aa1cfd731e223284f409e6fb32e84cc95014c3be98b local: 519135ccfebd30abe494d636ce3e67b23010e7dc6189e32e71800734eb260a6c)
```

This bug only occurs when StaticCall is called in tx and the block number is less than TIPXDCXCancellationFee:

- mainnet: 38383838
- testnet: 23779191

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
