### PR TITLE
fix(eth/bft): avoid broadcast send blocking during shutdown

### DIFF
--- a/eth/bft/bft_handler.go
+++ b/eth/bft/bft_handler.go
@@ -94,7 +94,9 @@ func (b *Bfter) Vote(peer string, vote *types.Vote) error {
 	}
 
 	if verified {
-		b.broadcastCh <- vote
+		if !b.enqueueForBroadcast(vote) {
+			return nil
+		}
 		err = b.consensus.voteHandler(b.blockChainReader, vote)
 		if err != nil {
 			if _, ok := err.(*utils.ErrIncomingMessageRoundTooFarFromCurrentRound); ok {
@@ -129,7 +131,9 @@ func (b *Bfter) Timeout(peer string, timeout *types.Timeout) error {
 	log.Debug("[Timeout] Received Timeout", "gap", gapNum, "hash", timeout.Hash().Hex(), "round", timeout.Round, "signer", timeout.GetSigner().Hex()) //get signer after verifyTimeout
 
 	if verified {
-		b.broadcastCh <- timeout
+		if !b.enqueueForBroadcast(timeout) {
+			return nil
+		}
 		err = b.consensus.timeoutHandler(b.blockChainReader, timeout)
 		if err != nil {
 			if _, ok := err.(*utils.ErrIncomingMessageRoundNotEqualCurrentRound); ok {
@@ -170,7 +174,9 @@ func (b *Bfter) SyncInfo(peer string, syncInfo *types.SyncInfo) error {
 
 	// Process only if verified and qualified
 	if verified {
-		b.broadcastCh <- syncInfo
+		if !b.enqueueForBroadcast(syncInfo) {
+			return nil
+		}
 		err = b.consensus.syncInfoHandler(b.blockChainReader, syncInfo)
 		if err != nil {
 			log.Error("[SyncInfo] Handle BFT SyncInfo", "error", err)
@@ -178,6 +184,15 @@ func (b *Bfter) SyncInfo(peer string, syncInfo *types.SyncInfo) error {
 		}
 	}
 	return nil
+}
+
+func (b *Bfter) enqueueForBroadcast(msg interface{}) bool {
+	select {
+	case <-b.quit:
+		return false
+	case b.broadcastCh <- msg:
+		return true
+	}
 }
 
 // Start Bft receiver

--- a/eth/bft/bft_handler_test.go
+++ b/eth/bft/bft_handler_test.go
@@ -393,3 +393,28 @@ func TestTooFarSyncInfo(t *testing.T) {
 		t.Fatalf("count mismatch: have %v on verify, have %v on handler, %v on broadcast, want %v", verifyCounter, handlerCounter, broadcastCounter, targetSyncInfo)
 	}
 }
+
+func TestVoteReturnsAfterBftStop(t *testing.T) {
+	tester := newTester()
+	tester.bfter.consensus.verifyVote = func(chain consensus.ChainReader, vote *types.Vote) (bool, error) {
+		return true, nil
+	}
+	tester.bfter.consensus.voteHandler = func(chain consensus.ChainReader, vote *types.Vote) error {
+		return nil
+	}
+
+	tester.bfter.Stop()
+
+	vote := types.Vote{ProposedBlockInfo: &types.BlockInfo{Number: big.NewInt(1350)}}
+	done := make(chan struct{})
+	go func() {
+		_ = tester.bfter.Vote(peerID, &vote)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("Vote blocks after bft loop is stopped")
+	}
+}


### PR DESCRIPTION
# Proposed changes

Guard BFT broadcast enqueue with the quit channel so Vote/Timeout/SyncInfo exit cleanly once shutdown starts.

Add a regression test to ensure Vote returns after BFT loop stop and does not hang.

log messages when stop node without this PR:

```text
INFO [05-21|13:01:19.273] [getTCEpochInfo] Init epochInfo          number=82,155,518 round=25893000   tcRound=25893274 tcEpoch=91913
INFO [05-21|13:01:19.273] [getTCEpochInfo] Final TC epochInfo      number=82,155,518 round=25893000   tcRound=25893274 tcEpoch=91913
INFO [05-21|13:01:19.273] Timeout pool threashold reached: true, number of items in the pool: 22
INFO [05-21|13:01:19.273] [setNewRound] new round and reset pools and workers round=25893275
INFO [05-21|13:01:19.273] [onTimeoutPoolThresholdReached] process TC successfully TcRound=25893274 NumberOfTcSig=22
INFO [05-21|13:01:19.348] [getTCEpochInfo] Init epochInfo          number=82,155,518 round=25893000   tcRound=25893275 tcEpoch=91913
INFO [05-21|13:01:19.349] [getTCEpochInfo] Final TC epochInfo      number=82,155,518 round=25893000   tcRound=25893275 tcEpoch=91913
INFO [05-21|13:01:19.353] Imported new chain segment               blocks=1   txs=0    mgas=0.000  elapsed=1.694ms       mgasps=0.000   number=82,155,770 hash=fa80d0..d8ffca dirty=0.00B
INFO [05-21|13:01:19.469] [voteHandler] Vote pool threashold reached: true, number of items in the pool: 22
INFO [05-21|13:01:19.470] [commitBlocks] Rounds not continuous(parent) found when committing block proposedBlockRound=25893275 decodedExtraField.Round=25893273 proposedBlockHeaderHash=fa80d0..d8ffca
INFO [05-21|13:01:19.470] [setNewRound] new round and reset pools and workers round=25893276
INFO [05-21|13:01:19.470] Successfully processed the vote and produced QC! QcRound=25893275 QcNumOfSig=22 QcHash=fa80d0..d8ffca QcNumber=82,155,770
INFO [05-21|13:01:19.470] [voteHandler] time cost from receive first vote under QC create elapsed=10.23727721s
INFO [05-21|13:01:19.821] Got interrupt, shutting down...
INFO [05-21|13:01:19.828] HTTP server stopped                      endpoint=[::]:8745
INFO [05-21|13:01:19.831] HTTP server stopped                      endpoint=[::]:9745
INFO [05-21|13:01:19.832] IPC endpoint closed                      url=/home/me/xdc_chain/testnet_1/XDC.ipc
INFO [05-21|13:01:19.833] Stopping Ethereum bloomIndexer start
INFO [05-21|13:01:19.833] Ethereum bloomIndexer stopped
INFO [05-21|13:01:19.833] Stopping Ethereum blockchain start
INFO [05-21|13:01:19.833] Blockchain manager stopped
INFO [05-21|13:01:19.833] Ethereum blockchain stopped
INFO [05-21|13:01:19.833] Stopping Ethereum protocolManager start
INFO [05-21|13:01:19.835] Stopping Ethereum protocol
WARN [05-21|13:01:19.839] BFT Loop Close
INFO [05-21|13:01:19.842] Ethereum protocol stopped
INFO [05-21|13:01:19.842] Ethereum protocolManager stopped
INFO [05-21|13:01:19.842] Stopping Ethereum txPool start
INFO [05-21|13:01:19.842] Transaction pool stopped
INFO [05-21|13:01:19.842] Ethereum txPool stopped
INFO [05-21|13:01:19.842] Stopping Ethereum shutdownChan start
INFO [05-21|13:01:19.842] Ethereum shutdownChan stopped
INFO [05-21|13:01:19.842] Stopping Ethereum miner start
INFO [05-21|13:01:19.842] Ethereum miner stopped
INFO [05-21|13:01:19.842] Stopping Ethereum eventMux start
INFO [05-21|13:01:19.842] Ethereum eventMux stopped
INFO [05-21|13:01:19.842] Stopping Ethereum chainDb start
INFO [05-21|13:01:20.308] Ethereum chainDb stopped
WARN [05-21|13:01:27.011] Propagated block verification failed     peer=386884ee0aa5383d number=82,154,346 hash=e14937..07a462 err="unknown ancestor"
WARN [05-21|13:02:43.000] Propagated block verification failed     peer=386884ee0aa5383d number=82,154,376 hash=11895e..23d420 err="unknown ancestor"
WARN [05-21|13:03:59.001] Propagated block verification failed     peer=386884ee0aa5383d number=82,154,406 hash=29cc51..857659 err="unknown ancestor"
```


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
