### PR TITLE
fix: add default env to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:1.25-alpine AS builder
 
-ENV GODEBUG=randseednop=0
-
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /XDPoSChain
 RUN cd /XDPoSChain && make XDC
 
 FROM alpine:latest
+
+ENV GODEBUG=randseednop=0
 
 WORKDIR /XDPoSChain
 

--- a/Dockerfile.bootnode
+++ b/Dockerfile.bootnode
@@ -1,7 +1,5 @@
 FROM golang:1.25-alpine AS builder
 
-ENV GODEBUG=randseednop=0
-
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
 ADD . /XDPoSChain
@@ -12,6 +10,8 @@ RUN chmod +x /XDPoSChain/build/bin/bootnode
 FROM alpine:latest
 
 LABEL maintainer="etienne@XDPoSChain.com"
+
+ENV GODEBUG=randseednop=0
 
 WORKDIR /XDPoSChain
 

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,7 +1,5 @@
 FROM golang:1.25-alpine AS builder
 
-ENV GODEBUG=randseednop=0
-
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /XDPoSChain
@@ -11,6 +9,8 @@ RUN cd /XDPoSChain \
     && chmod +x /XDPoSChain/build/bin/XDC
 
 FROM alpine:latest
+
+ENV GODEBUG=randseednop=0
 
 WORKDIR /XDPoSChain
 

--- a/cicd/Dockerfile
+++ b/cicd/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.25-alpine AS builder
 
-ENV GODEBUG=randseednop=0
-
 RUN apk add make build-base linux-headers
 
 COPY . /builder
@@ -21,6 +19,8 @@ RUN cd /builder && make && mv /builder/build/bin/XDC /builder/build/bin/XDC-loca
 
 # The runtime image
 FROM alpine:3
+
+ENV GODEBUG=randseednop=0
 
 WORKDIR /work
 


### PR DESCRIPTION
# Proposed changes
ref: https://github.com/XinFinOrg/XDPoSChain/pull/1476
After upgrade golang to v1.25.1, we must set `GODEBUG="randseednop=0"`

Without the ENV the mainnet node runs into sync stuck error.
This PR adds the ENV by default to the runtime image for docker deployment


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [x] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
