### PR TITLE
feat(consensus): add RPC endpoint to query signing tx count by epoch

### DIFF
--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -769,3 +769,75 @@ func (api *API) GetBlockInfoByEpochNum(epochNumber uint64) (*utils.EpochNumInfo,
 	}
 	return api.GetBlockInfoByV2EpochNum(epochNumber)
 }
+
+// GetSigningTxCountByEpoch returns the signing transaction count for ALL masternodes
+// (including non-active ones) in the epoch that ends at epochBlockNum.
+// epochBlockNum must be an epoch-switch block number.
+func (api *API) GetSigningTxCountByEpoch(epochBlockNum rpc.BlockNumber) (map[common.Address]uint64, error) {
+	header := api.chain.GetHeaderByNumber(uint64(epochBlockNum.Int64()))
+	if header == nil {
+		return nil, fmt.Errorf("block %d not found", epochBlockNum)
+	}
+
+	isEpochSwitch, _, err := api.XDPoS.IsEpochSwitch(header)
+	if err != nil {
+		return nil, err
+	}
+	if !isEpochSwitch {
+		return nil, fmt.Errorf("block %d is not an epoch switch block", epochBlockNum)
+	}
+
+	// Walk backwards from epochBlockNum-1 to the previous epoch switch block,
+	// collecting signing txs from every block.
+	mapBlkHash := map[uint64]common.Hash{}
+	// sigData maps blockHash -> list of signers who signed for that block
+	sigData := make(map[common.Hash][]common.Address)
+
+	h := header
+	for i := header.Number.Uint64() - 1; ; i-- {
+		parentHash := h.ParentHash
+		h = api.chain.GetHeader(parentHash, i)
+		if h == nil {
+			return nil, fmt.Errorf("failed to get header at number %d hash %s", i, parentHash.Hex())
+		}
+
+		mapBlkHash[i] = h.Hash()
+
+		signingTxs, ok := api.XDPoS.GetCachedSigningTxs(h.Hash())
+		if !ok {
+			block := api.chain.GetBlock(h.Hash(), i)
+			if block != nil {
+				signingTxs = api.XDPoS.CacheSigningTxs(h.Hash(), block.Transactions())
+			}
+		}
+		for _, tx := range signingTxs {
+			blkHash := common.BytesToHash(tx.Data()[len(tx.Data())-32:])
+			from := *tx.From()
+			sigData[blkHash] = append(sigData[blkHash], from)
+		}
+
+		prevIsEpochSwitch, _, err := api.XDPoS.IsEpochSwitch(h)
+		if err != nil {
+			return nil, err
+		}
+		if prevIsEpochSwitch || i == 0 {
+			break
+		}
+	}
+
+	// Count signings: for each block at MergeSignRange boundary, tally unique signers.
+	result := make(map[common.Address]uint64)
+	for blockNum, blkHash := range mapBlkHash {
+		if blockNum%common.MergeSignRange != 0 {
+			continue
+		}
+		seen := make(map[common.Address]bool)
+		for _, addr := range sigData[blkHash] {
+			if !seen[addr] {
+				seen[addr] = true
+				result[addr]++
+			}
+		}
+	}
+	return result, nil
+}

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -776,7 +776,10 @@ func (api *API) GetBlockInfoByEpochNum(epochNumber uint64) (*utils.EpochNumInfo,
 // epochBlockNum-1 backwards to the previous epoch-switch block (inclusive).
 // epochBlockNum must be an epoch-switch block number that marks the start of an epoch.
 func (api *API) GetSigningTxCountByEpoch(epochBlockNum rpc.BlockNumber) (map[common.Address]uint64, error) {
-	header := api.chain.GetHeaderByNumber(uint64(epochBlockNum.Int64()))
+	header, err := api.getHeaderFromApiBlockNum(epochBlockNum)
+	if err != nil {
+		return nil, err
+	}
 	if header == nil {
 		return nil, fmt.Errorf("block %d not found", epochBlockNum)
 	}

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -776,7 +776,7 @@ func (api *API) GetBlockInfoByEpochNum(epochNumber uint64) (*utils.EpochNumInfo,
 // epochBlockNum-1 backwards to the previous epoch-switch block (inclusive).
 // epochBlockNum must be an epoch-switch block number that marks the start of an epoch.
 func (api *API) GetSigningTxCountByEpoch(epochBlockNum rpc.BlockNumber) (map[common.Address]uint64, error) {
-	header, err := api.getHeaderFromApiBlockNum(epochBlockNum)
+	header, err := api.getHeaderFromApiBlockNum(&epochBlockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -811,9 +811,10 @@ func (api *API) GetSigningTxCountByEpoch(epochBlockNum rpc.BlockNumber) (map[com
 		signingTxs, ok := api.XDPoS.GetCachedSigningTxs(h.Hash())
 		if !ok {
 			block := api.chain.GetBlock(h.Hash(), i)
-			if block != nil {
-				signingTxs = api.XDPoS.CacheNoneTIPSigningTxs(h.Hash(), block.Transactions())
+			if block == nil {
+				return nil, fmt.Errorf("failed to get block at number %d hash %s", i, h.Hash().Hex())
 			}
+			signingTxs = api.XDPoS.CacheSigningTxs(h.Hash(), block.Transactions())
 		}
 		for _, tx := range signingTxs {
 			blkHash := common.BytesToHash(tx.Data()[len(tx.Data())-32:])

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -771,8 +771,10 @@ func (api *API) GetBlockInfoByEpochNum(epochNumber uint64) (*utils.EpochNumInfo,
 }
 
 // GetSigningTxCountByEpoch returns the signing transaction count for ALL masternodes
-// (including non-active ones) in the epoch that ends at epochBlockNum.
-// epochBlockNum must be an epoch-switch block number.
+// (including non-active ones) in the epoch that immediately precedes the epoch
+// that starts at epochBlockNum. In other words, it walks blocks from
+// epochBlockNum-1 backwards to the previous epoch-switch block (inclusive).
+// epochBlockNum must be an epoch-switch block number that marks the start of an epoch.
 func (api *API) GetSigningTxCountByEpoch(epochBlockNum rpc.BlockNumber) (map[common.Address]uint64, error) {
 	header := api.chain.GetHeaderByNumber(uint64(epochBlockNum.Int64()))
 	if header == nil {

--- a/consensus/XDPoS/api.go
+++ b/consensus/XDPoS/api.go
@@ -812,7 +812,7 @@ func (api *API) GetSigningTxCountByEpoch(epochBlockNum rpc.BlockNumber) (map[com
 		if !ok {
 			block := api.chain.GetBlock(h.Hash(), i)
 			if block != nil {
-				signingTxs = api.XDPoS.CacheSigningTxs(h.Hash(), block.Transactions())
+				signingTxs = api.XDPoS.CacheNoneTIPSigningTxs(h.Hash(), block.Transactions())
 			}
 		}
 		for _, tx := range signingTxs {

--- a/consensus/XDPoS/engines/engine_v2/timeout.go
+++ b/consensus/XDPoS/engines/engine_v2/timeout.go
@@ -124,7 +124,7 @@ func (x *XDPoS_v2) getTCEpochInfo(chain consensus.ChainReader, timeoutRound type
 		Round:  epochRound,
 		Number: epochSwitchInfo.EpochSwitchBlockInfo.Number,
 	}
-	log.Info("[getTCEpochInfo] Init epochInfo", "number", epochBlockInfo.Number, "round", epochRound, "tcRound", timeoutRound, "tcEpoch", tempTCEpoch)
+	log.Debug("[getTCEpochInfo] Init epochInfo", "number", epochBlockInfo.Number, "round", epochRound, "tcRound", timeoutRound, "tcEpoch", tempTCEpoch)
 	for epochBlockInfo.Round > timeoutRound && tempTCEpoch > 0 {
 		tempTCEpoch--
 		epochBlockInfo, err = x.GetBlockByEpochNumber(chain, tempTCEpoch)
@@ -135,7 +135,7 @@ func (x *XDPoS_v2) getTCEpochInfo(chain consensus.ChainReader, timeoutRound type
 		log.Debug("[getTCEpochInfo] Loop to get right epochInfo", "number", epochBlockInfo.Number, "round", epochBlockInfo.Round, "tcRound", timeoutRound, "tcEpoch", tempTCEpoch)
 	}
 	tcEpoch := tempTCEpoch
-	log.Info("[getTCEpochInfo] Final TC epochInfo", "number", epochBlockInfo.Number, "round", epochBlockInfo.Round, "tcRound", timeoutRound, "tcEpoch", tcEpoch)
+	log.Debug("[getTCEpochInfo] Final TC epochInfo", "number", epochBlockInfo.Number, "round", epochBlockInfo.Round, "tcRound", timeoutRound, "tcEpoch", tcEpoch)
 
 	epochInfo, err := x.getEpochSwitchInfo(chain, nil, epochBlockInfo.Hash)
 	if err != nil {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -142,6 +142,12 @@ web3._extend({
 			params: 3,
 			inputFormatter: [null, web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'getSigningTxCountByEpoch',
+			call: 'XDPoS_getSigningTxCountByEpoch',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
# Proposed changes

Add new GetSigningTxCountByEpoch API method that returns signing transaction 
counts for all masternodes (including non-active ones) within a specified epoch. 
The method validates that the provided block number is an epoch-switch block, 
then walks backwards through the epoch collecting signing transactions at 
MergeSignRange boundaries.

Also reduces log verbosity by changing two timeout-related log statements from 
Info to Debug level in the v2 consensus engine.

## Output:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "0x14f375e18a878abb4b713328e392abce98f07bfd": 7,
        "0x311bdf9066246e68559816e7f636435867f824ef": 60,
        "0x442a44a6fc20f5b8dfa8b304d7137581f7e6bef3": 60,
        "0x47318441696e9ae962633c16e04d53935272639d": 60,
        "0x537fc89618edae86950e12687a612e15c4786b84": 60,
        "0x73898cc3c5beca5841306b26fdb4e30411392a6a": 60,
        "0x74826141342a4dc33a1045cefa4182b6212ec031": 60,
        "0x7bc30fbeb7208192d1474b5f87ffbc056de43c11": 60
    }
}
        
```

## Changes:
- Add GetSigningTxCountByEpoch API method to consensus/XDPoS/api.go
- Expose method via web3 RPC extension in internal/web3ext/web3ext.go
- Demote getTCEpochInfo logs from Info to Debug level

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [x] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
