### PR TITLE
all: remove deprecated uses of math.rand #26710

### DIFF
--- a/XDCxlending/lendingstate/lendingitem_test.go
+++ b/XDCxlending/lendingstate/lendingitem_test.go
@@ -3,7 +3,6 @@ package lendingstate
 import (
 	"fmt"
 	"math/big"
-	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -521,7 +520,6 @@ func sendOrder(nonce uint64) {
 		os.Exit(1)
 	}
 	defer rpcClient.Close()
-	rand.Seed(time.Now().UTC().UnixNano())
 	item := &LendingOrderMsg{
 		AccountNonce:    nonce,
 		Quantity:        EtherToWei(big.NewInt(1000)),

--- a/contracts/blocksigner/blocksigner_test.go
+++ b/contracts/blocksigner/blocksigner_test.go
@@ -81,7 +81,6 @@ func randomHash() common.Hash {
 	letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789"
 	var b common.Hash
 	for i := range b {
-		rand.Seed(time.Now().UnixNano())
 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
 	return b

--- a/contracts/utils_test.go
+++ b/contracts/utils_test.go
@@ -22,7 +22,6 @@ import (
 	"math/big"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind"
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind/backends"
@@ -121,7 +120,6 @@ func randomHash() common.Hash {
 	letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789"
 	var b common.Hash
 	for i := range b {
-		rand.Seed(time.Now().UnixNano())
 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
 	return b
@@ -170,7 +168,6 @@ func isArrayEqual(a [][]int64, b [][]int64) bool {
 func TestGenM2FromRandomize(t *testing.T) {
 	var a []int64
 	for i := 0; i <= 10; i++ {
-		rand.Seed(time.Now().UTC().UnixNano())
 		a = append(a, int64(rand.Intn(9999)))
 	}
 	b, err := GenM2FromRandomize(a, common.MaxMasternodes)

--- a/contracts/validator/validator_test.go
+++ b/contracts/validator/validator_test.go
@@ -131,7 +131,6 @@ func TestRewardBalance(t *testing.T) {
 	}
 	logCaps := make(map[int]*logCap)
 	for i := 0; i <= 10; i++ {
-		rand.Seed(time.Now().UTC().UnixNano())
 		randIndex := rand.Intn(len(accounts))
 		randCap := rand.Intn(10) * 1000
 		if randCap <= 0 {

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -100,7 +100,6 @@ func TestSubscribeDuplicateType(t *testing.T) {
 }
 
 func TestMuxConcurrent(t *testing.T) {
-	rand.Seed(time.Now().Unix())
 	mux := new(TypeMux)
 	defer mux.Stop()
 

--- a/p2p/discover/udp_test.go
+++ b/p2p/discover/udp_test.go
@@ -147,7 +147,6 @@ func TestUDP_responseTimeouts(t *testing.T) {
 	test := newUDPTest(t)
 	defer test.table.Close()
 
-	rand.Seed(time.Now().UnixNano())
 	randomDuration := func(max time.Duration) time.Duration {
 		return time.Duration(rand.Int63n(int64(max)))
 	}


### PR DESCRIPTION
# Proposed changes

The PR removes deprecated uses of math.rand for test files.

Ref: #26710

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
