### PR TITLE
fix(eth): make paired peer unregister instance-aware

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -339,10 +339,10 @@ func (d *Downloader) Synchronising() bool {
 
 // RegisterPeer injects a new download peer into the set of block source to be
 // used for fetching hashes and blocks from.
-func (d *Downloader) RegisterPeer(id string, version int, peer Peer) error {
+func (d *Downloader) RegisterPeer(id string, version int, peer Peer, drop peerInstanceDropFn) error {
 	logger := log.New("peer", id)
 	logger.Trace("Registering sync peer")
-	if err := d.peers.Register(newPeerConnection(id, version, peer, logger)); err != nil {
+	if err := d.peers.Register(newPeerConnection(id, version, peer, logger, drop)); err != nil {
 		logger.Error("Failed to register sync peer", "err", err)
 		return err
 	}
@@ -352,8 +352,8 @@ func (d *Downloader) RegisterPeer(id string, version int, peer Peer) error {
 }
 
 // RegisterLightPeer injects a light client peer, wrapping it so it appears as a regular peer.
-func (d *Downloader) RegisterLightPeer(id string, version int, peer LightPeer) error {
-	return d.RegisterPeer(id, version, &lightPeerWrapper{peer})
+func (d *Downloader) RegisterLightPeer(id string, version int, peer LightPeer, drop peerInstanceDropFn) error {
+	return d.RegisterPeer(id, version, &lightPeerWrapper{peer}, drop)
 }
 
 // UnregisterPeer remove a peer from the known list, preventing any action from
@@ -375,6 +375,7 @@ func (d *Downloader) UnregisterPeer(id string) error {
 // Synchronise tries to sync up our local block chain with a remote peer, both
 // adding various sanity checks as well as wrapping it with various log entries.
 func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode SyncMode) error {
+	syncPeer := d.peers.Peer(id)
 	err := d.synchronise(id, head, td, mode)
 
 	switch err {
@@ -391,7 +392,9 @@ func (d *Downloader) Synchronise(id string, head common.Hash, td *big.Int, mode 
 			// Timeouts can occur if e.g. compaction hits at the wrong time, and can be ignored
 			log.Warn("Downloader wants to drop peer, but peerdrop-function is not set", "peer", id)
 		} else {
-			d.dropPeer(id)
+			if syncPeer != nil {
+				syncPeer.dropPeer()
+			}
 		}
 		return err
 	}
@@ -1052,7 +1055,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 			// Header retrieval timed out, consider the peer bad and drop
 			p.log.Debug("Header request timed out", "elapsed", ttl)
 			headerTimeoutMeter.Mark(1)
-			d.dropPeer(p.id)
+			p.dropPeer()
 
 			// Finish the sync gracefully instead of dumping the gathered data though
 			for _, ch := range []chan bool{d.bodyWakeCh, d.receiptWakeCh} {
@@ -1276,7 +1279,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 							// Timeouts can occur if e.g. compaction hits at the wrong time, and can be ignored
 							peer.log.Warn("Downloader wants to drop peer, but peerdrop-function is not set", "peer", pid)
 						} else {
-							d.dropPeer(pid)
+							peer.dropPeer()
 
 							// If this peer was the master peer, abort sync immediately
 							d.cancelLock.RLock()

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -331,7 +331,7 @@ func (dl *downloadTester) newPeer(id string, version int, chain *testChain) erro
 
 	peer := &downloadTesterPeer{dl: dl, id: id, chain: chain}
 	dl.peers[id] = peer
-	return dl.downloader.RegisterPeer(id, version, peer)
+	return dl.downloader.RegisterPeer(id, version, peer, func() { dl.dropPeer(id) })
 }
 
 // dropPeer simulates a hard peer removal from the connection pool.
@@ -1335,6 +1335,44 @@ func TestSyncBatchNoAncestorErrKeepPeer(t *testing.T) {
 				t.Fatalf("peer should not be dropped on successful sync")
 			}
 		})
+	}
+}
+
+func TestPeerConnectionDropUsesBoundInstance(t *testing.T) {
+	tester := newTester()
+	defer tester.terminate()
+
+	const id = "peer"
+	stalePeer := &downloadTesterPeer{dl: tester, id: id, chain: testChainBase}
+	replacementPeer := &downloadTesterPeer{dl: tester, id: id, chain: testChainBase}
+
+	staleDropped := false
+	replacementDropped := false
+
+	if err := tester.downloader.RegisterPeer(id, 64, stalePeer, func() { staleDropped = true }); err != nil {
+		t.Fatalf("register stale peer: %v", err)
+	}
+	staleConn := tester.downloader.peers.Peer(id)
+	if staleConn == nil {
+		t.Fatal("missing stale peer connection")
+	}
+	if err := tester.downloader.UnregisterPeer(id); err != nil {
+		t.Fatalf("unregister stale peer: %v", err)
+	}
+	if err := tester.downloader.RegisterPeer(id, 64, replacementPeer, func() { replacementDropped = true }); err != nil {
+		t.Fatalf("register replacement peer: %v", err)
+	}
+
+	staleConn.dropPeer()
+
+	if !staleDropped {
+		t.Fatal("stale peer dropper was not invoked")
+	}
+	if replacementDropped {
+		t.Fatal("replacement peer dropper should not be invoked by stale connection")
+	}
+	if got := tester.downloader.peers.Peer(id); got == nil || got.peer != replacementPeer {
+		t.Fatal("replacement peer connection should remain registered")
 	}
 }
 

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -69,6 +69,7 @@ type peerConnection struct {
 	lacking map[common.Hash]struct{} // Set of hashes not to request (didn't have previously)
 
 	peer Peer
+	drop peerInstanceDropFn
 
 	version int        // Eth protocol version number to switch strategies
 	log     log.Logger // Contextual logger to add extra infos to peer logs
@@ -113,13 +114,20 @@ func (w *lightPeerWrapper) RequestNodeData([]common.Hash) error {
 }
 
 // newPeerConnection creates a new downloader peer.
-func newPeerConnection(id string, version int, peer Peer, logger log.Logger) *peerConnection {
+func newPeerConnection(id string, version int, peer Peer, logger log.Logger, drop peerInstanceDropFn) *peerConnection {
 	return &peerConnection{
 		id:      id,
 		lacking: make(map[common.Hash]struct{}),
 		peer:    peer,
+		drop:    drop,
 		version: version,
 		log:     logger,
+	}
+}
+
+func (p *peerConnection) dropPeer() {
+	if p.drop != nil {
+		p.drop()
 	}
 }
 

--- a/eth/downloader/statesync.go
+++ b/eth/downloader/statesync.go
@@ -384,7 +384,7 @@ func (s *stateSync) loop() (err error) {
 					// Timeouts can occur if e.g. compaction hits at the wrong time, and can be ignored
 					req.peer.log.Warn("Downloader wants to drop peer, but peerdrop-function is not set", "peer", req.peer.id)
 				} else {
-					s.d.dropPeer(req.peer.id)
+					req.peer.dropPeer()
 
 					// If this peer was the master peer, abort sync immediately
 					s.d.cancelLock.RLock()

--- a/eth/downloader/types.go
+++ b/eth/downloader/types.go
@@ -25,6 +25,9 @@ import (
 // peerDropFn is a callback type for dropping a peer detected as malicious.
 type peerDropFn func(id string)
 
+// peerInstanceDropFn drops the specific peer instance that triggered a failure.
+type peerInstanceDropFn func()
+
 // dataPack is a data message returned by a peer for some query.
 type dataPack interface {
 	PeerId() string

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -74,6 +74,9 @@ type blockPrepareFn func(block *types.Block) error
 // peerDropFn is a callback type for dropping a peer detected as malicious.
 type peerDropFn func(id string)
 
+// peerInstanceDropFn drops the specific peer instance that misbehaved.
+type peerInstanceDropFn func()
+
 // announce is the hash notification of the availability of a new block in the
 // network.
 type announce struct {
@@ -82,7 +85,8 @@ type announce struct {
 	header *types.Header // Header of the block partially reassembled (new protocol)
 	time   time.Time     // Timestamp of the announcement
 
-	origin string // Identifier of the peer originating the notification
+	origin   string             // Identifier of the peer originating the notification
+	dropPeer peerInstanceDropFn // Instance-aware dropper bound at announcement time
 
 	fetchHeader headerRequesterFn // Fetcher function to retrieve the header of an announced block
 	fetchBodies bodyRequesterFn   // Fetcher function to retrieve the body of an announced block
@@ -106,8 +110,9 @@ type bodyFilterTask struct {
 
 // inject represents a schedules import operation.
 type inject struct {
-	origin string
-	block  *types.Block
+	origin   string
+	block    *types.Block
+	dropPeer peerInstanceDropFn
 }
 
 // Fetcher is responsible for accumulating block announcements from various peers
@@ -199,13 +204,15 @@ func (f *Fetcher) Stop() {
 
 // Notify announces the fetcher of the potential availability of a new block in
 // the network.
+
 func (f *Fetcher) Notify(peer string, hash common.Hash, number uint64, time time.Time,
-	headerFetcher headerRequesterFn, bodyFetcher bodyRequesterFn) error {
+	headerFetcher headerRequesterFn, bodyFetcher bodyRequesterFn, drop peerInstanceDropFn) error {
 	block := &announce{
 		hash:        hash,
 		number:      number,
 		time:        time,
 		origin:      peer,
+		dropPeer:    drop,
 		fetchHeader: headerFetcher,
 		fetchBodies: bodyFetcher,
 	}
@@ -218,10 +225,12 @@ func (f *Fetcher) Notify(peer string, hash common.Hash, number uint64, time time
 }
 
 // Enqueue tries to fill gaps the fetcher's future import queue.
-func (f *Fetcher) Enqueue(peer string, block *types.Block) error {
+
+func (f *Fetcher) Enqueue(peer string, block *types.Block, drop peerInstanceDropFn) error {
 	op := &inject{
-		origin: peer,
-		block:  block,
+		origin:   peer,
+		block:    block,
+		dropPeer: drop,
 	}
 	select {
 	case f.inject <- op:
@@ -323,7 +332,7 @@ func (f *Fetcher) loop() {
 				f.forgetBlock(hash)
 				continue
 			}
-			f.insert(op.origin, op.block)
+			f.insert(op.origin, op.block, op.dropPeer)
 		}
 		// Wait for an outside event to occur
 		select {
@@ -368,7 +377,7 @@ func (f *Fetcher) loop() {
 		case op := <-f.inject:
 			// A direct block insertion was requested, try and fill any pending gaps
 			propBroadcastInMeter.Mark(1)
-			f.enqueue(op.origin, op.block)
+			f.enqueue(op.origin, op.block, op.dropPeer)
 
 		case hash := <-f.done:
 			// A pending import finished, remove all traces of the notification
@@ -463,7 +472,9 @@ func (f *Fetcher) loop() {
 					// If the delivered header does not match the promised number, drop the announcer
 					if header.Number.Uint64() != announce.number {
 						log.Trace("Invalid block number fetched", "peer", announce.origin, "hash", header.Hash(), "announced", announce.number, "provided", header.Number)
-						f.dropPeer(announce.origin)
+						if announce.dropPeer != nil {
+							announce.dropPeer()
+						}
 						f.forgetHash(hash)
 						continue
 					}
@@ -514,7 +525,7 @@ func (f *Fetcher) loop() {
 			// Schedule the header-only blocks for import
 			for _, block := range complete {
 				if announce := f.completing[block.Hash()]; announce != nil {
-					f.enqueue(announce.origin, block)
+					f.enqueue(announce.origin, block, announce.dropPeer)
 				}
 			}
 
@@ -580,7 +591,7 @@ func (f *Fetcher) loop() {
 			// Schedule the retrieved blocks for ordered import
 			for _, block := range blocks {
 				if announce := f.completing[block.Hash()]; announce != nil {
-					f.enqueue(announce.origin, block)
+					f.enqueue(announce.origin, block, announce.dropPeer)
 				}
 			}
 		}
@@ -621,7 +632,7 @@ func (f *Fetcher) rescheduleComplete(complete *time.Timer) {
 
 // enqueue schedules a new future import operation, if the block to be imported
 // has not yet been seen.
-func (f *Fetcher) enqueue(peer string, block *types.Block) {
+func (f *Fetcher) enqueue(peer string, block *types.Block, drop peerInstanceDropFn) {
 	hash := block.Hash()
 	if f.knowns.Contains(hash) {
 		log.Trace("Discarded propagated block, known block", "peer", peer, "number", block.Number(), "hash", hash, "limit", blockLimit)
@@ -645,8 +656,9 @@ func (f *Fetcher) enqueue(peer string, block *types.Block) {
 	// Schedule the block for future importing
 	if _, ok := f.queued[hash]; !ok {
 		op := &inject{
-			origin: peer,
-			block:  block,
+			origin:   peer,
+			block:    block,
+			dropPeer: drop,
 		}
 		f.queues[peer] = count
 		f.queued[hash] = op
@@ -662,7 +674,7 @@ func (f *Fetcher) enqueue(peer string, block *types.Block) {
 // insert spawns a new goroutine to run a block insertion into the chain. If the
 // block's number is at the same height as the current import phase, it updates
 // the phase states accordingly.
-func (f *Fetcher) insert(peer string, block *types.Block) {
+func (f *Fetcher) insert(peer string, block *types.Block, drop peerInstanceDropFn) {
 	hash := block.Hash()
 
 	// Run the import on a new thread
@@ -721,7 +733,9 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 		default:
 			// Something went very wrong, drop the peer
 			log.Warn("Propagated block verification failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
-			f.dropPeer(peer)
+			if drop != nil {
+				drop()
+			}
 			return
 		}
 		// Run the actual import and log any issues

--- a/eth/fetcher/fetcher_test.go
+++ b/eth/fetcher/fetcher_test.go
@@ -349,7 +349,7 @@ func testSequentialAnnouncements(t *testing.T, protocol int) {
 	}
 
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)
@@ -391,9 +391,9 @@ func testConcurrentAnnouncements(t *testing.T, protocol int) {
 	}
 
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("first", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), firstHeaderWrapper, firstBodyFetcher)
-		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout+time.Millisecond), secondHeaderWrapper, secondBodyFetcher)
-		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout-time.Millisecond), secondHeaderWrapper, secondBodyFetcher)
+		tester.fetcher.Notify("first", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), firstHeaderWrapper, firstBodyFetcher, nil)
+		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout+time.Millisecond), secondHeaderWrapper, secondBodyFetcher, nil)
+		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout-time.Millisecond), secondHeaderWrapper, secondBodyFetcher, nil)
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)
@@ -431,7 +431,7 @@ func testOverlappingAnnouncements(t *testing.T, protocol int) {
 	}
 
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 		select {
 		case <-imported:
 		case <-time.After(time.Second):
@@ -470,7 +470,7 @@ func testPendingDeduplication(t *testing.T, protocol int) {
 	}
 	// Announce the same block many times until it's fetched (wait for any pending ops)
 	for tester.getBlock(hashes[0]) == nil {
-		tester.fetcher.Notify("repeater", hashes[0], 1, time.Now().Add(-arriveTimeout), headerWrapper, bodyFetcher)
+		tester.fetcher.Notify("repeater", hashes[0], 1, time.Now().Add(-arriveTimeout), headerWrapper, bodyFetcher, nil)
 		time.Sleep(time.Millisecond)
 	}
 	time.Sleep(delay)
@@ -509,12 +509,12 @@ func testRandomArrivalImport(t *testing.T, protocol int) {
 
 	for i := len(hashes) - 1; i >= 0; i-- {
 		if i != skip {
-			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 			time.Sleep(time.Millisecond)
 		}
 	}
 	// Finally announce the skipped entry and check full import
-	tester.fetcher.Notify("valid", hashes[skip], uint64(len(hashes)-skip-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("valid", hashes[skip], uint64(len(hashes)-skip-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 	verifyImportCount(t, imported, len(hashes)-1)
 }
 
@@ -543,12 +543,12 @@ func testQueueGapFill(t *testing.T, protocol int) {
 
 	for i := len(hashes) - 1; i >= 0; i-- {
 		if i != skip {
-			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 			time.Sleep(time.Millisecond)
 		}
 	}
 	// Fill the missing block directly as if propagated
-	tester.fetcher.Enqueue("valid", blocks[hashes[skip]])
+	tester.fetcher.Enqueue("valid", blocks[hashes[skip]], nil)
 	verifyImportCount(t, imported, len(hashes)-1)
 }
 
@@ -582,15 +582,15 @@ func testImportDeduplication(t *testing.T, protocol int) {
 	}
 
 	// Announce the duplicating block, wait for retrieval, and also propagate directly
-	tester.fetcher.Notify("valid", hashes[0], 1, time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("valid", hashes[0], 1, time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 	<-fetching
 
-	tester.fetcher.Enqueue("valid", blocks[hashes[0]])
-	tester.fetcher.Enqueue("valid", blocks[hashes[0]])
-	tester.fetcher.Enqueue("valid", blocks[hashes[0]])
+	tester.fetcher.Enqueue("valid", blocks[hashes[0]], nil)
+	tester.fetcher.Enqueue("valid", blocks[hashes[0]], nil)
+	tester.fetcher.Enqueue("valid", blocks[hashes[0]], nil)
 
 	// Fill the missing block directly as if propagated, and check import uniqueness
-	tester.fetcher.Enqueue("valid", blocks[hashes[1]])
+	tester.fetcher.Enqueue("valid", blocks[hashes[1]], nil)
 	verifyImportCount(t, imported, 2)
 
 	if counter != 2 {
@@ -616,13 +616,13 @@ func TestDistantPropagationDiscarding(t *testing.T) {
 	tester.lock.Unlock()
 
 	// Ensure that a block with a lower number than the threshold is discarded
-	tester.fetcher.Enqueue("lower", blocks[hashes[low]])
+	tester.fetcher.Enqueue("lower", blocks[hashes[low]], nil)
 	time.Sleep(10 * time.Millisecond)
 	if !tester.fetcher.queue.Empty() {
 		t.Fatalf("fetcher queued stale block")
 	}
 	// Ensure that a block with a higher number than the threshold is discarded
-	tester.fetcher.Enqueue("higher", blocks[hashes[high]])
+	tester.fetcher.Enqueue("higher", blocks[hashes[high]], nil)
 	time.Sleep(10 * time.Millisecond)
 	if !tester.fetcher.queue.Empty() {
 		t.Fatalf("fetcher queued future block")
@@ -658,14 +658,14 @@ func testDistantAnnouncementDiscarding(t *testing.T, protocol int) {
 	tester.fetcher.fetchingHook = func(hashes []common.Hash) { fetching <- struct{}{} }
 
 	// Ensure that a block with a lower number than the threshold is discarded
-	tester.fetcher.Notify("lower", hashes[low], blocks[hashes[low]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("lower", hashes[low], blocks[hashes[low]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-fetching:
 		t.Fatalf("fetcher requested stale header")
 	}
 	// Ensure that a block with a higher number than the threshold is discarded
-	tester.fetcher.Notify("higher", hashes[high], blocks[hashes[high]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("higher", hashes[high], blocks[hashes[high]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-fetching:
@@ -698,7 +698,9 @@ func testInvalidNumberAnnouncement(t *testing.T, protocol int) {
 	tester.fetcher.announceChangeHook = func(hash common.Hash, b bool) {
 		announced <- nil
 	}
-	tester.fetcher.Notify("bad", hashes[0], 2, time.Now().Add(-arriveTimeout), badHeaderFetcher, badBodyFetcher)
+	tester.fetcher.Notify("bad", hashes[0], 2, time.Now().Add(-arriveTimeout), badHeaderFetcher, badBodyFetcher, func() {
+		tester.dropPeer("bad")
+	})
 	verifyAnnounce := func() {
 		for i := 0; i < 2; i++ {
 			select {
@@ -723,7 +725,7 @@ func testInvalidNumberAnnouncement(t *testing.T, protocol int) {
 	goodHeaderFetcher := tester.makeHeaderFetcher("good", blocks, -gatherSlack)
 	goodBodyFetcher := tester.makeBodyFetcher("good", blocks, 0)
 	// Make sure a good announcement passes without a drop
-	tester.fetcher.Notify("good", hashes[0], 1, time.Now().Add(-arriveTimeout), goodHeaderFetcher, goodBodyFetcher)
+	tester.fetcher.Notify("good", hashes[0], 1, time.Now().Add(-arriveTimeout), goodHeaderFetcher, goodBodyFetcher, nil)
 	verifyAnnounce()
 	verifyImportEvent(t, imported, true)
 
@@ -735,6 +737,77 @@ func testInvalidNumberAnnouncement(t *testing.T, protocol int) {
 		t.Fatalf("peer with valid numbered announcement dropped")
 	}
 	verifyImportDone(t, imported)
+}
+
+func TestInvalidNumberAnnouncementUsesBoundDropper(t *testing.T) {
+	hashes, blocks := makeChain(1, 0, genesis)
+
+	tester := newTester()
+	badHeaderFetcher := tester.makeHeaderFetcher("bad", blocks, -gatherSlack)
+	badBodyFetcher := tester.makeBodyFetcher("bad", blocks, 0)
+
+	staleDropped := make(chan struct{}, 1)
+	tester.fetcher.Notify("bad", hashes[0], 2, time.Now().Add(-arriveTimeout), badHeaderFetcher, badBodyFetcher, func() {
+		staleDropped <- struct{}{}
+	})
+
+	select {
+	case <-staleDropped:
+	case <-time.After(time.Second):
+		t.Fatal("bound dropper was not invoked")
+	}
+
+	tester.lock.RLock()
+	usedFallback := tester.drops["bad"]
+	tester.lock.RUnlock()
+	if usedFallback {
+		t.Fatal("fetcher fell back to id-based drop instead of the bound dropper")
+	}
+}
+
+func TestEnqueueVerifyFailureUsesBoundDropperAfterForget(t *testing.T) {
+	hashes, blocks := makeChain(1, 0, genesis)
+
+	tester := newTester()
+	defer tester.fetcher.Stop()
+
+	started := make(chan struct{}, 1)
+	proceed := make(chan struct{})
+	dropped := make(chan struct{}, 1)
+
+	tester.fetcher.verifyHeader = func(header *types.Header) error {
+		started <- struct{}{}
+		<-proceed
+		return errors.New("bad header")
+	}
+
+	if err := tester.fetcher.Enqueue("bad", blocks[hashes[0]], func() {
+		dropped <- struct{}{}
+	}); err != nil {
+		t.Fatalf("enqueue bad block: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("verification did not start")
+	}
+
+	tester.fetcher.forgetBlock(hashes[0])
+	close(proceed)
+
+	select {
+	case <-dropped:
+	case <-time.After(time.Second):
+		t.Fatal("bound dropper was lost after queued entry cleanup")
+	}
+
+	tester.lock.RLock()
+	usedFallback := tester.drops["bad"]
+	tester.lock.RUnlock()
+	if usedFallback {
+		t.Fatal("enqueue verify failure fell back to id-based drop")
+	}
 }
 
 // Tests that if a block is empty (i.e. header only), no body request should be
@@ -766,7 +839,7 @@ func testEmptyBlockShortCircuit(t *testing.T, protocol int) {
 
 	// Iteratively announce blocks until all are imported
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher, nil)
 
 		// All announces should fetch the header
 		verifyFetchingEvent(t, fetching, true)
@@ -816,9 +889,9 @@ func testHashMemoryExhaustionAttack(t *testing.T, protocol int) {
 	// Feed the tester a huge hashset from the attacker, and a limited from the valid peer
 	for i := 0; i < len(attack); i++ {
 		if i < maxQueueDist {
-			tester.fetcher.Notify("valid", hashes[len(hashes)-2-i], uint64(i+1), time.Now(), validHeaderFetcher, validBodyFetcher)
+			tester.fetcher.Notify("valid", hashes[len(hashes)-2-i], uint64(i+1), time.Now(), validHeaderFetcher, validBodyFetcher, nil)
 		}
-		tester.fetcher.Notify("attacker", attack[i], 1 /* don't distance drop */, time.Now(), attackerHeaderFetcher, attackerBodyFetcher)
+		tester.fetcher.Notify("attacker", attack[i], 1 /* don't distance drop */, time.Now(), attackerHeaderFetcher, attackerBodyFetcher, nil)
 	}
 	if count := atomic.LoadInt32(&announces); count != hashLimit+maxQueueDist {
 		t.Fatalf("queued announce count mismatch: have %d, want %d", count, hashLimit+maxQueueDist)
@@ -828,7 +901,7 @@ func testHashMemoryExhaustionAttack(t *testing.T, protocol int) {
 
 	// Feed the remaining valid hashes to ensure DOS protection state remains clean
 	for i := len(hashes) - maxQueueDist - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), validHeaderFetcher, validBodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), validHeaderFetcher, validBodyFetcher, nil)
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)
@@ -865,7 +938,7 @@ func TestBlockMemoryExhaustionAttack(t *testing.T) {
 	}
 	// Try to feed all the attacker blocks make sure only a limited batch is accepted
 	for _, block := range attack {
-		tester.fetcher.Enqueue("attacker", block)
+		tester.fetcher.Enqueue("attacker", block, nil)
 	}
 	time.Sleep(200 * time.Millisecond)
 	if queued := atomic.LoadInt32(&enqueued); queued != blockLimit {
@@ -873,19 +946,19 @@ func TestBlockMemoryExhaustionAttack(t *testing.T) {
 	}
 	// Queue up a batch of valid blocks, and check that a new peer is allowed to do so
 	for i := 0; i < maxQueueDist-1; i++ {
-		tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-3-i]])
+		tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-3-i]], nil)
 	}
 	time.Sleep(100 * time.Millisecond)
 	if queued := atomic.LoadInt32(&enqueued); queued != blockLimit+maxQueueDist-1 {
 		t.Fatalf("queued block count mismatch: have %d, want %d", queued, blockLimit+maxQueueDist-1)
 	}
 	// Insert the missing piece (and sanity check the import)
-	tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-2]])
+	tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-2]], nil)
 	verifyImportCount(t, imported, maxQueueDist)
 
 	// Insert the remaining blocks in chunks to ensure clean DOS protection
 	for i := maxQueueDist; i < len(hashes)-1; i++ {
-		tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-2-i]])
+		tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-2-i]], nil)
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -162,7 +163,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 	}
 
 	// Construct the different synchronisation mechanisms
-	manager.downloader = downloader.New(chaindb, manager.eventMux, blockchain, nil, manager.removePeer, handleProposedBlock)
+	manager.downloader = downloader.New(chaindb, manager.eventMux, blockchain, nil, manager.removePeerByID, handleProposedBlock)
 
 	validator := func(header *types.Header) error {
 		return engine.VerifyHeader(blockchain, header, true)
@@ -191,7 +192,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
 		return manager.blockchain.PrepareBlock(block)
 	}
-	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, handleProposedBlock, manager.BroadcastBlock, heighter, inserter, prepare, manager.removePeer)
+	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, handleProposedBlock, manager.BroadcastBlock, heighter, inserter, prepare, manager.removePeerByID)
 	//Define bft function
 	broadcasts := bft.BroadcastFns{
 		Vote:     manager.BroadcastVote,
@@ -248,21 +249,47 @@ func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 	}
 }
 
-func (pm *ProtocolManager) removePeer(id string) {
-	// Short circuit if the peer was already removed
-	peer := pm.peers.Peer(id)
+// removePeer disconnects a peer instance, unregistering it only when it is the
+// current primary connection because the downloader invariant is primary-only.
+func (pm *ProtocolManager) removePeer(peer *peer) {
 	if peer == nil {
 		return
 	}
-	log.Debug("Removing Ethereum peer", "peer", id)
+	removedPrimary, err := pm.peers.UnregisterPeer(peer)
+	if err != nil {
+		if errors.Is(err, errPairNotRegistered) {
+			log.Debug("Stale paired peer removal", "peer", peer.id, "err", err)
+		} else if errors.Is(err, errNotRegistered) {
+			log.Debug("Peer already removed", "peer", peer.id)
+		} else {
+			log.Warn("Peer removal failed", "peer", peer.id, "err", err)
+		}
+		// Intentionally disconnect even on not-registered errors. For an
+		// already tearing-down peer this is redundant, and for a stale paired
+		// peer it is a harmless idempotent fallback that keeps cleanup robust.
+		peer.Peer.Disconnect(p2p.DiscUselessPeer)
+		return
+	}
+	log.Debug("Removing Ethereum peer", "peer", peer.id)
 
-	// Unregister the peer from the downloader and Ethereum peer set
-	pm.downloader.UnregisterPeer(id)
-	if err := pm.peers.Unregister(id); err != nil {
-		log.Debug("Peer removal failed", "peer", id, "err", err)
+	// Only the currently registered primary connection is tracked by the
+	// downloader. Paired connections skip downloader.RegisterPeer in handle.
+	if removedPrimary {
+		pm.downloader.UnregisterPeer(peer.id)
 	}
 	// Hard disconnect at the networking layer
 	peer.Peer.Disconnect(p2p.DiscUselessPeer)
+}
+
+// removePeerByID adapts downloader and fetcher callbacks that only expose a peer id.
+func (pm *ProtocolManager) removePeerByID(id string) {
+	log.Debug("Ignoring id-only peer drop without instance context", "peer", id)
+}
+
+func (pm *ProtocolManager) makePeerDropper(peer *peer) func() {
+	return func() {
+		pm.removePeer(peer)
+	}
 }
 
 func (pm *ProtocolManager) Start(maxPeers int) {
@@ -356,10 +383,10 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		p.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}
-	defer pm.removePeer(p.id)
+	defer pm.removePeer(p)
 	if err != p2p.ErrAddPairPeer {
 		// Register the peer in the downloader. If the downloader considers it banned, we disconnect
-		if err := pm.downloader.RegisterPeer(p.id, p.version, p); err != nil {
+		if err := pm.downloader.RegisterPeer(p.id, p.version, p, pm.makePeerDropper(p)); err != nil {
 			return err
 		}
 		p.Log().Info("Register peer", "nodeid", p.ID().String(), "version", p.version, "addr", p.RemoteAddr())
@@ -376,7 +403,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 			// Start a timer to disconnect if the peer doesn't reply in time
 			p.forkDrop = time.AfterFunc(daoChallengeTimeout, func() {
 				p.Log().Debug("Timed out DAO fork-check, dropping")
-				pm.removePeer(p.id)
+				pm.removePeer(p)
 			})
 			// Make sure it's cleaned up if the peer dies off
 			defer func() {
@@ -709,7 +736,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 		}
 		for _, block := range unknown {
-			pm.fetcher.Notify(p.id, block.Hash, block.Number, time.Now(), p.RequestOneHeader, p.RequestBodies)
+			pm.fetcher.Notify(p.id, block.Hash, block.Number, time.Now(), p.RequestOneHeader, p.RequestBodies, pm.makePeerDropper(p))
 		}
 
 	case msg.Code == NewBlockMsg:
@@ -723,7 +750,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 
 		// Mark the peer as owning the block and schedule it for import
 		p.MarkBlock(request.Block.Hash())
-		pm.fetcher.Enqueue(p.id, request.Block)
+		pm.fetcher.Enqueue(p.id, request.Block, pm.makePeerDropper(p))
 
 		// Assuming the block is importable by the peer, but possibly not yet done so,
 		// calculate the head hash and TD that the peer truly must have.
@@ -945,7 +972,7 @@ func (pm *ProtocolManager) BroadcastVote(vote *types.Vote) {
 			err := peer.SendVote(vote)
 			if err != nil {
 				log.Debug("[BroadcastVote] Fail to broadcast vote message", "peerId", peer.id, "version", peer.version, "blockNum", vote.ProposedBlockInfo.Number, "err", err)
-				pm.removePeer(peer.id)
+				pm.removePeer(peer)
 			}
 		}
 		log.Trace("Propagated Vote", "vote hash", vote.Hash(), "voted block hash", vote.ProposedBlockInfo.Hash.Hex(), "number", vote.ProposedBlockInfo.Number, "round", vote.ProposedBlockInfo.Round, "recipients", len(peers))
@@ -962,7 +989,7 @@ func (pm *ProtocolManager) BroadcastTimeout(timeout *types.Timeout) {
 			err := peer.SendTimeout(timeout)
 			if err != nil {
 				log.Debug("[BroadcastTimeout] Fail to broadcast timeout message, remove peer", "peerId", peer.id, "version", peer.version, "timeout", timeout, "err", err)
-				pm.removePeer(peer.id)
+				pm.removePeer(peer)
 			}
 		}
 		log.Trace("Propagated Timeout", "hash", hash, "recipients", len(peers))
@@ -979,7 +1006,7 @@ func (pm *ProtocolManager) BroadcastSyncInfo(syncInfo *types.SyncInfo) {
 			err := peer.SendSyncInfo(syncInfo)
 			if err != nil {
 				log.Debug("[BroadcastSyncInfo] Fail to broadcast syncInfo message, remove peer", "peerId", peer.id, "version", peer.version, "syncInfo", syncInfo, "err", err)
-				pm.removePeer(peer.id)
+				pm.removePeer(peer)
 			}
 		}
 		log.Trace("Propagated SyncInfo", "hash", hash, "recipients", len(peers))

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"errors"
 	"math"
 	"math/big"
 	"math/rand"
@@ -35,6 +36,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/eth/ethconfig"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/p2p"
+	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
 	"github.com/XinFinOrg/XDPoSChain/params"
 )
 
@@ -43,6 +45,224 @@ func TestGetBlockHeaders62(t *testing.T) { testGetBlockHeaders(t, 62) }
 
 // TestGetBlockHeaders63 tests get block headers 63.
 func TestGetBlockHeaders63(t *testing.T) { testGetBlockHeaders(t, 63) }
+
+func TestGetBlockHeadersAfterPairDrop63(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, downloader.MaxHashFetch+15, nil, nil)
+	defer pm.Stop()
+
+	var id enode.ID
+	id[0] = 1
+
+	newPeerWithID := func(name string) (*testPeer, <-chan error) {
+		app, net := p2p.MsgPipe()
+		peer := pm.newPeer(eth63, p2p.NewPeer(id, name, nil), net)
+
+		errc := make(chan error, 1)
+		go func() {
+			select {
+			case pm.newPeerCh <- peer:
+				errc <- pm.handle(peer)
+			case <-pm.quitSync:
+				errc <- p2p.DiscQuitting
+			}
+		}()
+
+		return &testPeer{app: app, net: net, peer: peer}, errc
+	}
+
+	primary, primaryErrc := newPeerWithID("primary")
+	defer primary.close()
+	pair, pairErrc := newPeerWithID("pair")
+
+	var (
+		genesis = pm.blockchain.Genesis()
+		head    = pm.blockchain.CurrentHeader()
+		hash    = head.Hash()
+		td      = pm.blockchain.GetTd(hash, head.Number.Uint64())
+	)
+	primary.handshake(t, td, hash, genesis.Hash())
+	pair.handshake(t, td, hash, genesis.Hash())
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.After(3 * time.Second)
+	for primary.pairWriter() == nil {
+		select {
+		case <-ticker.C:
+		case <-timeout:
+			t.Fatalf("pairing state not established: peers=%d pairRWSet=%t", pm.peers.Len(), primary.pairWriter() != nil)
+		}
+	}
+
+	pair.close()
+	select {
+	case <-pairErrc:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for pair peer to disconnect")
+	}
+
+	if got := pm.peers.Peer(primary.id); got != primary.peer {
+		t.Fatal("primary peer was removed after pair disconnect")
+	}
+	if primary.pairWriter() != nil {
+		t.Fatal("primary peer still has stale pair writer after pair disconnect")
+	}
+	if primary.PairPeer() != nil {
+		t.Fatal("primary peer still references pair peer after pair disconnect")
+	}
+
+	query := &getBlockHeadersData{Origin: hashOrNumber{Number: 1}, Amount: 1}
+	expected := []*types.Header{pm.blockchain.GetBlockByNumber(1).Header()}
+
+	if err := p2p.Send(primary.app, GetBlockHeadersMsg, query); err != nil {
+		t.Fatalf("failed to send header request from primary peer: %v", err)
+	}
+	if err := p2p.ExpectMsg(primary.app, BlockHeadersMsg, expected); err != nil {
+		t.Fatalf("failed to receive header response after pair disconnect: %v", err)
+	}
+
+	select {
+	case err := <-primaryErrc:
+		t.Fatalf("primary peer disconnected unexpectedly: %v", err)
+	default:
+	}
+}
+
+type failingMsgReadWriter struct {
+	writeErr error
+}
+
+func (rw *failingMsgReadWriter) ReadMsg() (p2p.Msg, error) {
+	return p2p.Msg{}, errors.New("unexpected read")
+}
+
+func (rw *failingMsgReadWriter) WriteMsg(p2p.Msg) error {
+	return rw.writeErr
+}
+
+func TestBroadcastVotePairWriteFailureKeepsPrimary(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+	defer pm.Stop()
+
+	var id enode.ID
+	id[0] = 13
+
+	primary := pm.newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := pm.newPeer(eth63, p2p.NewPeer(id, "pair", nil), &failingMsgReadWriter{writeErr: errors.New("pair write failed")})
+
+	if err := pm.peers.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := pm.downloader.RegisterPeer(primary.id, primary.version, primary, nil); err != nil {
+		t.Fatalf("register downloader primary: %v", err)
+	}
+	if err := pm.peers.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+
+	vote := &types.Vote{ProposedBlockInfo: &types.BlockInfo{Number: big.NewInt(1)}}
+	pm.BroadcastVote(vote)
+
+	if got := pm.peers.Peer(primary.id); got != primary {
+		t.Fatal("primary peer was removed after pair write failure")
+	}
+	if err := pm.downloader.RegisterPeer(primary.id, primary.version, primary, nil); err == nil {
+		t.Fatal("primary downloader registration was removed after pair write failure")
+	}
+	if primary.pairWriter() != nil {
+		t.Fatal("primary peer still references pair writer after pair write failure")
+	}
+	if primary.PairPeer() != nil {
+		t.Fatal("primary peer still references pair peer after pair write failure")
+	}
+	if pair.PairPeer() != nil {
+		t.Fatal("pair peer still references primary after pair write failure")
+	}
+}
+
+func TestRemovePeerByIDAfterReconnectionKeepsReplacementPrimary(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+	defer pm.Stop()
+
+	var id enode.ID
+	id[0] = 14
+
+	first := pm.newPeer(eth63, p2p.NewPeer(id, "first", nil), &stubMsgReadWriter{})
+	replacement := pm.newPeer(eth63, p2p.NewPeer(id, "replacement", nil), &stubMsgReadWriter{})
+
+	if err := pm.peers.Register(first); err != nil {
+		t.Fatalf("register first: %v", err)
+	}
+	if _, err := pm.peers.UnregisterPeer(first); err != nil {
+		t.Fatalf("unregister first: %v", err)
+	}
+	if err := pm.peers.Register(replacement); err != nil {
+		t.Fatalf("register replacement: %v", err)
+	}
+
+	pm.removePeerByID(first.id)
+
+	if got := pm.peers.Peer(first.id); got != replacement {
+		t.Fatal("stale id-based drop removed replacement primary")
+	}
+}
+
+func TestRemovePeerKeepsDownloaderRegistrationForPair(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+	defer pm.Stop()
+
+	var id enode.ID
+	id[0] = 11
+
+	primary := pm.newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := pm.newPeer(eth63, p2p.NewPeer(id, "pair", nil), &stubMsgReadWriter{})
+
+	if err := pm.peers.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := pm.downloader.RegisterPeer(primary.id, primary.version, primary, nil); err != nil {
+		t.Fatalf("register downloader primary: %v", err)
+	}
+	if err := pm.peers.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	pm.removePeer(pair)
+
+	if err := pm.downloader.RegisterPeer(primary.id, primary.version, primary, nil); err == nil {
+		t.Fatal("pair removal should keep downloader primary registration")
+	}
+	if got := pm.peers.Peer(primary.id); got != primary {
+		t.Fatal("pair removal should keep primary registered")
+	}
+	if primary.pairWriter() != nil {
+		t.Fatal("pair removal should clear the primary pair writer")
+	}
+}
+
+func TestRemovePeerUnregistersDownloaderForPrimary(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+	defer pm.Stop()
+
+	var id enode.ID
+	id[0] = 12
+
+	primary := pm.newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+
+	if err := pm.peers.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := pm.downloader.RegisterPeer(primary.id, primary.version, primary, nil); err != nil {
+		t.Fatalf("register downloader primary: %v", err)
+	}
+	pm.removePeer(primary)
+
+	if err := pm.downloader.RegisterPeer(primary.id, primary.version, primary, nil); err != nil {
+		t.Fatalf("primary removal should unregister downloader peer: %v", err)
+	}
+	if got := pm.peers.Peer(primary.id); got != nil {
+		t.Fatal("primary removal should unregister primary peer")
+	}
+}
 
 func testGetBlockHeaders(t *testing.T, protocol int) {
 	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, downloader.MaxHashFetch+15, nil, nil)

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -21,10 +21,12 @@ import (
 	"fmt"
 	"math/big"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/p2p"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
 	mapset "github.com/deckarep/golang-set/v2"
@@ -34,6 +36,7 @@ var (
 	errClosed            = errors.New("peer set is closed")
 	errAlreadyRegistered = errors.New("peer is already registered")
 	errNotRegistered     = errors.New("peer is not registered")
+	errPairNotRegistered = errors.New("paired peer is not registered")
 )
 
 const (
@@ -56,11 +59,12 @@ type PeerInfo struct {
 }
 
 type peer struct {
-	id string
+	id     string
+	isPair bool
 
 	*p2p.Peer
 	rw     p2p.MsgReadWriter
-	pairRw p2p.MsgReadWriter
+	pairRW atomic.Pointer[p2p.MsgReadWriter]
 
 	version  int         // Protocol version negotiated
 	forkDrop *time.Timer // Timed connection dropper if forks aren't validated in time
@@ -97,6 +101,53 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) *peer {
 		knownTimeout:  mapset.NewSet[common.Hash](),
 		knownSyncInfo: mapset.NewSet[common.Hash](),
 	}
+}
+
+func (p *peer) pairWriter() p2p.MsgReadWriter {
+	pairRW := p.pairRW.Load()
+	if pairRW == nil {
+		return nil
+	}
+	return *pairRW
+}
+
+func (p *peer) setPairWriter(rw *p2p.MsgReadWriter) {
+	p.pairRW.Store(rw)
+}
+
+func (p *peer) clearPairWriter() {
+	p.pairRW.Store(nil)
+}
+
+func (p *peer) handlePairWriteFailure(pairRW *p2p.MsgReadWriter, err error) {
+	if !p.pairRW.CompareAndSwap(pairRW, nil) {
+		return
+	}
+	if pairPeer := p.PairPeer(); pairPeer != nil {
+		if p.ClearPairPeer(pairPeer) {
+			pairPeer.ClearPairPeer(p.Peer)
+		}
+		pairPeer.Disconnect(p2p.DiscUselessPeer)
+	}
+	log.Debug("Dropping failed paired writer and retrying on primary", "peer", p.id, "err", err)
+}
+
+func (p *peer) sendWithPairFallback(code uint64, data interface{}) error {
+	if pairRW := p.pairRW.Load(); pairRW != nil {
+		if err := p2p.Send(*pairRW, code, data); err == nil {
+			return nil
+		} else {
+			p.handlePairWriteFailure(pairRW, err)
+		}
+	}
+	return p2p.Send(p.rw, code, data)
+}
+
+func (p *peer) msgWriter() p2p.MsgReadWriter {
+	if pairRW := p.pairWriter(); pairRW != nil {
+		return pairRW
+	}
+	return p.rw
 }
 
 // Info gathers and returns a collection of metadata known about a peer.
@@ -262,59 +313,35 @@ func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	}
 
 	p.knownBlocks.Add(block.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, NewBlockMsg, []interface{}{block, td})
-	} else {
-		return p2p.Send(p.rw, NewBlockMsg, []interface{}{block, td})
-	}
+	return p.sendWithPairFallback(NewBlockMsg, []interface{}{block, td})
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, BlockHeadersMsg, headers)
-	} else {
-		return p2p.Send(p.rw, BlockHeadersMsg, headers)
-	}
+	return p.sendWithPairFallback(BlockHeadersMsg, headers)
 }
 
 // SendBlockBodies sends a batch of block contents to the remote peer.
 func (p *peer) SendBlockBodies(bodies []*blockBody) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, BlockBodiesMsg, blockBodiesData(bodies))
-	} else {
-		return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
-	}
+	return p.sendWithPairFallback(BlockBodiesMsg, blockBodiesData(bodies))
 }
 
 // SendBlockBodiesRLP sends a batch of block contents to the remote peer from
 // an already RLP encoded format.
 func (p *peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, BlockBodiesMsg, bodies)
-	} else {
-		return p2p.Send(p.rw, BlockBodiesMsg, bodies)
-	}
+	return p.sendWithPairFallback(BlockBodiesMsg, bodies)
 }
 
 // SendNodeDataRLP sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, NodeDataMsg, data)
-	} else {
-		return p2p.Send(p.rw, NodeDataMsg, data)
-	}
+	return p.sendWithPairFallback(NodeDataMsg, data)
 }
 
 // SendReceiptsRLP sends a batch of transaction receipts, corresponding to the
 // ones requested from an already RLP encoded format.
 func (p *peer) SendReceiptsRLP(receipts []rlp.RawValue) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, ReceiptsMsg, receipts)
-	} else {
-		return p2p.Send(p.rw, ReceiptsMsg, receipts)
-	}
+	return p.sendWithPairFallback(ReceiptsMsg, receipts)
 }
 
 func (p *peer) SendVote(vote *types.Vote) error {
@@ -323,11 +350,7 @@ func (p *peer) SendVote(vote *types.Vote) error {
 	}
 
 	p.knownVote.Add(vote.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, VoteMsg, vote)
-	} else {
-		return p2p.Send(p.rw, VoteMsg, vote)
-	}
+	return p.sendWithPairFallback(VoteMsg, vote)
 }
 
 /*
@@ -341,11 +364,7 @@ func (p *peer) SendTimeout(timeout *types.Timeout) error {
 	}
 
 	p.knownTimeout.Add(timeout.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, TimeoutMsg, timeout)
-	} else {
-		return p2p.Send(p.rw, TimeoutMsg, timeout)
-	}
+	return p.sendWithPairFallback(TimeoutMsg, timeout)
 }
 
 /*
@@ -359,11 +378,7 @@ func (p *peer) SendSyncInfo(syncInfo *types.SyncInfo) error {
 	}
 
 	p.knownSyncInfo.Add(syncInfo.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, SyncInfoMsg, syncInfo)
-	} else {
-		return p2p.Send(p.rw, SyncInfoMsg, syncInfo)
-	}
+	return p.sendWithPairFallback(SyncInfoMsg, syncInfo)
 }
 
 /*
@@ -376,65 +391,41 @@ func (p *peer) AsyncSendSyncInfo() {
 // single header. It is used solely by the fetcher.
 func (p *peer) RequestOneHeader(hash common.Hash) error {
 	p.Log().Debug("Fetching single header", "hash", hash)
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
-	} else {
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
-	}
+	return p.sendWithPairFallback(GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
 }
 
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(origin common.Hash, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromhash", origin, "skip", skip, "reverse", reverse)
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	} else {
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	}
+	return p.sendWithPairFallback(GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
 }
 
 // RequestHeadersByNumber fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the number of an origin block.
 func (p *peer) RequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromnum", origin, "skip", skip, "reverse", reverse)
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	} else {
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	}
+	return p.sendWithPairFallback(GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
 }
 
 // RequestBodies fetches a batch of blocks' bodies corresponding to the hashes
 // specified.
 func (p *peer) RequestBodies(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of block bodies", "count", len(hashes))
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockBodiesMsg, hashes)
-	} else {
-		return p2p.Send(p.rw, GetBlockBodiesMsg, hashes)
-	}
+	return p.sendWithPairFallback(GetBlockBodiesMsg, hashes)
 }
 
 // RequestNodeData fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
 func (p *peer) RequestNodeData(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of state data", "count", len(hashes))
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetNodeDataMsg, hashes)
-	} else {
-		return p2p.Send(p.rw, GetNodeDataMsg, hashes)
-	}
+	return p.sendWithPairFallback(GetNodeDataMsg, hashes)
 }
 
 // RequestReceipts fetches a batch of transaction receipts from a remote node.
 func (p *peer) RequestReceipts(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of receipts", "count", len(hashes))
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetReceiptsMsg, hashes)
-	} else {
-		return p2p.Send(p.rw, GetReceiptsMsg, hashes)
-	}
+	return p.sendWithPairFallback(GetReceiptsMsg, hashes)
 }
 
 // Handshake executes the eth protocol handshake, negotiating version number,
@@ -531,29 +522,72 @@ func (ps *peerSet) Register(p *peer) error {
 		return errClosed
 	}
 	if existPeer, ok := ps.peers[p.id]; ok {
-		if existPeer.pairRw != nil {
+		// Mark duplicate connections as pair-role peers before any early return
+		// so rejected duplicate pairs still take the pair cleanup path in
+		// UnregisterPeer and report errPairNotRegistered instead of looking
+		// like an unregistered primary.
+		p.isPair = true
+		if existPeer.pairWriter() != nil {
 			return errAlreadyRegistered
 		}
 		existPeer.SetPairPeer(p.Peer)
-		existPeer.pairRw = p.rw
 		p.SetPairPeer(existPeer.Peer)
+		rw := p.rw
+		existPeer.setPairWriter(&rw)
 		return p2p.ErrAddPairPeer
 	}
+	p.isPair = false
 	ps.peers[p.id] = p
 	return nil
 }
 
-// Unregister removes a remote peer from the active set, disabling any further
-// actions to/from that particular entity.
-func (ps *peerSet) Unregister(id string) error {
+// UnregisterPeer removes a specific peer instance from the active set. The
+// returned flag reports whether this exact instance was the currently
+// registered primary peer, allowing callers to keep downloader bookkeeping in
+// sync without performing a separate lookup.
+//
+// When the instance is a paired connection, the primary peer remains
+// registered and only its pair state is cleared.
+func (ps *peerSet) UnregisterPeer(p *peer) (bool, error) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
-	if _, ok := ps.peers[id]; !ok {
-		return errNotRegistered
+	current, ok := ps.peers[p.id]
+	if !ok {
+		if p.isPair {
+			return false, errPairNotRegistered
+		}
+		return false, errNotRegistered
 	}
-	delete(ps.peers, id)
-	return nil
+	if current == p {
+		// Keep the p2p-level primary->pair peer link intact here. The paired
+		// connection is disconnected by the p2p.Peer.run exit path, and its own
+		// unregister path will clean up any remaining stale pair state.
+		if pairPeer := current.PairPeer(); pairPeer != nil {
+			pairPeer.ClearPairPeer(current.Peer)
+		}
+		// Clear the eth-level paired writer now because only the registered
+		// primary stores pairRW.
+		current.clearPairWriter()
+		delete(ps.peers, p.id)
+		return true, nil
+	}
+	if pairPeer := current.PairPeer(); p.isPair && pairPeer != p.Peer {
+		// A paired connection is known for this id, but it is not this specific
+		// peer instance anymore (for example, a stale pair after primary removal).
+		return false, errPairNotRegistered
+	}
+	if current.ClearPairPeer(p.Peer) {
+		p.ClearPairPeer(current.Peer)
+		current.clearPairWriter()
+		// The current primary cleared its active paired connection; the primary
+		// stays registered, so callers should not treat this as a primary removal.
+		return false, nil
+	}
+	// Reaching here means p shares the id with the current primary but is neither
+	// the registered primary nor the currently tracked pair instance.
+	log.Trace("Ignoring unregister for unexpected same-id peer", "peer", p.id, "isPair", p.isPair, "hasTrackedPair", current.PairPeer() != nil)
+	return false, errNotRegistered
 }
 
 // Peer retrieves the registered peer with the given id.

--- a/eth/peer_test.go
+++ b/eth/peer_test.go
@@ -1,0 +1,421 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/p2p"
+	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
+)
+
+type stubMsgReadWriter struct{}
+
+func (*stubMsgReadWriter) ReadMsg() (p2p.Msg, error) {
+	return p2p.Msg{}, io.EOF
+}
+
+func (*stubMsgReadWriter) WriteMsg(p2p.Msg) error {
+	return nil
+}
+
+func TestPeerMsgWriterUsesAtomicPairWriter(t *testing.T) {
+	var p peer
+
+	primaryRW := &stubMsgReadWriter{}
+	pairedRW := p2p.MsgReadWriter(&stubMsgReadWriter{})
+	p.rw = primaryRW
+
+	if got := p.msgWriter(); got != primaryRW {
+		t.Fatal("msgWriter should return primary writer when pair writer is unset")
+	}
+
+	p.setPairWriter(&pairedRW)
+	if got := p.msgWriter(); got != pairedRW {
+		t.Fatal("msgWriter should return pair writer when one is registered")
+	}
+
+	p.clearPairWriter()
+	if got := p.msgWriter(); got != primaryRW {
+		t.Fatal("msgWriter should fall back to primary writer after clearing pair writer")
+	}
+}
+
+func TestPeerSetUnregisterPairKeepsPrimaryAndClearsPairWriter(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 1
+
+	primaryRW := &stubMsgReadWriter{}
+	pairRW := &stubMsgReadWriter{}
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), primaryRW)
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), pairRW)
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if primary.isPair {
+		t.Fatal("primary peer should not be marked as pair after primary registration")
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	if !pair.isPair {
+		t.Fatal("paired peer should be marked as pair after duplicate registration")
+	}
+	if primary.pairWriter() != pair.rw {
+		t.Fatal("primary did not record pair writer")
+	}
+	if pair.PairPeer() != primary.Peer {
+		t.Fatal("pair peer did not record primary peer")
+	}
+
+	removedPrimary, err := ps.UnregisterPeer(pair)
+	if err != nil {
+		t.Fatalf("unregister pair: %v", err)
+	}
+	if removedPrimary {
+		t.Fatal("pair unregister should not report primary removal")
+	}
+	if got := ps.Peer(primary.id); got != primary {
+		t.Fatal("primary peer was removed while unregistering pair")
+	}
+	if primary.pairWriter() != nil {
+		t.Fatal("primary peer still references pair writer after unregister")
+	}
+	if primary.PairPeer() != nil {
+		t.Fatal("primary peer still references pair peer after unregister")
+	}
+	if pair.PairPeer() != nil {
+		t.Fatal("pair peer still references primary peer after unregister")
+	}
+}
+
+func TestPeerSetUnregisterPrimaryKeepsDisconnectLinkAndClearsPairBacklink(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 2
+
+	primaryRW := &stubMsgReadWriter{}
+	pairRW := &stubMsgReadWriter{}
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), primaryRW)
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), pairRW)
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	if primary.pairWriter() != pair.rw {
+		t.Fatal("primary did not record pair writer")
+	}
+	if primary.PairPeer() != pair.Peer {
+		t.Fatal("primary peer did not record pair peer")
+	}
+
+	removedPrimary, err := ps.UnregisterPeer(primary)
+	if err != nil {
+		t.Fatalf("unregister primary: %v", err)
+	}
+	if !removedPrimary {
+		t.Fatal("primary unregister should report primary removal")
+	}
+	if got := ps.Peer(primary.id); got != nil {
+		t.Fatal("primary peer still registered after unregister")
+	}
+	if primary.pairWriter() != nil {
+		t.Fatal("primary peer still references pair writer after unregister")
+	}
+	if primary.PairPeer() != pair.Peer {
+		t.Fatal("primary peer lost pair link needed for disconnect cleanup")
+	}
+	if pair.PairPeer() != nil {
+		t.Fatal("pair peer still references removed primary")
+	}
+}
+
+func TestPeerSetUnregisterPairAfterDisconnectReturnsPairNotRegistered(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 3
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), &stubMsgReadWriter{})
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	removedPrimary, err := ps.UnregisterPeer(pair)
+	if err != nil {
+		t.Fatalf("first unregister pair: %v", err)
+	}
+	if removedPrimary {
+		t.Fatal("pair unregister should not report primary removal")
+	}
+	removedPrimary, err = ps.UnregisterPeer(pair)
+	if err != errPairNotRegistered {
+		t.Fatalf("second unregister pair: got %v want %v", err, errPairNotRegistered)
+	}
+	if removedPrimary {
+		t.Fatal("stale pair unregister should not report primary removal")
+	}
+	if got := ps.Peer(primary.id); got != primary {
+		t.Fatal("primary peer was removed after pair double unregister")
+	}
+	if primary.pairWriter() != nil {
+		t.Fatal("primary peer still references pair writer after pair double unregister")
+	}
+	if primary.PairPeer() != nil {
+		t.Fatal("primary peer still references pair peer after pair double unregister")
+	}
+	if pair.PairPeer() != nil {
+		t.Fatal("pair peer still references primary peer after pair double unregister")
+	}
+}
+
+func TestPeerSetUnregisterStalePairAfterPrimaryRemovalReturnsPairNotRegistered(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 5
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), &stubMsgReadWriter{})
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	removedPrimary, err := ps.UnregisterPeer(primary)
+	if err != nil {
+		t.Fatalf("unregister primary: %v", err)
+	}
+	if !removedPrimary {
+		t.Fatal("primary unregister should report primary removal")
+	}
+	removedPrimary, err = ps.UnregisterPeer(pair)
+	if err != errPairNotRegistered {
+		t.Fatalf("unregister stale pair: got %v want %v", err, errPairNotRegistered)
+	}
+	if removedPrimary {
+		t.Fatal("stale pair unregister should not report primary removal")
+	}
+	if errors.Is(errPairNotRegistered, errNotRegistered) {
+		t.Fatal("pair not registered should remain distinct from not registered")
+	}
+	removedPrimary, err = ps.UnregisterPeer(primary)
+	if err != errNotRegistered {
+		t.Fatalf("unregister stale primary: got %v want %v", err, errNotRegistered)
+	}
+	if removedPrimary {
+		t.Fatal("stale primary unregister should not report primary removal")
+	}
+}
+
+func TestPeerSetUnregisterStalePairAfterPrimaryClearsPairReturnsPairNotRegistered(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 7
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), &stubMsgReadWriter{})
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	if !primary.ClearPairPeer(pair.Peer) {
+		t.Fatal("primary pair link was not established")
+	}
+	primary.clearPairWriter()
+
+	removedPrimary, err := ps.UnregisterPeer(pair)
+	if err != errPairNotRegistered {
+		t.Fatalf("unregister stale pair after primary clear: got %v want %v", err, errPairNotRegistered)
+	}
+	if removedPrimary {
+		t.Fatal("stale pair unregister should not report primary removal")
+	}
+	if got := ps.Peer(primary.id); got != primary {
+		t.Fatal("primary peer should remain registered after stale pair cleanup")
+	}
+	if primary.PairPeer() != nil {
+		t.Fatal("primary peer should keep cleared pair reference")
+	}
+	if pair.PairPeer() != primary.Peer {
+		t.Fatal("pair peer should retain stale primary reference for cleanup path")
+	}
+}
+
+func TestPeerSetUnregisterRejectedDuplicatePairReturnsPairNotRegistered(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 6
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), &stubMsgReadWriter{})
+	rejectedPair := newPeer(eth63, p2p.NewPeer(id, "rejected-pair", nil), &stubMsgReadWriter{})
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+	if err := ps.Register(rejectedPair); err != errAlreadyRegistered {
+		t.Fatalf("register rejected pair: got %v want %v", err, errAlreadyRegistered)
+	}
+	if !rejectedPair.isPair {
+		t.Fatal("rejected duplicate pair should retain pair role for cleanup semantics")
+	}
+	removedPrimary, err := ps.UnregisterPeer(rejectedPair)
+	if err != errPairNotRegistered {
+		t.Fatalf("unregister rejected pair: got %v want %v", err, errPairNotRegistered)
+	}
+	if removedPrimary {
+		t.Fatal("rejected pair unregister should not report primary removal")
+	}
+	if rejectedPair.PairPeer() != nil {
+		t.Fatal("rejected pair should not retain a pair peer link")
+	}
+	if primary.pairWriter() != pair.rw {
+		t.Fatal("primary pair writer changed after rejected duplicate pair")
+	}
+}
+
+func TestPeerPairRWConcurrentRegisterAndSend(t *testing.T) {
+	ps := newPeerSet()
+	var id enode.ID
+	id[0] = 4
+
+	primary := newPeer(eth63, p2p.NewPeer(id, "primary", nil), &stubMsgReadWriter{})
+	pair := newPeer(eth63, p2p.NewPeer(id, "pair", nil), &stubMsgReadWriter{})
+
+	if err := ps.Register(primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+		t.Fatalf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+	}
+
+	start := make(chan struct{})
+	errc := make(chan error, 3)
+	var lifecycleMu sync.Mutex
+	var primaryCycles atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 2000; i++ {
+			if err := primary.SendBlockHeaders(nil); err != nil {
+				errc <- fmt.Errorf("send block headers: %w", err)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 2000; i++ {
+			lifecycleMu.Lock()
+			removedPrimary, err := ps.UnregisterPeer(pair)
+			if err != nil {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("unregister pair: %w", err)
+				return
+			}
+			if removedPrimary {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("unregister pair: reported primary removal")
+				return
+			}
+			if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("register pair: got %v want %v", err, p2p.ErrAddPairPeer)
+				return
+			}
+			lifecycleMu.Unlock()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 200; i++ {
+			lifecycleMu.Lock()
+			removedPrimary, err := ps.UnregisterPeer(primary)
+			if err != nil {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("unregister primary: %w", err)
+				return
+			}
+			if !removedPrimary {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("unregister primary: did not report primary removal")
+				return
+			}
+			primaryCycles.Add(1)
+			if err := ps.Register(primary); err != nil {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("register primary: %v", err)
+				return
+			}
+			if err := ps.Register(pair); err != p2p.ErrAddPairPeer {
+				lifecycleMu.Unlock()
+				errc <- fmt.Errorf("re-register pair after primary: got %v want %v", err, p2p.ErrAddPairPeer)
+				return
+			}
+			lifecycleMu.Unlock()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errc)
+
+	for err := range errc {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if primaryCycles.Load() == 0 {
+		t.Fatal("primary unregister path was not exercised")
+	}
+	if got := ps.Peer(primary.id); got != primary {
+		t.Fatal("primary peer was not restored after concurrent lifecycle churn")
+	}
+	if primary.pairWriter() != pair.rw {
+		t.Fatal("primary peer did not restore pair writer after primary re-register")
+	}
+}

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common/mclock"
@@ -118,8 +119,7 @@ type Peer struct {
 	// events receives message send / receive events if set
 	events *event.Feed
 
-	pairPeerMu sync.RWMutex
-	pairPeer   *Peer
+	pairPeer atomic.Pointer[Peer]
 }
 
 // NewPeer returns a peer for testing purposes.
@@ -203,27 +203,15 @@ func (p *Peer) Log() log.Logger {
 }
 
 func (p *Peer) PairPeer() *Peer {
-	p.pairPeerMu.RLock()
-	defer p.pairPeerMu.RUnlock()
-
-	return p.pairPeer
+	return p.pairPeer.Load()
 }
 
 func (p *Peer) SetPairPeer(pair *Peer) {
-	p.pairPeerMu.Lock()
-	p.pairPeer = pair
-	p.pairPeerMu.Unlock()
+	p.pairPeer.Store(pair)
 }
 
 func (p *Peer) ClearPairPeer(pair *Peer) bool {
-	p.pairPeerMu.Lock()
-	defer p.pairPeerMu.Unlock()
-
-	if p.pairPeer != pair {
-		return false
-	}
-	p.pairPeer = nil
-	return true
+	return p.pairPeer.CompareAndSwap(pair, nil)
 }
 
 func (p *Peer) run() (remoteRequested bool, err error) {

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -225,6 +225,37 @@ func TestPeerRunDisconnectsPairPeer(t *testing.T) {
 	}
 }
 
+func TestPeerPairPeerAtomicSemantics(t *testing.T) {
+	var peer Peer
+	first := &Peer{}
+	second := &Peer{}
+
+	if got := peer.PairPeer(); got != nil {
+		t.Fatalf("initial pair peer = %p, want nil", got)
+	}
+	peer.SetPairPeer(first)
+	if got := peer.PairPeer(); got != first {
+		t.Fatalf("pair peer after first set = %p, want %p", got, first)
+	}
+	if cleared := peer.ClearPairPeer(second); cleared {
+		t.Fatal("ClearPairPeer should fail when current pair differs")
+	}
+	if got := peer.PairPeer(); got != first {
+		t.Fatalf("pair peer after failed clear = %p, want %p", got, first)
+	}
+	if cleared := peer.ClearPairPeer(first); !cleared {
+		t.Fatal("ClearPairPeer should succeed for the current pair")
+	}
+	if got := peer.PairPeer(); got != nil {
+		t.Fatalf("pair peer after successful clear = %p, want nil", got)
+	}
+	peer.SetPairPeer(second)
+	peer.SetPairPeer(nil)
+	if got := peer.PairPeer(); got != nil {
+		t.Fatalf("pair peer after explicit nil set = %p, want nil", got)
+	}
+}
+
 func TestNewPeer(t *testing.T) {
 	name := "nodename"
 	caps := []Cap{{"foo", 2}, {"bar", 3}}


### PR DESCRIPTION
# Proposed changes

Handle paired eth peer teardown by instance so dropping the secondary connection clears pair state without removing the primary peer from the set.

Synchronize pairRw access to avoid torn interface reads during concurrent send and unregister paths, and cover the lifecycle with regression tests.

fix panic:

```text
INFO [05-14|17:14:13.116] [voteHandler] Vote pool threashold reached: true, number of items in the pool: 21
INFO [05-14|17:14:13.117] Successfully commit and confirm block from continuous 3 blocks num=81,945,965 round=25662942   hash=f9a13f..81aa74
INFO [05-14|17:14:13.117] [setNewRound] new round and reset pools and workers round=25662945
INFO [05-14|17:14:13.117] Successfully processed the vote and produced QC! QcRound=25662944 QcNumOfSig=21 QcHash=2b4bbf..54f3bc QcNumber=81,945,967
INFO [05-14|17:14:13.117] [voteHandler] time cost from receive first vote under QC create elapsed=70.225291ms
INFO [05-14|17:14:14.780] Register peer                            id=f3c2f7d28018e67d conn=inbound nodeid=f3c2f7d28018e67d1e0fbc70eb4b539facf92e6d2c02ffdc98124e76e6ff8310bc8a4a14d58404dda2d9ca767c5f99ef354749133a68048d3727255170c404de version=100 addr=144.126.142.140:41902
INFO [05-14|17:14:15.075] [voteHandler] set vote pool time         round=25662945
INFO [05-14|17:14:15.078] Imported new chain segment               blocks=1   txs=0    mgas=0.000  elapsed=1.065ms         mgasps=0.000   number=81,945,968 hash=fefc22..b0e749 dirty=0.00B
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xc083ab]

goroutine 69688380 [running]:
github.com/XinFinOrg/XDPoSChain/p2p.(*protoRW).WriteMsg(0x1?, {0x4, 0x80b, {0x19c2ca0, 0xc05385c630}, {0x0, 0x0, 0x0}, {{0x0, 0x0}, ...}, ...})
        github.com/XinFinOrg/XDPoSChain/p2p/peer.go:425 +0x2b
github.com/XinFinOrg/XDPoSChain/p2p.Send({0x7fa0b8085e60, 0x0}, 0x4, {0x132fa40?, 0xc057a16408?})
        github.com/XinFinOrg/XDPoSChain/p2p/message.go:100 +0x9d
github.com/XinFinOrg/XDPoSChain/eth.(*peer).SendBlockHeaders(0xc00005b320?, {0xc04a8b72d8, 0x1, 0x1})
        github.com/XinFinOrg/XDPoSChain/eth/peer.go:275 +0x16c
github.com/XinFinOrg/XDPoSChain/eth.(*ProtocolManager).handleMsg(0xc0169662c0, 0xc037563700)
        github.com/XinFinOrg/XDPoSChain/eth/handler.go:508 +0x3579
github.com/XinFinOrg/XDPoSChain/eth.(*ProtocolManager).handle(0xc0169662c0, 0xc037563700)
        github.com/XinFinOrg/XDPoSChain/eth/handler.go:405 +0xa7b
github.com/XinFinOrg/XDPoSChain/eth.NewProtocolManager.func1(0x1609318?, {0x19c95e8?, 0xc05f580380?})
        github.com/XinFinOrg/XDPoSChain/eth/handler.go:179 +0x1bc
github.com/XinFinOrg/XDPoSChain/p2p.(*Peer).startProtocols.func1()
        github.com/XinFinOrg/XDPoSChain/p2p/peer.go:391 +0x3d
sync.(*WaitGroup).Go.func1()
        sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 69688377
        sync/waitgroup.go:237 +0x73
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
