### PR TITLE
make XDPoS_getBlockInfoByEpochNum work with v1 epoch number

### DIFF
--- a/consensus/XDPoS/utils/types.go
+++ b/consensus/XDPoS/utils/types.go
@@ -75,10 +75,11 @@ type PublicApiMissedRoundsMetadata struct {
 
 // Given an epoch number, this struct records the epoch switch block (first block in epoch) infos such as block number
 type EpochNumInfo struct {
-	EpochBlockHash        common.Hash `json:"hash"`
-	EpochRound            types.Round `json:"round"`
-	EpochFirstBlockNumber *big.Int    `json:"firstBlock"`
-	EpochLastBlockNumber  *big.Int    `json:"lastBlock"`
+	EpochBlockHash        common.Hash  `json:"hash"`
+	EpochRound            *types.Round `json:"round,omitempty"`
+	EpochFirstBlockNumber *big.Int     `json:"firstBlock"`
+	EpochLastBlockNumber  *big.Int     `json:"lastBlock"`
+	EpochConsensusVersion string       `json:"consensusVersion"`
 }
 
 type SigLRU = lru.Cache[common.Hash, common.Address]

--- a/consensus/tests/engine_v2_tests/api_test.go
+++ b/consensus/tests/engine_v2_tests/api_test.go
@@ -169,7 +169,6 @@ func TestGetEpochNumbersBetween(t *testing.T) {
 	assert.EqualError(t, err, "illegal begin block number")
 }
 func TestGetBlockByEpochNumber(t *testing.T) {
-	//todo
 	blockchain, _, currentBlock, signer, signFn := PrepareXDCTestBlockChainWithPenaltyForV2Engine(t, 1802, params.TestXDPoSMockChainConfig)
 
 	blockCoinBase := "0x111000000000000000000000000000000123"
@@ -201,19 +200,22 @@ func TestGetBlockByEpochNumber(t *testing.T) {
 	assert.Nil(t, err)
 
 	info, err := engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(0)
-	assert.NotNil(t, err)
-	assert.Nil(t, info)
+	assert.Equal(t, info.EpochConsensusVersion, "v1")
+	assert.Nil(t, err)
 
 	info, err = engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(1)
-	assert.Equal(t, info.EpochRound, types.Round(1))
+	assert.Equal(t, *info.EpochRound, types.Round(1))
+	assert.Equal(t, info.EpochConsensusVersion, "v2")
 	assert.Nil(t, err)
 
 	info, err = engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(2)
-	assert.Equal(t, info.EpochRound, types.Round(900))
+	assert.Equal(t, *info.EpochRound, types.Round(900))
+	assert.Equal(t, info.EpochConsensusVersion, "v2")
 	assert.Nil(t, err)
 
 	info, err = engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(3)
-	assert.Equal(t, info.EpochRound, types.Round(largeRound))
+	assert.Equal(t, *info.EpochRound, types.Round(largeRound))
+	assert.Equal(t, info.EpochConsensusVersion, "v2")
 	assert.Nil(t, err)
 
 	info, err = engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(4)
@@ -221,7 +223,8 @@ func TestGetBlockByEpochNumber(t *testing.T) {
 	assert.Nil(t, info)
 
 	info, err = engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(5)
-	assert.Equal(t, info.EpochRound, types.Round(largeRound2))
+	assert.Equal(t, *info.EpochRound, types.Round(largeRound2))
+	assert.Equal(t, info.EpochConsensusVersion, "v2")
 	assert.Nil(t, err)
 
 	info, err = engine.APIs(blockchain)[0].Service.(*XDPoS.API).GetBlockInfoByEpochNum(6)

--- a/consensus/tests/engine_v2_tests/api_test.go
+++ b/consensus/tests/engine_v2_tests/api_test.go
@@ -169,6 +169,7 @@ func TestGetEpochNumbersBetween(t *testing.T) {
 	assert.EqualError(t, err, "illegal begin block number")
 }
 func TestGetBlockByEpochNumber(t *testing.T) {
+	//todo
 	blockchain, _, currentBlock, signer, signFn := PrepareXDCTestBlockChainWithPenaltyForV2Engine(t, 1802, params.TestXDPoSMockChainConfig)
 
 	blockCoinBase := "0x111000000000000000000000000000000123"


### PR DESCRIPTION
# Proposed changes
Make XDPoS_getBlockInfoByEpochNum accept v1 epoch numbers. In the backend we can use math to calculate v1 epoch block numbers since each epoch is fixed to 900 blocks in v1 consensus.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
