### PR TITLE
ethstats: fix URL parser for '@' or ':' in node name/password #21640

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -150,21 +149,43 @@ func (w *connWrapper) Close() error {
 	return w.conn.Close()
 }
 
+// parseEthstatsURL parses the netstats connection url.
+// URL argument should be of the form <nodename:secret@host:port>
+// If non-erroring, the returned slice contains 3 elements: [nodename, pass, host]
+func parseEthstatsURL(url string) (parts []string, err error) {
+	err = fmt.Errorf("invalid netstats url: \"%s\", should be nodename:secret@host:port", url)
+
+	hostIndex := strings.LastIndex(url, "@")
+	if hostIndex == -1 || hostIndex == len(url)-1 {
+		return nil, err
+	}
+	preHost, host := url[:hostIndex], url[hostIndex+1:]
+
+	passIndex := strings.LastIndex(preHost, ":")
+	if passIndex == -1 {
+		return []string{preHost, "", host}, nil
+	}
+	nodename, pass := preHost[:passIndex], ""
+	if passIndex != len(preHost)-1 {
+		pass = preHost[passIndex+1:]
+	}
+
+	return []string{nodename, pass, host}, nil
+}
+
 // New returns a monitoring service ready for stats reporting.
 func New(node *node.Node, backend backend, engine consensus.Engine, url string) error {
-	// Parse the netstats connection url
-	re := regexp.MustCompile("([^:@]*)(:([^@]*))?@(.+)")
-	parts := re.FindStringSubmatch(url)
-	if len(parts) != 5 {
-		return fmt.Errorf("invalid netstats url: \"%s\", should be nodename:secret@host:port", url)
+	parts, err := parseEthstatsURL(url)
+	if err != nil {
+		return err
 	}
 	ethstats := &Service{
 		backend: backend,
 		engine:  engine,
 		server:  node.Server(),
-		node:    parts[1],
-		pass:    parts[3],
-		host:    parts[4],
+		node:    parts[0],
+		pass:    parts[1],
+		host:    parts[2],
 		pongCh:  make(chan struct{}),
 		histCh:  make(chan []uint64, 1),
 	}

--- a/ethstats/ethstats_test.go
+++ b/ethstats/ethstats_test.go
@@ -1,0 +1,67 @@
+package ethstats
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestParseEthstatsURL(t *testing.T) {
+	cases := []struct {
+		url              string
+		node, pass, host string
+	}{
+		{
+			url:  `"debug meowsbits":mypass@ws://mordor.dash.fault.dev:3000`,
+			node: "debug meowsbits", pass: "mypass", host: "ws://mordor.dash.fault.dev:3000",
+		},
+		{
+			url:  `"debug @meowsbits":mypass@ws://mordor.dash.fault.dev:3000`,
+			node: "debug @meowsbits", pass: "mypass", host: "ws://mordor.dash.fault.dev:3000",
+		},
+		{
+			url:  `"debug: @meowsbits":mypass@ws://mordor.dash.fault.dev:3000`,
+			node: "debug: @meowsbits", pass: "mypass", host: "ws://mordor.dash.fault.dev:3000",
+		},
+		{
+			url:  `name:@ws://mordor.dash.fault.dev:3000`,
+			node: "name", pass: "", host: "ws://mordor.dash.fault.dev:3000",
+		},
+		{
+			url:  `name@ws://mordor.dash.fault.dev:3000`,
+			node: "name", pass: "", host: "ws://mordor.dash.fault.dev:3000",
+		},
+		{
+			url:  `:mypass@ws://mordor.dash.fault.dev:3000`,
+			node: "", pass: "mypass", host: "ws://mordor.dash.fault.dev:3000",
+		},
+		{
+			url:  `:@ws://mordor.dash.fault.dev:3000`,
+			node: "", pass: "", host: "ws://mordor.dash.fault.dev:3000",
+		},
+	}
+
+	for i, c := range cases {
+		parts, err := parseEthstatsURL(c.url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		node, pass, host := parts[0], parts[1], parts[2]
+
+		// unquote because the value provided will be used as a CLI flag value, so unescaped quotes will be removed
+		nodeUnquote, err := strconv.Unquote(node)
+		if err == nil {
+			node = nodeUnquote
+		}
+
+		if node != c.node {
+			t.Errorf("case=%d mismatch node value, got: %v ,want: %v", i, node, c.node)
+		}
+		if pass != c.pass {
+			t.Errorf("case=%d mismatch pass value, got: %v ,want: %v", i, pass, c.pass)
+		}
+		if host != c.host {
+			t.Errorf("case=%d mismatch host value, got: %v ,want: %v", i, host, c.host)
+		}
+	}
+
+}


### PR DESCRIPTION
# Proposed changes

Ref: #21640

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
