### PR TITLE
miner: fix deep copy in copyReceipts, close XFN-49

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -519,9 +519,35 @@ func (w *worker) push(work *Work) {
 // copyReceipts makes a deep copy of the given receipts.
 func copyReceipts(receipts []*types.Receipt) []*types.Receipt {
 	result := make([]*types.Receipt, len(receipts))
-	for i, l := range receipts {
-		cpy := *l
-		result[i] = &cpy
+	for i, receipt := range receipts {
+		cpyReceipt := *receipt
+		if len(receipt.PostState) > 0 {
+			cpyReceipt.PostState = make([]byte, len(receipt.PostState))
+			copy(cpyReceipt.PostState, receipt.PostState)
+		}
+		if cpyReceipt.EffectiveGasPrice = new(big.Int); receipt.EffectiveGasPrice != nil {
+			cpyReceipt.EffectiveGasPrice.Set(receipt.EffectiveGasPrice)
+		}
+		if cpyReceipt.BlockNumber = new(big.Int); receipt.BlockNumber != nil {
+			cpyReceipt.BlockNumber.Set(receipt.BlockNumber)
+		}
+		// deep copy logs
+		if len(receipt.Logs) > 0 {
+			cpyReceipt.Logs = make([]*types.Log, len(receipt.Logs))
+			for i, log := range receipt.Logs {
+				cpyLog := *log
+				if len(log.Topics) > 0 {
+					cpyLog.Topics = make([]common.Hash, len(log.Topics))
+					copy(cpyLog.Topics, log.Topics)
+				}
+				if len(log.Data) > 0 {
+					cpyLog.Data = make([]byte, len(log.Data))
+					copy(cpyLog.Data, log.Data)
+				}
+				cpyReceipt.Logs[i] = &cpyLog
+			}
+		}
+		result[i] = &cpyReceipt
 	}
 	return result
 }


### PR DESCRIPTION
# Proposed changes

fix audit issue XFN-49: `copyReceipts` Performs A Shallow Copy Despite “Deep Copy” Comments

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Regular KTLO or any of the maintaince work. e.g code style
- [ ] CICD Improvement

## Impacted Components
Which part of the codebase this PR will touch base on,

_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist
_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
