### PR TITLE
separate fullVerifies array into v1fullVerifies and v2fullVerifies

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -203,27 +203,33 @@ func (x *XDPoS) VerifyHeader(chain consensus.ChainReader, header *types.Header, 
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
 func (x *XDPoS) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, fullVerifies []bool) (chan<- struct{}, <-chan error) {
+
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 
 	// Split the headers list into v1 and v2 buckets
 	var v1headers []*types.Header
 	var v2headers []*types.Header
+	var v1fullVerifies []bool
+	var v2fullVerifies []bool
 
-	for _, header := range headers {
+	for i, header := range headers {
 		switch x.config.BlockConsensusVersion(header.Number) {
 		case params.ConsensusEngineVersion2:
 			v2headers = append(v2headers, header)
+			v2fullVerifies = append(v2fullVerifies, fullVerifies[i])
 		default: // Default "v1"
 			v1headers = append(v1headers, header)
+			v1fullVerifies = append(v1fullVerifies, fullVerifies[i])
 		}
 	}
 
+
 	if v1headers != nil {
-		x.EngineV1.VerifyHeaders(chain, v1headers, fullVerifies, abort, results)
+		x.EngineV1.VerifyHeaders(chain, v1headers, v1fullVerifies, abort, results)
 	}
 	if v2headers != nil {
-		x.EngineV2.VerifyHeaders(chain, v2headers, fullVerifies, abort, results)
+		x.EngineV2.VerifyHeaders(chain, v2headers, v2fullVerifies, abort, results)
 	}
 
 	return abort, results


### PR DESCRIPTION
# Proposed changes
separate fullVerifies array into v1fullVerifies and v2fullVerifies
ref audit ticket: XFN-06

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
