### PR TITLE
trie: support empty range proof #21199

### DIFF
--- a/trie/proof.go
+++ b/trie/proof.go
@@ -393,7 +393,7 @@ func hasRightElement(node node, key []byte) bool {
 // (unless firstProof is an existent proof).
 //
 // Expect the normal case, this function can also be used to verify the following
-// range proofs(note this function doesn't accept zero element proof):
+// range proofs:
 //
 //   - All elements proof. In this case the left and right proof can be nil, but the
 //     range should be all the leaves in the trie.
@@ -401,14 +401,15 @@ func hasRightElement(node node, key []byte) bool {
 //   - One element proof. In this case no matter the left edge proof is a non-existent
 //     proof or not, we can always verify the correctness of the proof.
 //
+// - Zero element proof(left edge proof should be a non-existent proof). In this
+//   case if there are still some other leaves available on the right side, then
+//   an error will be returned.
+//
 // Except returning the error to indicate the proof is valid or not, the function will
 // also return a flag to indicate whether there exists more accounts/slots in the trie.
 func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, values [][]byte, firstProof ethdb.KeyValueReader, lastProof ethdb.KeyValueReader) (error, bool) {
 	if len(keys) != len(values) {
 		return fmt.Errorf("inconsistent proof data, keys: %d, values: %d", len(keys), len(values)), false
-	}
-	if len(keys) == 0 {
-		return errors.New("empty proof"), false
 	}
 	// Ensure the received batch is monotonic increasing.
 	for i := 0; i < len(keys)-1; i++ {
@@ -430,6 +431,18 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, keys [][]byte, valu
 			return fmt.Errorf("invalid proof, want hash %x, got %x", rootHash, emptytrie.Hash()), false
 		}
 		return nil, false // no more element.
+	}
+	// Special case, there is a provided left edge proof and zero key/value
+	// pairs, ensure there are no more accounts / slots in the trie.
+	if len(keys) == 0 {
+		root, val, err := proofToPath(rootHash, nil, firstKey, firstProof, true)
+		if err != nil {
+			return err, false
+		}
+		if val != nil || hasRightElement(root, firstKey) {
+			return errors.New("more entries available"), false
+		}
+		return nil, false
 	}
 	// Special case, there is only one element and left edge
 	// proof is an existent one.


### PR DESCRIPTION
# Proposed changes

This PR adds the support for empty range proof.

Ref: #21199

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
