### PR TITLE
node: allow JWT pass by file only #24579

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -418,7 +418,7 @@ var (
 	}
 	JWTSecretFlag = &cli.StringFlag{
 		Name:     "authrpc-jwtsecret",
-		Usage:    "JWT secret (or path to a jwt secret) to use for authenticated RPC endpoints",
+		Usage:    "Path to a JWT secret to use for authenticated RPC endpoints",
 		Category: flags.APICategory,
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -354,17 +354,8 @@ func (n *Node) closeDataDir() {
 // or from the default location. If neither of those are present, it generates
 // a new secret and stores to the default location.
 func (n *Node) obtainJWTSecret(cliParam string) ([]byte, error) {
-	var fileName string
-	if len(cliParam) > 0 {
-		// If a plaintext secret was provided via cli flags, use that
-		jwtSecret := common.FromHex(cliParam)
-		if len(jwtSecret) == 32 && strings.HasPrefix(cliParam, "0x") {
-			log.Warn("Plaintext JWT secret provided, please consider passing via file")
-			return jwtSecret, nil
-		}
-		// path provided
-		fileName = cliParam
-	} else {
+	fileName := cliParam
+	if len(fileName) == 0 {
 		// no path provided, use default
 		fileName = n.ResolvePath(datadirJWTKey)
 	}


### PR DESCRIPTION
# Proposed changes
Removes the ability to pass a JWT secret in plaintext via CLI.This should help users not reveal their secret e.g. in bug reports

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
