### PR TITLE
eth/tracers: avoid panic in state test runner #30332

### DIFF
--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -267,7 +267,9 @@ func (t *jsTracer) OnTxEnd(receipt *types.Receipt, err error) {
 		}
 		return
 	}
-	t.ctx["gasUsed"] = t.vm.ToValue(receipt.GasUsed)
+	if receipt != nil {
+		t.ctx["gasUsed"] = t.vm.ToValue(receipt.GasUsed)
+	}
 }
 
 // onStart implements the Tracer interface to initialize the tracing operation.

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -268,7 +268,9 @@ func (l *StructLogger) OnTxEnd(receipt *types.Receipt, err error) {
 		}
 		return
 	}
-	l.usedGas = receipt.GasUsed
+	if receipt != nil {
+		l.usedGas = receipt.GasUsed
+	}
 }
 
 // StructLogs returns the captured log entries.

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -220,7 +220,9 @@ func (t *callTracer) OnTxEnd(receipt *types.Receipt, err error) {
 	if err != nil {
 		return
 	}
-	t.callstack[0].GasUsed = receipt.GasUsed
+	if receipt != nil {
+		t.callstack[0].GasUsed = receipt.GasUsed
+	}
 	if t.config.WithLog {
 		// Logs are not emitted when the call fails
 		clearFailedLogs(&t.callstack[0], false)


### PR DESCRIPTION
# Proposed changes

Ref: #30332

Make tracers more robust by handling `nil` receipt as input. Also pass in a receipt with gas used in the state test runner. Closes https://github.com/ethereum/go-ethereum/issues/30117.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
