### PR TITLE
accounts/keystore: use ticker to avoid timer allocations #32732

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -195,23 +195,17 @@ func (ks *KeyStore) Subscribe(sink chan<- accounts.WalletEvent) event.Subscripti
 // forces a manual refresh (only triggers for systems where the filesystem notifier
 // is not running).
 func (ks *KeyStore) updater() {
-	// Create a timer for the wallet refresh cycle
-	timer := time.NewTimer(walletRefreshCycle)
-	defer timer.Stop()
+	ticker := time.NewTicker(walletRefreshCycle)
+	defer ticker.Stop()
 
 	for {
 		// Wait for an account update or a refresh timeout
 		select {
 		case <-ks.changes:
-			// Stop the timer if we receive an account update before the timer fires
-			if !timer.Stop() {
-				<-timer.C
-			}
-		case <-timer.C:
+		case <-ticker.C:
 		}
 		// Run the wallet refresher
 		ks.refreshWallets()
-
 		// If all our subscribers left, stop the updater
 		ks.mu.Lock()
 		if ks.updateScope.Count() == 0 {
@@ -220,9 +214,6 @@ func (ks *KeyStore) updater() {
 			return
 		}
 		ks.mu.Unlock()
-
-		// Reset the timer for the next cycle
-		timer.Reset(walletRefreshCycle)
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

accounts/keystore: use ticker to avoid timer allocations #32732

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
