### PR TITLE
refactor(p2p,eth): collapse pair-peer dual links into a single prioritized write path, close #2359 #2351

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -351,41 +351,38 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		rw.Init(p.version)
 	}
 	// Register the peer locally
-	err := pm.peers.Register(p)
-	if err != nil && err != p2p.ErrAddPairPeer {
+	if err := pm.peers.Register(p); err != nil {
 		p.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}
 	defer pm.removePeer(p.id)
-	if err != p2p.ErrAddPairPeer {
-		// Register the peer in the downloader. If the downloader considers it banned, we disconnect
-		if err := pm.downloader.RegisterPeer(p.id, p.version, p); err != nil {
+	// Register the peer in the downloader. If the downloader considers it banned, we disconnect
+	if err := pm.downloader.RegisterPeer(p.id, p.version, p); err != nil {
+		return err
+	}
+	p.Log().Info("Register peer", "nodeid", p.ID().String(), "version", p.version, "addr", p.RemoteAddr())
+	// Propagate existing transactions. new transactions appearing
+	// after this will be sent via broadcasts.
+	pm.syncTransactions(p)
+
+	// If we're DAO hard-fork aware, validate any remote peer with regard to the hard-fork
+	if daoBlock := pm.blockchain.Config().DAOForkBlock; daoBlock != nil {
+		// Request the peer's DAO fork header for extra-data validation
+		if err := p.RequestHeadersByNumber(daoBlock.Uint64(), 1, 0, false); err != nil {
 			return err
 		}
-		p.Log().Info("Register peer", "nodeid", p.ID().String(), "version", p.version, "addr", p.RemoteAddr())
-		// Propagate existing transactions. new transactions appearing
-		// after this will be sent via broadcasts.
-		pm.syncTransactions(p)
-
-		// If we're DAO hard-fork aware, validate any remote peer with regard to the hard-fork
-		if daoBlock := pm.blockchain.Config().DAOForkBlock; daoBlock != nil {
-			// Request the peer's DAO fork header for extra-data validation
-			if err := p.RequestHeadersByNumber(daoBlock.Uint64(), 1, 0, false); err != nil {
-				return err
+		// Start a timer to disconnect if the peer doesn't reply in time
+		p.forkDrop = time.AfterFunc(daoChallengeTimeout, func() {
+			p.Log().Debug("Timed out DAO fork-check, dropping")
+			pm.removePeer(p.id)
+		})
+		// Make sure it's cleaned up if the peer dies off
+		defer func() {
+			if p.forkDrop != nil {
+				p.forkDrop.Stop()
+				p.forkDrop = nil
 			}
-			// Start a timer to disconnect if the peer doesn't reply in time
-			p.forkDrop = time.AfterFunc(daoChallengeTimeout, func() {
-				p.Log().Debug("Timed out DAO fork-check, dropping")
-				pm.removePeer(p.id)
-			})
-			// Make sure it's cleaned up if the peer dies off
-			defer func() {
-				if p.forkDrop != nil {
-					p.forkDrop.Stop()
-					p.forkDrop = nil
-				}
-			}()
-		}
+		}()
 	}
 	// main loop. handle incoming messages.
 	for {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -17,9 +17,9 @@
 package eth
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -63,6 +63,8 @@ func errResp(code errCode, format string, v ...interface{}) error {
 type ProtocolManager struct {
 	networkId uint64
 
+	stopping uint32
+
 	snapSync  uint32 // Flag whether snap sync is enabled (gets disabled if we already have blocks)
 	acceptTxs uint32 // Flag whether we're considered synchronised (enables transaction processing)
 
@@ -95,6 +97,8 @@ type ProtocolManager struct {
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
 	wg             sync.WaitGroup
+	handlerLock    sync.Mutex
+	registeredLive map[string]registeredPeerHandler
 	knownTxs       *lru.Cache[common.Hash, struct{}]
 	knowOrderTxs   *lru.Cache[common.Hash, struct{}]
 	knowLendingTxs *lru.Cache[common.Hash, struct{}]
@@ -103,6 +107,11 @@ type ProtocolManager struct {
 	knownVotes     *lru.Cache[common.Hash, struct{}]
 	knownSyncInfos *lru.Cache[common.Hash, struct{}]
 	knownTimeouts  *lru.Cache[common.Hash, struct{}]
+}
+
+type registeredPeerHandler struct {
+	peer  *peer
+	stage string
 }
 
 // NewProtocolManagerEx add order pool to protocol
@@ -263,6 +272,193 @@ func (pm *ProtocolManager) removePeer(id string) {
 	}
 	// Hard disconnect at the networking layer
 	peer.Peer.Disconnect(p2p.DiscUselessPeer)
+	closePeerReadWriter(peer.rw)
+	log.Info("Ethereum peer removal forced close", "peer", id, "remote", peer.RemoteAddr())
+}
+
+func registeredPeerHandlerKey(p *peer) string {
+	return p.id + "|" + p.RemoteAddr().String()
+}
+
+func (pm *ProtocolManager) trackRegisteredPeerHandler(p *peer, stage string) {
+	pm.handlerLock.Lock()
+	defer pm.handlerLock.Unlock()
+
+	if pm.registeredLive == nil {
+		pm.registeredLive = make(map[string]registeredPeerHandler)
+	}
+	pm.registeredLive[registeredPeerHandlerKey(p)] = registeredPeerHandler{peer: p, stage: stage}
+}
+
+func (pm *ProtocolManager) updateRegisteredPeerHandlerStage(p *peer, stage string) {
+	pm.handlerLock.Lock()
+	defer pm.handlerLock.Unlock()
+
+	if pm.registeredLive == nil {
+		return
+	}
+	key := registeredPeerHandlerKey(p)
+	handler, ok := pm.registeredLive[key]
+	if !ok {
+		return
+	}
+	handler.stage = stage
+	pm.registeredLive[key] = handler
+}
+
+func (pm *ProtocolManager) untrackRegisteredPeerHandler(p *peer) {
+	pm.handlerLock.Lock()
+	defer pm.handlerLock.Unlock()
+
+	if pm.registeredLive == nil {
+		return
+	}
+	delete(pm.registeredLive, registeredPeerHandlerKey(p))
+}
+
+func (pm *ProtocolManager) snapshotRegisteredPeerHandlers() []registeredPeerHandler {
+	pm.handlerLock.Lock()
+	defer pm.handlerLock.Unlock()
+
+	handlers := make([]registeredPeerHandler, 0, len(pm.registeredLive))
+	for _, handler := range pm.registeredLive {
+		handlers = append(handlers, handler)
+	}
+	sort.Slice(handlers, func(i, j int) bool {
+		if handlers[i].peer.id == handlers[j].peer.id {
+			return handlers[i].peer.RemoteAddr().String() < handlers[j].peer.RemoteAddr().String()
+		}
+		return handlers[i].peer.id < handlers[j].peer.id
+	})
+	return handlers
+}
+
+func closePeerReadWriter(rw p2p.MsgReadWriter) {
+	if closer, ok := rw.(interface{ Close() error }); ok {
+		_ = closer.Close()
+	}
+}
+
+func (pm *ProtocolManager) disconnectRegisteredPeerHandlers() {
+	for _, handler := range pm.snapshotRegisteredPeerHandlers() {
+		handler.peer.Disconnect(p2p.DiscQuitting)
+		closePeerReadWriter(handler.peer.rw)
+	}
+}
+
+func (pm *ProtocolManager) logRegisteredPeerHandlers(prefix string) {
+	for _, handler := range pm.snapshotRegisteredPeerHandlers() {
+		log.Info(prefix, "peer", handler.peer.id, "remote", handler.peer.RemoteAddr(), "stage", handler.stage)
+	}
+}
+
+func (pm *ProtocolManager) shouldAbortRequestDuringShutdown(msgCode uint64) bool {
+	if atomic.LoadUint32(&pm.stopping) == 0 {
+		return false
+	}
+	switch msgCode {
+	case GetBlockHeadersMsg, GetBlockBodiesMsg:
+		return true
+	case GetNodeDataMsg, GetReceiptsMsg:
+		return true
+	default:
+		return false
+	}
+}
+
+func (pm *ProtocolManager) collectHeadersForQuery(query *getBlockHeadersData, getHeaderByHash func(common.Hash) *types.Header, getHeaderByNumber func(uint64) *types.Header, getHashesFromHash func(common.Hash, uint64) []common.Hash) ([]*types.Header, error) {
+	hashMode := query.Origin.Hash != (common.Hash{})
+	var (
+		bytes   common.StorageSize
+		headers []*types.Header
+		unknown bool
+	)
+	for !unknown && len(headers) < int(query.Amount) && bytes < softResponseLimit && len(headers) < downloader.MaxHeaderFetch {
+		if pm.shouldAbortRequestDuringShutdown(GetBlockHeadersMsg) {
+			return nil, p2p.DiscQuitting
+		}
+		var origin *types.Header
+		if hashMode {
+			origin = getHeaderByHash(query.Origin.Hash)
+		} else {
+			origin = getHeaderByNumber(query.Origin.Number)
+		}
+		if pm.shouldAbortRequestDuringShutdown(GetBlockHeadersMsg) {
+			return nil, p2p.DiscQuitting
+		}
+		if origin == nil {
+			break
+		}
+		number := origin.Number.Uint64()
+		headers = append(headers, origin)
+		bytes += estHeaderRlpSize
+
+		switch {
+		case query.Origin.Hash != (common.Hash{}) && query.Reverse:
+			for i := 0; i < int(query.Skip)+1; i++ {
+				if header := getHeaderByHash(query.Origin.Hash); header != nil {
+					query.Origin.Hash = header.ParentHash
+					number--
+				} else {
+					unknown = true
+					break
+				}
+			}
+		case query.Origin.Hash != (common.Hash{}) && !query.Reverse:
+			var (
+				current = origin.Number.Uint64()
+				next    = current + query.Skip + 1
+			)
+			if next <= current {
+				unknown = true
+			} else {
+				if header := getHeaderByNumber(next); header != nil {
+					if getHashesFromHash(header.Hash(), query.Skip+1)[query.Skip] == query.Origin.Hash {
+						query.Origin.Hash = header.Hash()
+					} else {
+						unknown = true
+					}
+				} else {
+					unknown = true
+				}
+			}
+		case query.Reverse:
+			if query.Origin.Number >= query.Skip+1 {
+				query.Origin.Number -= query.Skip + 1
+			} else {
+				unknown = true
+			}
+		case !query.Reverse:
+			query.Origin.Number += query.Skip + 1
+		}
+	}
+	return headers, nil
+}
+
+func (pm *ProtocolManager) collectBodiesForRequest(msgStream *rlp.Stream, getBodyRLP func(common.Hash) rlp.RawValue) ([]rlp.RawValue, error) {
+	var (
+		hash   common.Hash
+		bytes  int
+		bodies []rlp.RawValue
+	)
+	for bytes < softResponseLimit && len(bodies) < downloader.MaxBlockFetch {
+		if pm.shouldAbortRequestDuringShutdown(GetBlockBodiesMsg) {
+			return nil, p2p.DiscQuitting
+		}
+		if err := msgStream.Decode(&hash); err == rlp.EOL {
+			break
+		} else if err != nil {
+			return nil, errResp(ErrDecode, "stream decode: %v", err)
+		}
+		if pm.shouldAbortRequestDuringShutdown(GetBlockBodiesMsg) {
+			return nil, p2p.DiscQuitting
+		}
+		if data := getBodyRLP(hash); len(data) != 0 {
+			bodies = append(bodies, data)
+			bytes += len(data)
+		}
+	}
+	return bodies, nil
 }
 
 func (pm *ProtocolManager) Start(maxPeers int) {
@@ -293,6 +489,7 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 
 func (pm *ProtocolManager) Stop() {
 	log.Info("Stopping Ethereum protocol")
+	atomic.StoreUint32(&pm.stopping, 1)
 
 	pm.txsSub.Unsubscribe() // quits txBroadcastLoop
 	if pm.orderTxSub != nil {
@@ -305,19 +502,29 @@ func (pm *ProtocolManager) Stop() {
 
 	// Quit the sync loop.
 	// After this send has completed, no new peers will be accepted.
+	log.Info("Ethereum protocol stop: signaling sync loop", "peerCount", pm.peers.Len(), "registeredHandlers", len(pm.snapshotRegisteredPeerHandlers()))
 	pm.noMorePeers <- struct{}{}
+	log.Info("Ethereum protocol stop: sync loop signaled")
 
 	// Quit fetcher, txsyncLoop.
+	log.Info("Ethereum protocol stop: closing quitSync")
 	close(pm.quitSync)
+	log.Info("Ethereum protocol stop: quitSync closed")
 
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.
 	// sessions which are already established but not added to pm.peers yet
 	// will exit when they try to register.
+	log.Info("Ethereum protocol stop: disconnecting peerSet", "peerCount", pm.peers.Len(), "registeredHandlers", len(pm.snapshotRegisteredPeerHandlers()))
 	pm.peers.Close()
+	pm.disconnectRegisteredPeerHandlers()
+	log.Info("Ethereum protocol stop: peerSet disconnected")
 
 	// Wait for all peer handler goroutines and the loops to come down.
+	log.Info("Ethereum protocol stop: waiting for goroutines", "registeredHandlers", len(pm.snapshotRegisteredPeerHandlers()))
+	pm.logRegisteredPeerHandlers("Ethereum protocol stop: active registered handler")
 	pm.wg.Wait()
+	log.Info("Ethereum protocol stop: goroutines exited", "registeredHandlers", len(pm.snapshotRegisteredPeerHandlers()))
 
 	log.Info("Ethereum protocol stopped")
 }
@@ -355,7 +562,11 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		p.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}
-	defer pm.removePeer(p.id)
+	pm.trackRegisteredPeerHandler(p, "registered")
+	defer func() {
+		pm.untrackRegisteredPeerHandler(p)
+		pm.removePeer(p.id)
+	}()
 	// Register the peer in the downloader. If the downloader considers it banned, we disconnect
 	if err := pm.downloader.RegisterPeer(p.id, p.version, p); err != nil {
 		return err
@@ -396,13 +607,36 @@ func (pm *ProtocolManager) handle(p *peer) error {
 // handleMsg is invoked whenever an inbound message is received from a remote
 // peer. The remote connection is torn down upon returning any error.
 func (pm *ProtocolManager) handleMsg(p *peer) error {
+	pm.updateRegisteredPeerHandlerStage(p, "waiting_read_msg")
+	if atomic.LoadUint32(&pm.stopping) == 1 {
+		p.Log().Info("Ethereum peer waiting for message during shutdown", "peer", p.id, "remote", p.RemoteAddr())
+	}
 	// Read the next message from the remote peer, and ensure it's fully consumed
 	msg, err := p.rw.ReadMsg()
 	if err != nil {
+		if atomic.LoadUint32(&pm.stopping) == 1 {
+			p.Log().Info("Ethereum peer read message returned during shutdown", "peer", p.id, "remote", p.RemoteAddr(), "err", err)
+		}
 		return err
+	}
+	pm.updateRegisteredPeerHandlerStage(p, fmt.Sprintf("handling_msg_%d", msg.Code))
+	if atomic.LoadUint32(&pm.stopping) == 1 {
+		p.Log().Info("Ethereum peer received message during shutdown", "peer", p.id, "remote", p.RemoteAddr(), "code", msg.Code, "size", msg.Size)
 	}
 	if msg.Size > protocolMaxMsgSize {
 		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, protocolMaxMsgSize)
+	}
+	if atomic.LoadUint32(&pm.stopping) == 1 {
+		switch msg.Code {
+		case GetBlockHeadersMsg, GetBlockBodiesMsg:
+			p.Log().Info("Ethereum peer aborting request during shutdown", "peer", p.id, "remote", p.RemoteAddr(), "code", msg.Code)
+			return p2p.DiscQuitting
+		case GetNodeDataMsg, GetReceiptsMsg:
+			if p.version >= eth63 {
+				p.Log().Info("Ethereum peer aborting request during shutdown", "peer", p.id, "remote", p.RemoteAddr(), "code", msg.Code)
+				return p2p.DiscQuitting
+			}
+		}
 	}
 	defer msg.Discard()
 
@@ -419,75 +653,17 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if err := msg.Decode(&query); err != nil {
 			return errResp(ErrDecode, "%v: %v", msg, err)
 		}
-		hashMode := query.Origin.Hash != (common.Hash{})
-
-		// Gather headers until the fetch or network limits is reached
-		var (
-			bytes   common.StorageSize
-			headers []*types.Header
-			unknown bool
+		headers, err := pm.collectHeadersForQuery(
+			&query,
+			pm.blockchain.GetHeaderByHash,
+			pm.blockchain.GetHeaderByNumber,
+			pm.blockchain.GetBlockHashesFromHash,
 		)
-		for !unknown && len(headers) < int(query.Amount) && bytes < softResponseLimit && len(headers) < downloader.MaxHeaderFetch {
-			// Retrieve the next header satisfying the query
-			var origin *types.Header
-			if hashMode {
-				origin = pm.blockchain.GetHeaderByHash(query.Origin.Hash)
-			} else {
-				origin = pm.blockchain.GetHeaderByNumber(query.Origin.Number)
+		if err != nil {
+			if err == p2p.DiscQuitting {
+				p.Log().Info("Ethereum peer aborting request during shutdown", "peer", p.id, "remote", p.RemoteAddr(), "code", msg.Code)
 			}
-			if origin == nil {
-				break
-			}
-			number := origin.Number.Uint64()
-			headers = append(headers, origin)
-			bytes += estHeaderRlpSize
-
-			// Advance to the next header of the query
-			switch {
-			case query.Origin.Hash != (common.Hash{}) && query.Reverse:
-				// Hash based traversal towards the genesis block
-				for i := 0; i < int(query.Skip)+1; i++ {
-					if header := pm.blockchain.GetHeader(query.Origin.Hash, number); header != nil {
-						query.Origin.Hash = header.ParentHash
-						number--
-					} else {
-						unknown = true
-						break
-					}
-				}
-			case query.Origin.Hash != (common.Hash{}) && !query.Reverse:
-				// Hash based traversal towards the leaf block
-				var (
-					current = origin.Number.Uint64()
-					next    = current + query.Skip + 1
-				)
-				if next <= current {
-					infos, _ := json.MarshalIndent(p.Peer.Info(), "", "  ")
-					p.Log().Warn("GetBlockHeaders skip overflow attack", "current", current, "skip", query.Skip, "next", next, "attacker", infos)
-					unknown = true
-				} else {
-					if header := pm.blockchain.GetHeaderByNumber(next); header != nil {
-						if pm.blockchain.GetBlockHashesFromHash(header.Hash(), query.Skip+1)[query.Skip] == query.Origin.Hash {
-							query.Origin.Hash = header.Hash()
-						} else {
-							unknown = true
-						}
-					} else {
-						unknown = true
-					}
-				}
-			case query.Reverse:
-				// Number based traversal towards the genesis block
-				if query.Origin.Number >= query.Skip+1 {
-					query.Origin.Number -= query.Skip + 1
-				} else {
-					unknown = true
-				}
-
-			case !query.Reverse:
-				// Number based traversal towards the leaf block
-				query.Origin.Number += query.Skip + 1
-			}
+			return err
 		}
 		return p.SendBlockHeaders(headers)
 
@@ -550,24 +726,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		if _, err := msgStream.List(); err != nil {
 			return err
 		}
-		// Gather blocks until the fetch or network limits is reached
-		var (
-			hash   common.Hash
-			bytes  int
-			bodies []rlp.RawValue
-		)
-		for bytes < softResponseLimit && len(bodies) < downloader.MaxBlockFetch {
-			// Retrieve the hash of the next block
-			if err := msgStream.Decode(&hash); err == rlp.EOL {
-				break
-			} else if err != nil {
-				return errResp(ErrDecode, "msg %v: %v", msg, err)
+		bodies, err := pm.collectBodiesForRequest(msgStream, pm.blockchain.GetBodyRLP)
+		if err != nil {
+			if err == p2p.DiscQuitting {
+				p.Log().Info("Ethereum peer aborting request during shutdown", "peer", p.id, "remote", p.RemoteAddr(), "code", msg.Code)
 			}
-			// Retrieve the requested block body, stopping if enough was found
-			if data := pm.blockchain.GetBodyRLP(hash); len(data) != 0 {
-				bodies = append(bodies, data)
-				bytes += len(data)
-			}
+			return err
 		}
 		return p.SendBlockBodiesRLP(bodies)
 

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -17,9 +17,11 @@
 package eth
 
 import (
+	"bytes"
 	"math"
 	"math/big"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,8 +37,227 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/eth/ethconfig"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/p2p"
+	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
 	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/XinFinOrg/XDPoSChain/rlp"
 )
+
+func TestProtocolManagerStopReturnsWithRegisteredPeerHandler(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+	pm.Start(10)
+
+	app, net := p2p.MsgPipe()
+	errc := make(chan error, 1)
+	go func() {
+		err := pm.makeProtocol(eth63).Run(p2p.NewPeer(enode.ID{}, "peer", nil), net)
+		errc <- err
+	}()
+
+	var (
+		genesis = pm.blockchain.Genesis()
+		head    = pm.blockchain.CurrentHeader()
+		td      = pm.blockchain.GetTd(head.Hash(), head.Number.Uint64())
+	)
+	msg := &statusData{
+		ProtocolVersion: uint32(eth63),
+		NetworkId:       ethconfig.Defaults.NetworkId,
+		TD:              td,
+		CurrentBlock:    head.Hash(),
+		GenesisBlock:    genesis.Hash(),
+	}
+	if err := p2p.ExpectMsg(app, StatusMsg, msg); err != nil {
+		t.Fatalf("status recv: %v", err)
+	}
+	if err := p2p.Send(app, StatusMsg, msg); err != nil {
+		t.Fatalf("status send: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for pm.peers.Len() != 1 {
+		select {
+		case <-deadline:
+			app.Close()
+			t.Fatal("peer was not registered")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		pm.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		app.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+		}
+		t.Fatal("ProtocolManager.Stop blocked with a registered peer handler waiting on ReadMsg")
+	}
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("expected protocol run to return a shutdown error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("protocol run did not exit")
+	}
+}
+
+func TestRemovePeerReturnsWithRegisteredPeerHandler(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+	pm.Start(10)
+	defer func() {
+		go pm.Stop()
+	}()
+
+	app, net := p2p.MsgPipe()
+	errc := make(chan error, 1)
+	go func() {
+		err := pm.makeProtocol(eth63).Run(p2p.NewPeer(enode.ID{}, "peer", nil), net)
+		errc <- err
+	}()
+
+	var (
+		genesis = pm.blockchain.Genesis()
+		head    = pm.blockchain.CurrentHeader()
+		td      = pm.blockchain.GetTd(head.Hash(), head.Number.Uint64())
+	)
+	msg := &statusData{
+		ProtocolVersion: uint32(eth63),
+		NetworkId:       ethconfig.Defaults.NetworkId,
+		TD:              td,
+		CurrentBlock:    head.Hash(),
+		GenesisBlock:    genesis.Hash(),
+	}
+	if err := p2p.ExpectMsg(app, StatusMsg, msg); err != nil {
+		t.Fatalf("status recv: %v", err)
+	}
+	if err := p2p.Send(app, StatusMsg, msg); err != nil {
+		t.Fatalf("status send: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for pm.peers.Len() != 1 {
+		select {
+		case <-deadline:
+			app.Close()
+			t.Fatal("peer was not registered")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	pm.removePeer("0000000000000000")
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("expected protocol run to return an error after removePeer")
+		}
+	case <-time.After(300 * time.Millisecond):
+		app.Close()
+		select {
+		case <-errc:
+		case <-time.After(2 * time.Second):
+		}
+		t.Fatal("removePeer did not unblock the registered peer handler")
+	}
+}
+
+func TestRequestMessagesAbortDuringShutdown(t *testing.T) {
+	tests := []struct {
+		name string
+		code uint64
+		data interface{}
+	}{
+		{
+			name: "get block headers",
+			code: GetBlockHeadersMsg,
+			data: &getBlockHeadersData{Origin: hashOrNumber{Number: 0}, Amount: 1},
+		},
+		{
+			name: "get block bodies",
+			code: GetBlockBodiesMsg,
+			data: []common.Hash{{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
+			peer, errc := newTestPeer("peer", eth63, pm, true)
+			defer peer.close()
+
+			atomic.StoreUint32(&pm.stopping, 1)
+
+			if err := p2p.Send(peer.app, tt.code, tt.data); err != nil {
+				t.Fatalf("send failed: %v", err)
+			}
+
+			select {
+			case err := <-errc:
+				if err == nil {
+					t.Fatal("expected peer handler to abort during shutdown")
+				}
+			case <-time.After(300 * time.Millisecond):
+				t.Fatal("peer handler did not abort request handling during shutdown")
+			}
+		})
+	}
+}
+
+func TestCollectHeadersForQueryAbortsWhenShutdownStartsMidLoop(t *testing.T) {
+	pm := new(ProtocolManager)
+	query := &getBlockHeadersData{Origin: hashOrNumber{Number: 0}, Amount: 3}
+
+	headers := map[uint64]*types.Header{
+		0: {Number: big.NewInt(0)},
+		1: {Number: big.NewInt(1)},
+		2: {Number: big.NewInt(2)},
+	}
+
+	_, err := pm.collectHeadersForQuery(
+		query,
+		func(common.Hash) *types.Header { return nil },
+		func(number uint64) *types.Header {
+			if number == 0 {
+				atomic.StoreUint32(&pm.stopping, 1)
+			}
+			return headers[number]
+		},
+		func(common.Hash, uint64) []common.Hash { return nil },
+	)
+	if err != p2p.DiscQuitting {
+		t.Fatalf("unexpected error: got %v want %v", err, p2p.DiscQuitting)
+	}
+}
+
+func TestCollectBodiesForRequestAbortsWhenShutdownStartsMidLoop(t *testing.T) {
+	pm := new(ProtocolManager)
+	payload, err := rlp.EncodeToBytes([]common.Hash{{}, common.BytesToHash([]byte{1})})
+	if err != nil {
+		t.Fatalf("failed to encode payload: %v", err)
+	}
+	stream := rlp.NewStream(bytes.NewReader(payload), uint64(len(payload)))
+	if _, err := stream.List(); err != nil {
+		t.Fatalf("failed to open list: %v", err)
+	}
+
+	_, err = pm.collectBodiesForRequest(stream, func(hash common.Hash) rlp.RawValue {
+		atomic.StoreUint32(&pm.stopping, 1)
+		return rlp.RawValue(hash[:])
+	})
+	if err != p2p.DiscQuitting {
+		t.Fatalf("unexpected error: got %v want %v", err, p2p.DiscQuitting)
+	}
+}
 
 // Tests that block headers can be retrieved from a remote chain based on user queries.
 func TestGetBlockHeaders62(t *testing.T) { testGetBlockHeaders(t, 62) }

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -111,7 +111,33 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 }
 
 func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
-	// Account for the data traffic
+	rw.meterOut(msg)
+	// Send the packet to the p2p layer
+	return rw.MsgReadWriter.WriteMsg(msg)
+}
+
+// Compile-time check that meteredMsgReadWriter forwards the priority lane.
+// Without this, a future refactor could silently drop the wrapper back to
+// MsgReadWriter and downgrade BFT consensus messages to the normal lane.
+var _ p2p.PriorityMsgWriter = (*meteredMsgReadWriter)(nil)
+
+// WriteMsgPriority implements p2p.PriorityMsgWriter so that consensus messages
+// retain their priority routing when the metrics wrapper is enabled. The
+// outbound counters are updated identically to WriteMsg before the message is
+// forwarded to the underlying writer's priority lane (falling back to WriteMsg
+// if the underlying writer does not support priorities).
+func (rw *meteredMsgReadWriter) WriteMsgPriority(msg p2p.Msg, high bool) error {
+	rw.meterOut(msg)
+	if pw, ok := rw.MsgReadWriter.(p2p.PriorityMsgWriter); ok {
+		return pw.WriteMsgPriority(msg, high)
+	}
+	return rw.MsgReadWriter.WriteMsg(msg)
+}
+
+// meterOut updates the outbound packet/traffic meters for msg. It is shared
+// between WriteMsg and WriteMsgPriority so both paths produce identical
+// metrics.
+func (rw *meteredMsgReadWriter) meterOut(msg p2p.Msg) {
 	packets, traffic := miscOutPacketsMeter, miscOutTrafficMeter
 	switch {
 	case msg.Code == BlockHeadersMsg:
@@ -133,7 +159,4 @@ func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
 	}
 	packets.Mark(1)
 	traffic.Mark(int64(msg.Size))
-
-	// Send the packet to the p2p layer
-	return rw.MsgReadWriter.WriteMsg(msg)
 }

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -78,6 +78,13 @@ func (rw *meteredMsgReadWriter) Init(version int) {
 	rw.version = version
 }
 
+func (rw *meteredMsgReadWriter) Close() error {
+	if closer, ok := rw.MsgReadWriter.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
 func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	// Read the message and short circuit in case of an error
 	msg, err := rw.MsgReadWriter.ReadMsg()

--- a/eth/metrics_test.go
+++ b/eth/metrics_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 The XDPoSChain Authors
+// This file is part of the XDPoSChain library.
+//
+// The XDPoSChain library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The XDPoSChain library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the XDPoSChain library. If not, see <http://www.gnu.org/licenses/>.
+
+package eth
+
+import (
+	"io"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/p2p"
+)
+
+// priorityRecordingRW records whether the priority lane was used for the
+// last WriteMsg* call on it.
+type priorityRecordingRW struct {
+	last     p2p.Msg
+	high     bool
+	priority bool // true if WriteMsgPriority was called
+}
+
+func (rw *priorityRecordingRW) ReadMsg() (p2p.Msg, error) { return p2p.Msg{}, io.EOF }
+
+func (rw *priorityRecordingRW) WriteMsg(msg p2p.Msg) error {
+	rw.last = msg
+	rw.priority = false
+	return nil
+}
+
+func (rw *priorityRecordingRW) WriteMsgPriority(msg p2p.Msg, high bool) error {
+	rw.last = msg
+	rw.high = high
+	rw.priority = true
+	return nil
+}
+
+// TestMeteredMsgReadWriterForwardsPriority verifies that meteredMsgReadWriter
+// implements p2p.PriorityMsgWriter and forwards priority writes to the
+// underlying writer's high-priority lane. Without this, BFT consensus
+// messages (VoteMsg/TimeoutMsg/SyncInfoMsg) would silently fall back to the
+// normal lane on nodes that have metrics enabled.
+func TestMeteredMsgReadWriterForwardsPriority(t *testing.T) {
+	inner := &priorityRecordingRW{}
+	mrw := &meteredMsgReadWriter{MsgReadWriter: inner}
+	mrw.Init(eth63)
+
+	if _, ok := p2p.MsgReadWriter(mrw).(p2p.PriorityMsgWriter); !ok {
+		t.Fatal("meteredMsgReadWriter does not implement PriorityMsgWriter")
+	}
+
+	if err := p2p.SendPriority(mrw, VoteMsg, []uint{}); err != nil {
+		t.Fatalf("SendPriority: %v", err)
+	}
+	if !inner.priority {
+		t.Fatal("priority lane was not used on inner writer")
+	}
+	if !inner.high {
+		t.Fatal("high flag was not propagated to inner writer")
+	}
+	if inner.last.Code != VoteMsg {
+		t.Fatalf("code: got %d, want %d", inner.last.Code, VoteMsg)
+	}
+}
+
+// nonPriorityRW only implements p2p.MsgReadWriter and is used to verify the
+// fallback path in meteredMsgReadWriter.WriteMsgPriority.
+type nonPriorityRW struct {
+	last p2p.Msg
+}
+
+func (rw *nonPriorityRW) ReadMsg() (p2p.Msg, error) { return p2p.Msg{}, io.EOF }
+func (rw *nonPriorityRW) WriteMsg(msg p2p.Msg) error {
+	rw.last = msg
+	return nil
+}
+
+func TestMeteredMsgReadWriterPriorityFallback(t *testing.T) {
+	inner := &nonPriorityRW{}
+	mrw := &meteredMsgReadWriter{MsgReadWriter: inner}
+	mrw.Init(eth63)
+
+	if err := mrw.WriteMsgPriority(p2p.Msg{Code: VoteMsg}, true); err != nil {
+		t.Fatalf("WriteMsgPriority: %v", err)
+	}
+	if inner.last.Code != VoteMsg {
+		t.Fatalf("code: got %d, want %d", inner.last.Code, VoteMsg)
+	}
+}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -59,8 +59,7 @@ type peer struct {
 	id string
 
 	*p2p.Peer
-	rw     p2p.MsgReadWriter
-	pairRw p2p.MsgReadWriter
+	rw p2p.MsgReadWriter
 
 	version  int         // Protocol version negotiated
 	forkDrop *time.Timer // Timed connection dropper if forks aren't validated in time
@@ -262,59 +261,35 @@ func (p *peer) SendNewBlock(block *types.Block, td *big.Int) error {
 	}
 
 	p.knownBlocks.Add(block.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, NewBlockMsg, []interface{}{block, td})
-	} else {
-		return p2p.Send(p.rw, NewBlockMsg, []interface{}{block, td})
-	}
+	return p2p.Send(p.rw, NewBlockMsg, []interface{}{block, td})
 }
 
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *peer) SendBlockHeaders(headers []*types.Header) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, BlockHeadersMsg, headers)
-	} else {
-		return p2p.Send(p.rw, BlockHeadersMsg, headers)
-	}
+	return p2p.Send(p.rw, BlockHeadersMsg, headers)
 }
 
 // SendBlockBodies sends a batch of block contents to the remote peer.
 func (p *peer) SendBlockBodies(bodies []*blockBody) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, BlockBodiesMsg, blockBodiesData(bodies))
-	} else {
-		return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
-	}
+	return p2p.Send(p.rw, BlockBodiesMsg, blockBodiesData(bodies))
 }
 
 // SendBlockBodiesRLP sends a batch of block contents to the remote peer from
 // an already RLP encoded format.
 func (p *peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, BlockBodiesMsg, bodies)
-	} else {
-		return p2p.Send(p.rw, BlockBodiesMsg, bodies)
-	}
+	return p2p.Send(p.rw, BlockBodiesMsg, bodies)
 }
 
 // SendNodeDataRLP sends a batch of arbitrary internal data, corresponding to the
 // hashes requested.
 func (p *peer) SendNodeData(data [][]byte) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, NodeDataMsg, data)
-	} else {
-		return p2p.Send(p.rw, NodeDataMsg, data)
-	}
+	return p2p.Send(p.rw, NodeDataMsg, data)
 }
 
 // SendReceiptsRLP sends a batch of transaction receipts, corresponding to the
 // ones requested from an already RLP encoded format.
 func (p *peer) SendReceiptsRLP(receipts []rlp.RawValue) error {
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, ReceiptsMsg, receipts)
-	} else {
-		return p2p.Send(p.rw, ReceiptsMsg, receipts)
-	}
+	return p2p.Send(p.rw, ReceiptsMsg, receipts)
 }
 
 func (p *peer) SendVote(vote *types.Vote) error {
@@ -323,11 +298,7 @@ func (p *peer) SendVote(vote *types.Vote) error {
 	}
 
 	p.knownVote.Add(vote.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, VoteMsg, vote)
-	} else {
-		return p2p.Send(p.rw, VoteMsg, vote)
-	}
+	return p2p.SendPriority(p.rw, VoteMsg, vote)
 }
 
 /*
@@ -341,11 +312,7 @@ func (p *peer) SendTimeout(timeout *types.Timeout) error {
 	}
 
 	p.knownTimeout.Add(timeout.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, TimeoutMsg, timeout)
-	} else {
-		return p2p.Send(p.rw, TimeoutMsg, timeout)
-	}
+	return p2p.SendPriority(p.rw, TimeoutMsg, timeout)
 }
 
 /*
@@ -359,11 +326,7 @@ func (p *peer) SendSyncInfo(syncInfo *types.SyncInfo) error {
 	}
 
 	p.knownSyncInfo.Add(syncInfo.Hash())
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, SyncInfoMsg, syncInfo)
-	} else {
-		return p2p.Send(p.rw, SyncInfoMsg, syncInfo)
-	}
+	return p2p.SendPriority(p.rw, SyncInfoMsg, syncInfo)
 }
 
 /*
@@ -376,65 +339,41 @@ func (p *peer) AsyncSendSyncInfo() {
 // single header. It is used solely by the fetcher.
 func (p *peer) RequestOneHeader(hash common.Hash) error {
 	p.Log().Debug("Fetching single header", "hash", hash)
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
-	} else {
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
-	}
+	return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: hash}, Amount: uint64(1), Skip: uint64(0), Reverse: false})
 }
 
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *peer) RequestHeadersByHash(origin common.Hash, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromhash", origin, "skip", skip, "reverse", reverse)
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	} else {
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	}
+	return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Hash: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
 }
 
 // RequestHeadersByNumber fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the number of an origin block.
 func (p *peer) RequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromnum", origin, "skip", skip, "reverse", reverse)
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	} else {
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
-	}
+	return p2p.Send(p.rw, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: origin}, Amount: uint64(amount), Skip: uint64(skip), Reverse: reverse})
 }
 
 // RequestBodies fetches a batch of blocks' bodies corresponding to the hashes
 // specified.
 func (p *peer) RequestBodies(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of block bodies", "count", len(hashes))
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetBlockBodiesMsg, hashes)
-	} else {
-		return p2p.Send(p.rw, GetBlockBodiesMsg, hashes)
-	}
+	return p2p.Send(p.rw, GetBlockBodiesMsg, hashes)
 }
 
 // RequestNodeData fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
 func (p *peer) RequestNodeData(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of state data", "count", len(hashes))
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetNodeDataMsg, hashes)
-	} else {
-		return p2p.Send(p.rw, GetNodeDataMsg, hashes)
-	}
+	return p2p.Send(p.rw, GetNodeDataMsg, hashes)
 }
 
 // RequestReceipts fetches a batch of transaction receipts from a remote node.
 func (p *peer) RequestReceipts(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of receipts", "count", len(hashes))
-	if p.pairRw != nil {
-		return p2p.Send(p.pairRw, GetReceiptsMsg, hashes)
-	} else {
-		return p2p.Send(p.rw, GetReceiptsMsg, hashes)
-	}
+	return p2p.Send(p.rw, GetReceiptsMsg, hashes)
 }
 
 // Handshake executes the eth protocol handshake, negotiating version number,
@@ -530,14 +469,8 @@ func (ps *peerSet) Register(p *peer) error {
 	if ps.closed {
 		return errClosed
 	}
-	if existPeer, ok := ps.peers[p.id]; ok {
-		if existPeer.pairRw != nil {
-			return errAlreadyRegistered
-		}
-		existPeer.SetPairPeer(p.Peer)
-		existPeer.pairRw = p.rw
-		p.SetPairPeer(existPeer.Peer)
-		return p2p.ErrAddPairPeer
+	if _, ok := ps.peers[p.id]; ok {
+		return errAlreadyRegistered
 	}
 	ps.peers[p.id] = p
 	return nil

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -266,10 +266,7 @@ func (s *dialstate) checkDial(n *enode.Node, peers map[enode.ID]*Peer) error {
 	case dialing:
 		return errAlreadyDialing
 	case peers[n.ID()] != nil:
-		existPeer := peers[n.ID()]
-		if existPeer.PairPeer() != nil {
-			return errAlreadyConnected
-		}
+		return errAlreadyConnected
 	case n.ID() == s.self:
 		return errSelf
 	case s.netrestrict != nil && !s.netrestrict.Contains(n.IP()):
@@ -305,22 +302,6 @@ func (t *dialTask) Do(srv *Server) {
 			if t.resolve(srv) {
 				t.dial(srv, t.dest)
 			}
-		}
-	}
-	if err == nil {
-		err = t.dial(srv, t.dest)
-		if err != nil {
-			// Try resolving the ID of static nodes if dialing failed.
-			if _, ok := err.(*dialError); ok && t.flags&staticDialedConn != 0 {
-				if t.resolve(srv) {
-					err = t.dial(srv, t.dest)
-				}
-			}
-		}
-		if err == nil {
-			log.Trace("Dial pair connection success", "task", t.dest)
-		} else {
-			log.Trace("Dial pair connection error", "task", t.dest, "err", err)
 		}
 	}
 }

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -52,11 +52,6 @@ func runDialTest(t *testing.T, test dialtest) {
 	pm := func(ps []*Peer) map[enode.ID]*Peer {
 		m := make(map[enode.ID]*Peer)
 		for _, p := range ps {
-			// Generic dialstate scenarios model peers that are already fully occupied.
-			// Pair-connection admission is covered by dedicated tests.
-			if p.PairPeer() == nil {
-				p.SetPairPeer(&Peer{})
-			}
 			m[p.ID()] = p
 		}
 		return m
@@ -708,26 +703,50 @@ func (t *resolveMock) Close()                                {}
 func (t *resolveMock) LookupRandom() []*enode.Node           { return nil }
 func (t *resolveMock) ReadRandomNodes(buf []*enode.Node) int { return 0 }
 
-// This test checks that static dials are launched.
-func TestDialStateCheckDialAllowsSecondConnectionUntilPaired(t *testing.T) {
-	id := uintID(1)
-	state := newDialState(enode.ID{}, nil, nil, fakeTable{}, 10, nil)
-	existing := &Peer{rw: &conn{node: newNode(id, nil)}}
+// countingDialer counts the number of times Dial is invoked. It returns one
+// end of a net.Pipe so that the (test) transport can be set up on top of it
+// without performing any real I/O.
+type countingDialer struct {
+	count int
+}
 
-	err := state.checkDial(newNode(id, nil), map[enode.ID]*Peer{id: existing})
-	if err != nil {
-		t.Fatalf("expected second connection to be allowed before pairing, got %v", err)
+func (d *countingDialer) Dial(*enode.Node) (net.Conn, error) {
+	d.count++
+	c, _ := net.Pipe()
+	return c, nil
+}
+
+// TestDialTaskDoSingleDial verifies that a successful dial does not trigger a
+// second "pair" dial against the same node. The legacy XDPoSChain dialer used
+// to open two TCP connections per peer; the dual-connection behaviour has been
+// removed and the upstream single-connection semantics restored.
+func TestDialTaskDoSingleDial(t *testing.T) {
+	remkey := newkey()
+	srv := startTestServer(t, &remkey.PublicKey, func(p *Peer) {})
+	defer srv.Stop()
+
+	dialer := &countingDialer{}
+	srv.Dialer = dialer
+
+	task := &dialTask{
+		flags: dynDialedConn,
+		dest:  enode.NewV4(&remkey.PublicKey, net.IP{127, 0, 0, 1}, 30303, 30303),
+	}
+	task.Do(srv)
+
+	if dialer.count != 1 {
+		t.Fatalf("Dialer.Dial called %d times, want 1", dialer.count)
 	}
 }
 
-func TestDialStateCheckDialRejectsWhenPaired(t *testing.T) {
+// This test checks that a second connection to an already connected peer is rejected.
+func TestDialStateCheckDialRejectsAlreadyConnectedPeer(t *testing.T) {
 	id := uintID(1)
 	state := newDialState(enode.ID{}, nil, nil, fakeTable{}, 10, nil)
 	existing := &Peer{rw: &conn{node: newNode(id, nil)}}
-	existing.SetPairPeer(&Peer{})
 
 	err := state.checkDial(newNode(id, nil), map[enode.ID]*Peer{id: existing})
 	if err != errAlreadyConnected {
-		t.Fatalf("expected paired peer to reject second connection, got %v", err)
+		t.Fatalf("expected %v, got %v", errAlreadyConnected, err)
 	}
 }

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -722,7 +722,19 @@ func (d *countingDialer) Dial(*enode.Node) (net.Conn, error) {
 // removed and the upstream single-connection semantics restored.
 func TestDialTaskDoSingleDial(t *testing.T) {
 	remkey := newkey()
-	srv := startTestServer(t, &remkey.PublicKey, func(p *Peer) {})
+	srv := &Server{
+		Config: Config{
+			Name:        "test",
+			MaxPeers:    10,
+			NoDiscovery: true,
+			PrivateKey:  newkey(),
+		},
+		newPeerHook:  func(p *Peer) {},
+		newTransport: func(fd net.Conn) transport { return newTestTransport(&remkey.PublicKey, fd) },
+	}
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Could not start server: %v", err)
+	}
 	defer srv.Stop()
 
 	dialer := &countingDialer{}

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -100,6 +100,23 @@ func Send(w MsgWriter, msgcode uint64, data interface{}) error {
 	return w.WriteMsg(Msg{Code: msgcode, Size: uint32(size), Payload: r})
 }
 
+// SendPriority is like Send, but if w implements PriorityMsgWriter the message
+// is routed to the high-priority lane. SendPriority always requests the high
+// lane; callers that want the normal lane should use Send. Writers without
+// priority support fall back to the regular Send path so that callers do not
+// have to know whether the wrapper chain preserves priority.
+func SendPriority(w MsgWriter, msgcode uint64, data interface{}) error {
+	size, r, err := rlp.EncodeToReader(data)
+	if err != nil {
+		return err
+	}
+	msg := Msg{Code: msgcode, Size: uint32(size), Payload: r}
+	if pw, ok := w.(PriorityMsgWriter); ok {
+		return pw.WriteMsgPriority(msg, true)
+	}
+	return w.WriteMsg(msg)
+}
+
 // SendItems writes an RLP with the given code and data elements.
 // For a call such as:
 //
@@ -311,6 +328,33 @@ func (ev *msgEventer) WriteMsg(msg Msg) error {
 	})
 	return nil
 }
+
+// WriteMsgPriority forwards a priority-tagged write to the underlying writer
+// if it implements PriorityMsgWriter, falling back to WriteMsg otherwise. It
+// emits a "message sent" event identical to WriteMsg so that priority and
+// non-priority sends are observable through the same feed.
+func (ev *msgEventer) WriteMsgPriority(msg Msg, high bool) error {
+	var err error
+	if pw, ok := ev.MsgReadWriter.(PriorityMsgWriter); ok {
+		err = pw.WriteMsgPriority(msg, high)
+	} else {
+		err = ev.MsgReadWriter.WriteMsg(msg)
+	}
+	if err != nil {
+		return err
+	}
+	ev.feed.Send(&PeerEvent{
+		Type:     PeerEventTypeMsgSend,
+		Peer:     ev.peerID,
+		Protocol: ev.Protocol,
+		MsgCode:  &msg.Code,
+		MsgSize:  &msg.Size,
+	})
+	return nil
+}
+
+// Compile-time check that msgEventer forwards the PriorityMsgWriter contract.
+var _ PriorityMsgWriter = (*msgEventer)(nil)
 
 // Close closes the underlying MsgReadWriter if it implements the io.Closer
 // interface

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -344,11 +344,13 @@ func (ev *msgEventer) WriteMsgPriority(msg Msg, high bool) error {
 		return err
 	}
 	ev.feed.Send(&PeerEvent{
-		Type:     PeerEventTypeMsgSend,
-		Peer:     ev.peerID,
-		Protocol: ev.Protocol,
-		MsgCode:  &msg.Code,
-		MsgSize:  &msg.Size,
+		Type:          PeerEventTypeMsgSend,
+		Peer:          ev.peerID,
+		Protocol:      ev.Protocol,
+		MsgCode:       &msg.Code,
+		MsgSize:       &msg.Size,
+		LocalAddress:  ev.localAddress,
+		RemoteAddress: ev.remoteAddress,
 	})
 	return nil
 }

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -49,6 +49,17 @@ var (
 	dialUnexpectedIdentity  = metrics.NewRegisteredMeter("p2p/dials/error/id/unexpected", nil)
 	dialEncHandshakeError   = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/enc", nil)
 	dialProtoHandshakeError = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/proto", nil)
+
+	// Per-Peer write queue depth, sampled on every enqueue attempt (depth
+	// measured before the slot is added). Useful for tuning writeReqQueueSize
+	// and for spotting peers whose downstream transport is back-pressuring.
+	writeQueueHiDepth = metrics.NewRegisteredHistogram("p2p/peer/writeq/hi/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
+	writeQueueLoDepth = metrics.NewRegisteredHistogram("p2p/peer/writeq/lo/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
+
+	// Number of enqueue attempts that found the queue already full and had
+	// to block (back-pressure events).
+	writeQueueHiBlocked = metrics.NewRegisteredMeter("p2p/peer/writeq/hi/blocked", nil)
+	writeQueueLoBlocked = metrics.NewRegisteredMeter("p2p/peer/writeq/lo/blocked", nil)
 )
 
 func markDialError(err error) {

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -50,14 +50,15 @@ var (
 	dialEncHandshakeError   = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/enc", nil)
 	dialProtoHandshakeError = metrics.NewRegisteredMeter("p2p/dials/error/rlpx/proto", nil)
 
-	// Per-Peer write queue depth, sampled on every enqueue attempt (depth
-	// measured before the slot is added). Useful for tuning writeReqQueueSize
-	// and for spotting peers whose downstream transport is back-pressuring.
+	// Per-Peer write queue depth, sampled on every enqueue attempt before a
+	// request is admitted to the bounded writer ingress. Useful for tuning
+	// writeReqQueueSize and for spotting peers whose downstream transport is
+	// back-pressuring.
 	writeQueueHiDepth = metrics.NewRegisteredHistogram("p2p/peer/writeq/hi/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
 	writeQueueLoDepth = metrics.NewRegisteredHistogram("p2p/peer/writeq/lo/depth", nil, metrics.NewExpDecaySample(1028, 0.015))
 
-	// Number of enqueue attempts that found the queue already full and had
-	// to block (back-pressure events).
+	// Number of enqueue attempts that found the bounded writer ingress full and
+	// had to block (back-pressure events).
 	writeQueueHiBlocked = metrics.NewRegisteredMeter("p2p/peer/writeq/hi/blocked", nil)
 	writeQueueLoBlocked = metrics.NewRegisteredMeter("p2p/peer/writeq/lo/blocked", nil)
 )

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -102,6 +102,59 @@ type PeerEvent struct {
 	RemoteAddress string        `json:"remote,omitempty"`
 }
 
+// PriorityMsgWriter is an optional interface implemented by MsgWriters that
+// support two-level write priority. Messages marked as high priority preempt
+// normal-priority messages at the next write boundary on the underlying
+// transport (in-flight writes are never interrupted).
+//
+// Any MsgReadWriter that wraps another writer (for example msgEventer or
+// eth.meteredMsgReadWriter) MUST also implement PriorityMsgWriter and forward
+// the priority flag to the inner writer. Otherwise SendPriority will silently
+// fall back to the normal-priority lane on connections that go through the
+// wrapper, defeating the BFT latency guarantee for consensus messages.
+type PriorityMsgWriter interface {
+	MsgWriter
+	// WriteMsgPriority writes msg through the underlying transport. If high
+	// is true, the message is queued on the high-priority lane and will be
+	// served before any pending low-priority writes.
+	WriteMsgPriority(msg Msg, high bool) error
+}
+
+// writePriorityStarveLimit bounds the number of consecutive high-priority
+// writes that may be served before a pending low-priority write is forced
+// through. This prevents low-priority traffic (block bodies, transactions)
+// from being starved by a constant stream of high-priority messages.
+const writePriorityStarveLimit = 16
+
+// writeReqQueueSize is the capacity of the per-priority write request queues.
+// A buffered queue lets concurrent writers enqueue while the arbiter is busy
+// with an in-flight transport write, which is required for the priority bias
+// to take effect. When the queue is full, additional writers block (yielding
+// back-pressure equivalent to the single-token scheduler).
+//
+// The 128 default is sized to absorb a burst from all eth-protocol writers
+// on a single peer without blocking: a small constant set of consensus
+// senders (VoteMsg / TimeoutMsg / SyncInfoMsg) on the hi lane, plus the
+// tx-broadcast loop, block-propagation loop, header/body fetcher responses,
+// and downloader requests on the lo lane. In practice steady-state depth
+// should stay in single digits; sustained depths above a few dozen indicate
+// a slow downstream transport rather than producer bursts.
+//
+// The depth distribution and back-pressure rate are exposed as metrics
+// (p2p/peer/writeq/{hi,lo}/{depth,blocked}); use them to verify whether this
+// constant needs tuning under real load.
+const writeReqQueueSize = 128
+
+// writeSlot is a single-use handshake between a protoRW writer and the
+// per-Peer write arbiter in Peer.run. The writer enqueues a slot on either
+// the high- or low-priority request channel and waits for the arbiter to
+// grant the slot by closing proceed. The writer then performs the actual
+// transport write and reports the result on done.
+type writeSlot struct {
+	proceed chan struct{} // arbiter closes this to grant the write slot
+	done    chan error    // writer reports the write result (buffered, len 1)
+}
+
 // Peer represents a connected remote node.
 type Peer struct {
 	rw      *conn
@@ -115,11 +168,15 @@ type Peer struct {
 	pingRecv chan struct{}
 	disc     chan DiscReason
 
+	// Write arbitration: protoRW writers submit writeSlot requests on hiReq
+	// (high priority) or loReq (low priority). Peer.run picks one, grants
+	// it, waits for completion, then schedules the next. These channels are
+	// created in newPeer and never reassigned afterwards.
+	hiReq chan *writeSlot
+	loReq chan *writeSlot
+
 	// events receives message send / receive events if set
 	events *event.Feed
-
-	pairPeerMu sync.RWMutex
-	pairPeer   *Peer
 }
 
 // NewPeer returns a peer for testing purposes.
@@ -193,6 +250,8 @@ func newPeer(conn *conn, protocols []Protocol) *Peer {
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
 		pingRecv: make(chan struct{}, 16),
+		hiReq:    make(chan *writeSlot, writeReqQueueSize),
+		loReq:    make(chan *writeSlot, writeReqQueueSize),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
 	}
 	return p
@@ -202,56 +261,105 @@ func (p *Peer) Log() log.Logger {
 	return p.log
 }
 
-func (p *Peer) PairPeer() *Peer {
-	p.pairPeerMu.RLock()
-	defer p.pairPeerMu.RUnlock()
-
-	return p.pairPeer
-}
-
-func (p *Peer) SetPairPeer(pair *Peer) {
-	p.pairPeerMu.Lock()
-	p.pairPeer = pair
-	p.pairPeerMu.Unlock()
-}
-
-func (p *Peer) ClearPairPeer(pair *Peer) bool {
-	p.pairPeerMu.Lock()
-	defer p.pairPeerMu.Unlock()
-
-	if p.pairPeer != pair {
-		return false
-	}
-	p.pairPeer = nil
-	return true
-}
-
 func (p *Peer) run() (remoteRequested bool, err error) {
 	var (
-		writeStart = make(chan struct{}, 1)
-		writeErr   = make(chan error, 1)
 		readErr    = make(chan error, 1)
 		reason     DiscReason // sent to the peer
+		activeDone chan error // non-nil while a write is in flight
+		hiStreak   int        // consecutive hi-priority writes since the last lo
 	)
 	p.wg.Go(func() { p.readLoop(readErr) })
 	p.wg.Go(p.pingLoop)
 
 	// Start all protocol handlers.
-	writeStart <- struct{}{}
-	p.startProtocols(writeStart, writeErr)
+	p.startProtocols()
 
-	// Wait for an error or disconnect.
+	// Write arbiter loop, folded into the main select. The arbiter accepts
+	// writeSlot requests only when no write is currently in flight
+	// (activeDone == nil), prefers hi over lo, and enforces a starvation
+	// guard that biases lo every writePriorityStarveLimit consecutive hi.
+	//
+	// Note: the hi-over-lo preference is best-effort, not strict. It is
+	// strictly honoured only by the non-blocking probe at the top of the
+	// loop body. In the blocking select below, if both hiReq and loReq
+	// become ready simultaneously the Go runtime picks one at random; the
+	// next iteration will re-apply the hi bias, so a sustained hi load is
+	// still served ahead of lo on average.
 loop:
 	for {
+		// When no write is in flight, try to pick the next request with a
+		// priority bias before falling into the blocking select.
+		if activeDone == nil {
+			// Control-plane signals must preempt queued writes during teardown.
+			// Otherwise a steady stream of ready write requests can keep this
+			// loop busy long enough to starve Disconnect / read errors.
+			select {
+			case err = <-readErr:
+				if r, ok := err.(DiscReason); ok {
+					remoteRequested = true
+					reason = r
+				} else {
+					reason = DiscNetworkError
+				}
+				break loop
+			case err = <-p.protoErr:
+				reason = discReasonForError(err)
+				break loop
+			case err = <-p.disc:
+				reason = discReasonForError(err)
+				break loop
+			default:
+			}
+
+			if hiStreak >= writePriorityStarveLimit {
+				// Bias toward lo: try lo non-blocking first; if no lo is
+				// pending, fall through to the blocking select that
+				// accepts either.
+				select {
+				case slot := <-p.loReq:
+					close(slot.proceed)
+					activeDone = slot.done
+					hiStreak = 0
+					continue
+				default:
+				}
+			} else {
+				// Bias toward hi: try hi non-blocking first; if no hi is
+				// pending, fall through to the blocking select that
+				// accepts either.
+				select {
+				case slot := <-p.hiReq:
+					close(slot.proceed)
+					activeDone = slot.done
+					hiStreak++
+					continue
+				default:
+				}
+			}
+		}
+
+		// Only enable the request channels when no write is in flight.
+		var hiReq, loReq <-chan *writeSlot
+		if activeDone == nil {
+			hiReq, loReq = p.hiReq, p.loReq
+		}
+
 		select {
-		case err = <-writeErr:
-			// A write finished. Allow the next write to start if
-			// there was no error.
+		case slot := <-hiReq:
+			close(slot.proceed)
+			activeDone = slot.done
+			hiStreak++
+		case slot := <-loReq:
+			close(slot.proceed)
+			activeDone = slot.done
+			hiStreak = 0
+		case err = <-activeDone:
+			// Active write finished. Allow the next one to be scheduled.
+			activeDone = nil
 			if err != nil {
 				reason = DiscNetworkError
 				break loop
 			}
-			writeStart <- struct{}{}
 		case err = <-readErr:
 			if r, ok := err.(DiscReason); ok {
 				remoteRequested = true
@@ -271,9 +379,6 @@ loop:
 	close(p.closed)
 	p.rw.close(reason)
 	p.wg.Wait()
-	if pairPeer := p.PairPeer(); pairPeer != nil {
-		go pairPeer.Disconnect(DiscPairPeerStop)
-	}
 	return remoteRequested, err
 }
 
@@ -284,19 +389,47 @@ func (p *Peer) pingLoop() {
 	for {
 		select {
 		case <-ping.C:
-			if err := SendItems(p.rw, pingMsg); err != nil {
+			if err := p.writeMsg(pingMsg, nil); err != nil {
 				p.protoErr <- err
 				return
 			}
 			ping.Reset(pingInterval)
 
 		case <-p.pingRecv:
-			SendItems(p.rw, pongMsg)
+			_ = p.writeMsg(pongMsg, nil)
 
 		case <-p.closed:
 			return
 		}
 	}
+}
+
+func writeQueuedSlot(reqCh chan<- *writeSlot, closed <-chan struct{}) (*writeSlot, error) {
+	slot := &writeSlot{
+		proceed: make(chan struct{}),
+		done:    make(chan error, 1),
+	}
+	select {
+	case reqCh <- slot:
+	case <-closed:
+		return nil, ErrShuttingDown
+	}
+	return slot, nil
+}
+
+func (p *Peer) writeMsg(code uint64, payload []interface{}) error {
+	slot, err := writeQueuedSlot(p.loReq, p.closed)
+	if err != nil {
+		return err
+	}
+	select {
+	case <-slot.proceed:
+	case <-p.closed:
+		return ErrShuttingDown
+	}
+	err = SendItems(p.rw, code, payload...)
+	slot.done <- err
+	return err
 }
 
 func (p *Peer) readLoop(errc chan<- error) {
@@ -387,11 +520,11 @@ outer:
 	return result
 }
 
-func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error) {
+func (p *Peer) startProtocols() {
 	for _, proto := range p.running {
 		proto.closed = p.closed
-		proto.wstart = writeStart
-		proto.werr = writeErr
+		proto.hiReq = p.hiReq
+		proto.loReq = p.loReq
 		var rw MsgReadWriter = proto
 		if p.events != nil {
 			rw = newMsgEventer(rw, p.events, p.ID(), proto.Name, p.RemoteAddr().String(), p.LocalAddr().String())
@@ -423,15 +556,35 @@ func (p *Peer) getProto(code uint64) (*protoRW, error) {
 
 type protoRW struct {
 	Protocol
-	in     chan Msg        // receices read messages
+	in     chan Msg        // receives read messages
 	closed <-chan struct{} // receives when peer is shutting down
-	wstart <-chan struct{} // receives when write may start
-	werr   chan<- error    // for write results
+	// hiReq/loReq are written once by startProtocols before any concurrent
+	// writer is started and are read-only thereafter. Do not reassign them
+	// from goroutines other than the one that called startProtocols.
+	hiReq  chan<- *writeSlot // high-priority write request queue
+	loReq  chan<- *writeSlot // normal-priority write request queue
 	offset uint64
 	w      MsgWriter
 }
 
-func (rw *protoRW) WriteMsg(msg Msg) (err error) {
+// Compile-time check that protoRW honours the PriorityMsgWriter contract.
+// Wrappers in the chain (msgEventer, eth.meteredMsgReadWriter, ...) MUST do
+// the same; otherwise SendPriority silently falls back to the normal lane.
+var _ PriorityMsgWriter = (*protoRW)(nil)
+
+// WriteMsg writes msg through the underlying transport at normal priority.
+// It implements MsgWriter.
+func (rw *protoRW) WriteMsg(msg Msg) error {
+	return rw.writeMsg(msg, false)
+}
+
+// WriteMsgPriority writes msg through the underlying transport, optionally
+// at high priority. It implements PriorityMsgWriter.
+func (rw *protoRW) WriteMsgPriority(msg Msg, high bool) error {
+	return rw.writeMsg(msg, high)
+}
+
+func (rw *protoRW) writeMsg(msg Msg, high bool) (err error) {
 	if msg.Code >= rw.Length {
 		return newPeerError(errInvalidMsgCode, "not handled")
 	}
@@ -439,17 +592,38 @@ func (rw *protoRW) WriteMsg(msg Msg) (err error) {
 	msg.meterCode = msg.Code
 
 	msg.Code += rw.offset
-	select {
-	case <-rw.wstart:
-		err = rw.w.WriteMsg(msg)
-		// Report write status back to Peer.run. It will initiate
-		// shutdown if the error is non-nil and unblock the next write
-		// otherwise. The calling protocol code should exit for errors
-		// as well but we don't want to rely on that.
-		rw.werr <- err
-	case <-rw.closed:
-		err = ErrShuttingDown
+	reqCh := rw.loReq
+	depthMetric, blockedMetric := writeQueueLoDepth, writeQueueLoBlocked
+	if high {
+		reqCh = rw.hiReq
+		depthMetric, blockedMetric = writeQueueHiDepth, writeQueueHiBlocked
 	}
+	slot, err := writeQueuedSlot(reqCh, rw.closed)
+	if err != nil {
+		return err
+	}
+	// Sample queue depth before enqueue so the histogram reflects the
+	// back-pressure observed by this writer (slots ahead of it), independent
+	// of how quickly the arbiter drains afterwards. This is still a racy
+	// snapshot under concurrent producers, but it is a meaningful upper
+	// bound on what this writer waited behind, whereas sampling after the
+	// send can be drained to ~0 by the arbiter and underreports congestion.
+	depthMetric.Update(int64(len(reqCh)))
+	// Enqueue the request. Try non-blocking first so we can observe
+	// saturation events; on fallback the writer waits like before.
+	if len(reqCh) == cap(reqCh) {
+		blockedMetric.Mark(1)
+	}
+	// Wait for the arbiter to grant the slot.
+	select {
+	case <-slot.proceed:
+	case <-rw.closed:
+		return ErrShuttingDown
+	}
+	// Perform the actual write and report the result. done is buffered, so
+	// this send never blocks; the arbiter consumes it asynchronously.
+	err = rw.w.WriteMsg(msg)
+	slot.done <- err
 	return err
 }
 

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common/mclock"
@@ -145,14 +146,28 @@ const writePriorityStarveLimit = 16
 // constant needs tuning under real load.
 const writeReqQueueSize = 128
 
-// writeSlot is a single-use handshake between a protoRW writer and the
-// per-Peer write arbiter in Peer.run. The writer enqueues a slot on either
-// the high- or low-priority request channel and waits for the arbiter to
-// grant the slot by closing proceed. The writer then performs the actual
-// transport write and reports the result on done.
-type writeSlot struct {
-	proceed chan struct{} // arbiter closes this to grant the write slot
-	done    chan error    // writer reports the write result (buffered, len 1)
+// inflightWriteDrainTimeout bounds how long peer shutdown waits for a single
+// in-flight transport write to complete before forcing teardown to continue.
+// Defaulting to frameWriteTimeout keeps behavior aligned with transport write
+// deadlines while preventing indefinite shutdown stalls.
+var inflightWriteDrainTimeout = frameWriteTimeout
+
+// writeRequest is a single outbound write owned by the peer write arbiter.
+// Writers submit requests through Peer.writeReq and wait for the arbiter to
+// report the final transport result on done.
+type writeRequest struct {
+	msg  Msg
+	high bool
+	done chan error
+	pend *atomic.Int64
+}
+
+func (r *writeRequest) finish(err error) {
+	if r.pend != nil {
+		r.pend.Add(-1)
+		r.pend = nil
+	}
+	r.done <- err
 }
 
 // Peer represents a connected remote node.
@@ -168,12 +183,12 @@ type Peer struct {
 	pingRecv chan struct{}
 	disc     chan DiscReason
 
-	// Write arbitration: protoRW writers submit writeSlot requests on hiReq
-	// (high priority) or loReq (low priority). Peer.run picks one, grants
-	// it, waits for completion, then schedules the next. These channels are
-	// created in newPeer and never reassigned afterwards.
-	hiReq chan *writeSlot
-	loReq chan *writeSlot
+	// Write arbitration: writers submit requests on writeReq. Peer.run owns
+	// the internal high- and low-priority queues and decides which request
+	// reaches the transport next.
+	writeReq chan *writeRequest
+	hiPend   atomic.Int64
+	loPend   atomic.Int64
 
 	// events receives message send / receive events if set
 	events *event.Feed
@@ -250,8 +265,7 @@ func newPeer(conn *conn, protocols []Protocol) *Peer {
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
 		pingRecv: make(chan struct{}, 16),
-		hiReq:    make(chan *writeSlot, writeReqQueueSize),
-		loReq:    make(chan *writeSlot, writeReqQueueSize),
+		writeReq: make(chan *writeRequest, writeReqQueueSize),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
 	}
 	return p
@@ -265,8 +279,11 @@ func (p *Peer) run() (remoteRequested bool, err error) {
 	var (
 		readErr    = make(chan error, 1)
 		reason     DiscReason // sent to the peer
-		activeDone chan error // non-nil while a write is in flight
+		activeReq  *writeRequest
+		activeDone chan error // non-nil while a transport write is in flight
 		hiStreak   int        // consecutive hi-priority writes since the last lo
+		hiQueue    = newWriteRequestQueue()
+		loQueue    = newWriteRequestQueue()
 	)
 	p.wg.Go(func() { p.readLoop(readErr) })
 	p.wg.Go(p.pingLoop)
@@ -274,25 +291,13 @@ func (p *Peer) run() (remoteRequested bool, err error) {
 	// Start all protocol handlers.
 	p.startProtocols()
 
-	// Write arbiter loop, folded into the main select. The arbiter accepts
-	// writeSlot requests only when no write is currently in flight
-	// (activeDone == nil), prefers hi over lo, and enforces a starvation
-	// guard that biases lo every writePriorityStarveLimit consecutive hi.
-	//
-	// Note: the hi-over-lo preference is best-effort, not strict. It is
-	// strictly honoured only by the non-blocking probe at the top of the
-	// loop body. In the blocking select below, if both hiReq and loReq
-	// become ready simultaneously the Go runtime picks one at random; the
-	// next iteration will re-apply the hi bias, so a sustained hi load is
-	// still served ahead of lo on average.
+	// Write arbiter loop. Writers submit requests through writeReq; the peer
+	// owns the internal per-priority queues and is solely responsible for
+	// choosing the next request that reaches the transport.
 loop:
 	for {
-		// When no write is in flight, try to pick the next request with a
-		// priority bias before falling into the blocking select.
-		if activeDone == nil {
+		if activeReq == nil {
 			// Control-plane signals must preempt queued writes during teardown.
-			// Otherwise a steady stream of ready write requests can keep this
-			// loop busy long enough to starve Disconnect / read errors.
 			select {
 			case err = <-readErr:
 				if r, ok := err.(DiscReason); ok {
@@ -311,51 +316,37 @@ loop:
 			default:
 			}
 
-			if hiStreak >= writePriorityStarveLimit {
-				// Bias toward lo: try lo non-blocking first; if no lo is
-				// pending, fall through to the blocking select that
-				// accepts either.
-				select {
-				case slot := <-p.loReq:
-					close(slot.proceed)
-					activeDone = slot.done
-					hiStreak = 0
-					continue
-				default:
-				}
-			} else {
-				// Bias toward hi: try hi non-blocking first; if no hi is
-				// pending, fall through to the blocking select that
-				// accepts either.
-				select {
-				case slot := <-p.hiReq:
-					close(slot.proceed)
-					activeDone = slot.done
+			drainWriteRequests(p.writeReq, hiQueue, loQueue)
+
+			if req, high := pickNextWriteRequest(hiQueue, loQueue, hiStreak); req != nil {
+				activeReq = req
+				activeDone = make(chan error, 1)
+				if high {
 					hiStreak++
-					continue
-				default:
+				} else {
+					hiStreak = 0
 				}
+				go func(msg Msg) {
+					activeDone <- p.rw.WriteMsg(msg)
+				}(req.msg)
+				continue
 			}
 		}
 
-		// Only enable the request channels when no write is in flight.
-		var hiReq, loReq <-chan *writeSlot
-		if activeDone == nil {
-			hiReq, loReq = p.hiReq, p.loReq
-		}
-
 		select {
-		case slot := <-hiReq:
-			close(slot.proceed)
-			activeDone = slot.done
-			hiStreak++
-		case slot := <-loReq:
-			close(slot.proceed)
-			activeDone = slot.done
-			hiStreak = 0
+		case req := <-p.writeReq:
+			if req.high {
+				hiQueue.push(req)
+			} else {
+				loQueue.push(req)
+			}
 		case err = <-activeDone:
-			// Active write finished. Allow the next one to be scheduled.
+			req := activeReq
+			activeReq = nil
 			activeDone = nil
+			if req != nil {
+				req.finish(err)
+			}
 			if err != nil {
 				reason = DiscNetworkError
 				break loop
@@ -378,6 +369,20 @@ loop:
 	}
 	close(p.closed)
 	p.rw.close(reason)
+	if activeReq != nil {
+		select {
+		case inflightErr := <-activeDone:
+			activeReq.finish(inflightErr)
+			if err == nil {
+				err = inflightErr
+			}
+		case <-time.After(inflightWriteDrainTimeout):
+			activeReq.finish(ErrShuttingDown)
+		}
+	}
+	failQueuedWriteRequests(ErrShuttingDown, hiQueue)
+	failQueuedWriteRequests(ErrShuttingDown, loQueue)
+	drainQueuedWriteRequests(p.writeReq, ErrShuttingDown)
 	p.wg.Wait()
 	return remoteRequested, err
 }
@@ -404,32 +409,150 @@ func (p *Peer) pingLoop() {
 	}
 }
 
-func writeQueuedSlot(reqCh chan<- *writeSlot, closed <-chan struct{}) (*writeSlot, error) {
-	slot := &writeSlot{
-		proceed: make(chan struct{}),
-		done:    make(chan error, 1),
+type writeRequestQueue struct {
+	items []*writeRequest
+	head  int
+}
+
+func newWriteRequestQueue() *writeRequestQueue {
+	return &writeRequestQueue{}
+}
+
+func (q *writeRequestQueue) len() int {
+	return len(q.items) - q.head
+}
+
+func (q *writeRequestQueue) storageLen() int {
+	return len(q.items)
+}
+
+func (q *writeRequestQueue) push(req *writeRequest) {
+	q.items = append(q.items, req)
+}
+
+func (q *writeRequestQueue) pop() *writeRequest {
+	req := q.items[q.head]
+	q.items[q.head] = nil
+	q.head++
+	if q.head == len(q.items) {
+		q.items = nil
+		q.head = 0
+		return req
 	}
+	if q.head >= 32 && q.head*2 >= len(q.items) {
+		q.compact()
+	}
+	return req
+}
+
+func (q *writeRequestQueue) compact() {
+	copy(q.items, q.items[q.head:])
+	newLen := len(q.items) - q.head
+	for i := newLen; i < len(q.items); i++ {
+		q.items[i] = nil
+	}
+	q.items = q.items[:newLen]
+	q.head = 0
+}
+
+func (q *writeRequestQueue) remaining() []*writeRequest {
+	return q.items[q.head:]
+}
+
+func pickNextWriteRequest(hiQueue, loQueue *writeRequestQueue, hiStreak int) (*writeRequest, bool) {
+	if hiStreak >= writePriorityStarveLimit && loQueue.len() > 0 {
+		return loQueue.pop(), false
+	}
+	if hiQueue.len() > 0 {
+		return hiQueue.pop(), true
+	}
+	if loQueue.len() > 0 {
+		return loQueue.pop(), false
+	}
+	return nil, false
+}
+
+func drainWriteRequests(src <-chan *writeRequest, hiQueue, loQueue *writeRequestQueue) {
+	for {
+		select {
+		case req := <-src:
+			if req.high {
+				hiQueue.push(req)
+			} else {
+				loQueue.push(req)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func failQueuedWriteRequests(err error, queue *writeRequestQueue) {
+	for _, req := range queue.remaining() {
+		if req != nil {
+			req.finish(err)
+		}
+	}
+}
+
+func drainQueuedWriteRequests(src <-chan *writeRequest, err error) {
+	for {
+		select {
+		case req := <-src:
+			if req != nil {
+				req.finish(err)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func enqueueWriteRequest(reqCh chan<- *writeRequest, closed <-chan struct{}, req *writeRequest, blockedMetric *metrics.Meter) error {
+	pend := req.pend
+	if pend != nil {
+		pend.Add(1)
+	}
+	rollback := func() {
+		if pend != nil {
+			pend.Add(-1)
+		}
+	}
+
 	select {
-	case reqCh <- slot:
+	case reqCh <- req:
+		return nil
 	case <-closed:
-		return nil, ErrShuttingDown
+		rollback()
+		return ErrShuttingDown
+	default:
+		if blockedMetric != nil {
+			blockedMetric.Mark(1)
+		}
+		select {
+		case reqCh <- req:
+			return nil
+		case <-closed:
+			rollback()
+			return ErrShuttingDown
+		}
 	}
-	return slot, nil
 }
 
 func (p *Peer) writeMsg(code uint64, payload []interface{}) error {
-	slot, err := writeQueuedSlot(p.loReq, p.closed)
+	size, r, err := rlp.EncodeToReader(payload)
 	if err != nil {
 		return err
 	}
-	select {
-	case <-slot.proceed:
-	case <-p.closed:
-		return ErrShuttingDown
+	req := &writeRequest{
+		msg:  Msg{Code: code, Size: uint32(size), Payload: r},
+		done: make(chan error, 1),
+		pend: &p.loPend,
 	}
-	err = SendItems(p.rw, code, payload...)
-	slot.done <- err
-	return err
+	if err := enqueueWriteRequest(p.writeReq, p.closed, req, nil); err != nil {
+		return err
+	}
+	return <-req.done
 }
 
 func (p *Peer) readLoop(errc chan<- error) {
@@ -510,7 +633,7 @@ outer:
 					offset -= old.Length
 				}
 				// Assign the new match
-				result[cap.Name] = &protoRW{Protocol: proto, offset: offset, in: make(chan Msg), w: rw}
+				result[cap.Name] = &protoRW{Protocol: proto, offset: offset, in: make(chan Msg), w: rw, closing: make(chan struct{})}
 				offset += proto.Length
 
 				continue outer
@@ -523,8 +646,10 @@ outer:
 func (p *Peer) startProtocols() {
 	for _, proto := range p.running {
 		proto.closed = p.closed
-		proto.hiReq = p.hiReq
-		proto.loReq = p.loReq
+		proto.writeReq = p.writeReq
+		proto.hiPend = &p.hiPend
+		proto.loPend = &p.loPend
+		proto.closeErr = p.rw.close
 		var rw MsgReadWriter = proto
 		if p.events != nil {
 			rw = newMsgEventer(rw, p.events, p.ID(), proto.Name, p.RemoteAddr().String(), p.LocalAddr().String())
@@ -556,15 +681,16 @@ func (p *Peer) getProto(code uint64) (*protoRW, error) {
 
 type protoRW struct {
 	Protocol
-	in     chan Msg        // receives read messages
-	closed <-chan struct{} // receives when peer is shutting down
-	// hiReq/loReq are written once by startProtocols before any concurrent
-	// writer is started and are read-only thereafter. Do not reassign them
-	// from goroutines other than the one that called startProtocols.
-	hiReq  chan<- *writeSlot // high-priority write request queue
-	loReq  chan<- *writeSlot // normal-priority write request queue
-	offset uint64
-	w      MsgWriter
+	in        chan Msg           // receives read messages
+	closed    <-chan struct{}    // receives when peer is shutting down
+	closing   chan struct{}      // receives when the protocol reader is force-closed locally
+	writeReq  chan *writeRequest // peer-owned write ingress
+	hiPend    *atomic.Int64
+	loPend    *atomic.Int64
+	offset    uint64
+	w         MsgWriter
+	closeErr  func(error)
+	closeOnce sync.Once
 }
 
 // Compile-time check that protoRW honours the PriorityMsgWriter contract.
@@ -588,43 +714,68 @@ func (rw *protoRW) writeMsg(msg Msg, high bool) (err error) {
 	if msg.Code >= rw.Length {
 		return newPeerError(errInvalidMsgCode, "not handled")
 	}
+	select {
+	case <-rw.closing:
+		return ErrShuttingDown
+	case <-rw.closed:
+		return ErrShuttingDown
+	default:
+	}
 	msg.meterCap = rw.cap()
 	msg.meterCode = msg.Code
 
 	msg.Code += rw.offset
-	reqCh := rw.loReq
 	depthMetric, blockedMetric := writeQueueLoDepth, writeQueueLoBlocked
+	pending := rw.loPend
 	if high {
-		reqCh = rw.hiReq
 		depthMetric, blockedMetric = writeQueueHiDepth, writeQueueHiBlocked
-	}
-	slot, err := writeQueuedSlot(reqCh, rw.closed)
-	if err != nil {
-		return err
+		pending = rw.hiPend
 	}
 	// Sample queue depth before enqueue so the histogram reflects the
-	// back-pressure observed by this writer (slots ahead of it), independent
-	// of how quickly the arbiter drains afterwards. This is still a racy
-	// snapshot under concurrent producers, but it is a meaningful upper
-	// bound on what this writer waited behind, whereas sampling after the
-	// send can be drained to ~0 by the arbiter and underreports congestion.
-	depthMetric.Update(int64(len(reqCh)))
-	// Enqueue the request. Try non-blocking first so we can observe
-	// saturation events; on fallback the writer waits like before.
-	if len(reqCh) == cap(reqCh) {
-		blockedMetric.Mark(1)
+	// same-priority requests already pending ahead of this request across the
+	// peer-owned write model, not just the bounded ingress channel occupancy.
+	if pending != nil {
+		depthMetric.Update(pending.Load())
 	}
-	// Wait for the arbiter to grant the slot.
+	req := &writeRequest{
+		msg:  msg,
+		high: high,
+		done: make(chan error, 1),
+		pend: pending,
+	}
+	if pending != nil {
+		pending.Add(1)
+	}
+	rollback := func() {
+		if pending != nil {
+			pending.Add(-1)
+		}
+	}
+
 	select {
-	case <-slot.proceed:
-	case <-rw.closed:
+	case rw.writeReq <- req:
+	case <-rw.closing:
+		rollback()
 		return ErrShuttingDown
+	case <-rw.closed:
+		rollback()
+		return ErrShuttingDown
+	default:
+		if blockedMetric != nil {
+			blockedMetric.Mark(1)
+		}
+		select {
+		case rw.writeReq <- req:
+		case <-rw.closing:
+			rollback()
+			return ErrShuttingDown
+		case <-rw.closed:
+			rollback()
+			return ErrShuttingDown
+		}
 	}
-	// Perform the actual write and report the result. done is buffered, so
-	// this send never blocks; the arbiter consumes it asynchronously.
-	err = rw.w.WriteMsg(msg)
-	slot.done <- err
-	return err
+
+	return <-req.done
 }
 
 func (rw *protoRW) ReadMsg() (Msg, error) {
@@ -632,9 +783,21 @@ func (rw *protoRW) ReadMsg() (Msg, error) {
 	case msg := <-rw.in:
 		msg.Code -= rw.offset
 		return msg, nil
+	case <-rw.closing:
+		return Msg{}, io.EOF
 	case <-rw.closed:
 		return Msg{}, io.EOF
 	}
+}
+
+func (rw *protoRW) Close() error {
+	rw.closeOnce.Do(func() {
+		close(rw.closing)
+	})
+	if rw.closeErr != nil {
+		rw.closeErr(DiscQuitting)
+	}
+	return nil
 }
 
 // PeerInfo represents a short summary of the information known about a connected

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -54,8 +54,6 @@ func (pe *peerError) Error() string {
 
 var errProtocolReturned = errors.New("protocol returned")
 
-var ErrAddPairPeer = errors.New("add a pair peer")
-
 type DiscReason uint
 
 const (
@@ -71,6 +69,9 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
+	// DiscPairPeerStop is kept only as an iota slot for wire compatibility
+	// with legacy XDPoSChain peers that still send this reason code. This
+	// node never sends it anymore; do not remove or reorder.
 	DiscPairPeerStop
 	DiscNonAllowlistedPeer
 	DiscDenylistedPeer

--- a/p2p/peer_priority_test.go
+++ b/p2p/peer_priority_test.go
@@ -1,0 +1,577 @@
+// Copyright 2025 The XDPoSChain Authors
+// This file is part of the XDPoSChain library.
+//
+// The XDPoSChain library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The XDPoSChain library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the XDPoSChain library. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/event"
+	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
+)
+
+// readCode reads one message from rw, discards its body and returns the code.
+func readCode(t *testing.T, rw MsgReader) uint64 {
+	t.Helper()
+	msg, err := rw.ReadMsg()
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+	if err := msg.Discard(); err != nil {
+		t.Fatalf("Discard: %v", err)
+	}
+	return msg.Code
+}
+
+func awaitSignal(t *testing.T, ch <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+type writeGateTransport struct {
+	transport
+	started chan struct{}
+	release chan struct{}
+	blocked int32
+}
+
+func newWriteGateTransport(inner transport) *writeGateTransport {
+	return &writeGateTransport{
+		transport: inner,
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+}
+
+func (t *writeGateTransport) WriteMsg(msg Msg) error {
+	if atomic.CompareAndSwapInt32(&t.blocked, 0, 1) {
+		close(t.started)
+		<-t.release
+	}
+	return t.transport.WriteMsg(msg)
+}
+
+func (t *writeGateTransport) unblockFirstWrite() {
+	close(t.release)
+}
+
+type concurrentWriteGateTransport struct {
+	transport
+	started    chan struct{}
+	release    chan struct{}
+	concurrent chan struct{}
+	blocked    int32
+	active     int32
+}
+
+func newConcurrentWriteGateTransport(inner transport) *concurrentWriteGateTransport {
+	return &concurrentWriteGateTransport{
+		transport:  inner,
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+		concurrent: make(chan struct{}, 1),
+	}
+}
+
+func (t *concurrentWriteGateTransport) WriteMsg(msg Msg) error {
+	if atomic.AddInt32(&t.active, 1) > 1 {
+		select {
+		case t.concurrent <- struct{}{}:
+		default:
+		}
+	}
+	if atomic.CompareAndSwapInt32(&t.blocked, 0, 1) {
+		close(t.started)
+		<-t.release
+	}
+	err := t.transport.WriteMsg(msg)
+	atomic.AddInt32(&t.active, -1)
+	return err
+}
+
+func (t *concurrentWriteGateTransport) unblockFirstWrite() {
+	close(t.release)
+}
+
+type writeQueueHooks struct {
+	hiQueued chan struct{}
+	loQueued chan struct{}
+	stop     chan struct{}
+	proto    *protoRW
+	origHi   chan<- *writeSlot
+	origLo   chan<- *writeSlot
+}
+
+// hookProtoWriteQueues replaces a protoRW's hi/lo request channels with
+// observable proxies, so tests can detect the exact moment a write request
+// is enqueued. It mutates proto.hiReq/loReq directly; this is safe only
+// because the swap happens before any concurrent writer is started in the
+// test (production code writes these fields once in startProtocols and
+// treats them as read-only thereafter).
+func hookProtoWriteQueues(t *testing.T, rw MsgReadWriter) *writeQueueHooks {
+	t.Helper()
+
+	proto, ok := rw.(*protoRW)
+	if !ok {
+		t.Fatalf("unexpected MsgReadWriter type %T", rw)
+	}
+	hooks := &writeQueueHooks{
+		hiQueued: make(chan struct{}, writeReqQueueSize),
+		loQueued: make(chan struct{}, writeReqQueueSize),
+		stop:     make(chan struct{}),
+		proto:    proto,
+		origHi:   proto.hiReq,
+		origLo:   proto.loReq,
+	}
+	hiProxy := make(chan *writeSlot, writeReqQueueSize)
+	loProxy := make(chan *writeSlot, writeReqQueueSize)
+	proto.hiReq = hiProxy
+	proto.loReq = loProxy
+
+	go forwardWriteSlots(hiProxy, hooks.origHi, hooks.hiQueued, hooks.stop)
+	go forwardWriteSlots(loProxy, hooks.origLo, hooks.loQueued, hooks.stop)
+
+	return hooks
+}
+
+func forwardWriteSlots(in <-chan *writeSlot, out chan<- *writeSlot, ack chan<- struct{}, stop <-chan struct{}) {
+	for {
+		select {
+		case slot := <-in:
+			select {
+			case out <- slot:
+				ack <- struct{}{}
+			case <-stop:
+				return
+			}
+		case <-stop:
+			return
+		}
+	}
+}
+
+func (h *writeQueueHooks) close() {
+	h.proto.hiReq = h.origHi
+	h.proto.loReq = h.origLo
+	close(h.stop)
+}
+
+// TestPeerWritePriorityPreemption verifies that a high-priority write is
+// served before a low-priority write that was enqueued first, as long as
+// both are pending when the previous write finishes.
+func TestPeerWritePriorityPreemption(t *testing.T) {
+	rwc := make(chan MsgReadWriter, 1)
+	stop := make(chan struct{})
+	proto := Protocol{
+		Name:   "a",
+		Length: 64,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-stop
+			return nil
+		},
+	}
+	var gate *writeGateTransport
+	closer, remote, _, _ := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newWriteGateTransport(inner)
+		return gate
+	})
+	defer closer()
+	defer close(stop)
+
+	rw := <-rwc
+	hooks := hookProtoWriteQueues(t, rw)
+	defer hooks.close()
+
+	// Slot 1: low priority. The send blocks at the transport because nobody
+	// is reading from `remote` yet. While it blocks, the arbiter is parked
+	// on activeDone.
+	first := make(chan error, 1)
+	go func() { first <- SendItems(rw, 1) }()
+	awaitSignal(t, gate.started, "first write to reach the transport")
+
+	// Enqueue a low-priority write, then a high-priority write. The hi/lo
+	// request channels are buffered, so both enqueue immediately and wait
+	// on their proceed signal.
+	loCh := make(chan error, 1)
+	hiCh := make(chan error, 1)
+	go func() { loCh <- SendItems(rw, 2) }()
+	awaitSignal(t, hooks.loQueued, "low-priority request to enqueue")
+	go func() { hiCh <- SendPriority(rw, 3, []uint{}) }()
+	awaitSignal(t, hooks.hiQueued, "high-priority request to enqueue")
+	gate.unblockFirstWrite()
+
+	// Drain the first message. After this, the arbiter releases slot 1
+	// (no error) and picks the next pending request, preferring hi.
+	if got, want := readCode(t, remote), uint64(baseProtocolLength+1); got != want {
+		t.Fatalf("first message code: got %d, want %d", got, want)
+	}
+	if err := <-first; err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	// The next message on the wire must be the high-priority one (code 3),
+	// even though the low-priority one (code 2) was enqueued first.
+	if got, want := readCode(t, remote), uint64(baseProtocolLength+3); got != want {
+		t.Fatalf("preemption failed: next code = %d, want hi=%d", got, want)
+	}
+	if err := <-hiCh; err != nil {
+		t.Fatalf("hi write: %v", err)
+	}
+
+	// Finally the low-priority one is served.
+	if got, want := readCode(t, remote), uint64(baseProtocolLength+2); got != want {
+		t.Fatalf("lo not served last: code = %d, want lo=%d", got, want)
+	}
+	if err := <-loCh; err != nil {
+		t.Fatalf("lo write: %v", err)
+	}
+}
+
+// TestPeerPingLoopUsesQueuedWriteSlot verifies that pingLoop does not write
+// directly to the transport while another write is in flight.
+func TestPeerPingLoopUsesQueuedWriteSlot(t *testing.T) {
+	rwc := make(chan MsgReadWriter, 1)
+	stop := make(chan struct{})
+	proto := Protocol{
+		Name:   "a",
+		Length: 64,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-stop
+			return nil
+		},
+	}
+	var gate *concurrentWriteGateTransport
+	closer, remote, peer, _ := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newConcurrentWriteGateTransport(inner)
+		return gate
+	})
+	defer closer()
+	defer close(stop)
+
+	rw := <-rwc
+
+	first := make(chan error, 1)
+	go func() { first <- SendItems(rw, 1) }()
+	awaitSignal(t, gate.started, "first write to reach the transport")
+
+	peer.pingRecv <- struct{}{}
+
+	select {
+	case <-gate.concurrent:
+		t.Fatal("pingLoop wrote to transport concurrently with an in-flight write")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	gate.unblockFirstWrite()
+
+	firstCode := readCode(t, remote)
+	if err := <-first; err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	secondCode := readCode(t, remote)
+	firstWant := uint64(baseProtocolLength + 1)
+	secondWant := uint64(pongMsg)
+	if !((firstCode == firstWant && secondCode == secondWant) || (firstCode == secondWant && secondCode == firstWant)) {
+		t.Fatalf("unexpected message codes: got %d then %d, want %d and %d in any order", firstCode, secondCode, firstWant, secondWant)
+	}
+}
+
+// TestPeerWriteStarvationGuard verifies that after writePriorityStarveLimit
+// consecutive high-priority writes, a pending low-priority write is forced
+// through ahead of the next high-priority one.
+func TestPeerWriteStarvationGuard(t *testing.T) {
+	rwc := make(chan MsgReadWriter, 1)
+	stop := make(chan struct{})
+	proto := Protocol{
+		Name:   "a",
+		Length: 64,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-stop
+			return nil
+		},
+	}
+	var gate *writeGateTransport
+	closer, remote, _, _ := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newWriteGateTransport(inner)
+		return gate
+	})
+	defer closer()
+	defer close(stop)
+
+	rw := <-rwc
+	hooks := hookProtoWriteQueues(t, rw)
+	defer hooks.close()
+
+	// Block the arbiter on an initial low-priority in-flight write so we
+	// can pre-load both queues deterministically.
+	first := make(chan error, 1)
+	go func() { first <- SendItems(rw, 0) }()
+	awaitSignal(t, gate.started, "first write to reach the transport")
+
+	// Enqueue one low-priority write (code 1) ahead of any high-priority
+	// ones to make the starvation case observable.
+	loCh := make(chan error, 1)
+	go func() { loCh <- SendItems(rw, 1) }()
+	awaitSignal(t, hooks.loQueued, "low-priority request to enqueue")
+
+	// Then enqueue writePriorityStarveLimit+1 high-priority writes with
+	// codes 2..N. The first writePriorityStarveLimit of them must be
+	// served before the pending low-priority one is forced through.
+	const extraHi = writePriorityStarveLimit + 1
+	hiCh := make(chan error, extraHi)
+	for i := 0; i < extraHi; i++ {
+		code := uint64(2 + i)
+		go func() { hiCh <- SendPriority(rw, code, []uint{}) }()
+	}
+	for i := 0; i < extraHi; i++ {
+		awaitSignal(t, hooks.hiQueued, "high-priority request to enqueue")
+	}
+	gate.unblockFirstWrite()
+
+	// Drain the in-flight initial write (code 0).
+	if got, want := readCode(t, remote), uint64(baseProtocolLength+0); got != want {
+		t.Fatalf("initial code: got %d, want %d", got, want)
+	}
+	if err := <-first; err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+
+	// Read writePriorityStarveLimit messages: all should be high-priority
+	// (codes in [2, 2+extraHi)).
+	for i := 0; i < writePriorityStarveLimit; i++ {
+		got := readCode(t, remote)
+		if got < baseProtocolLength+2 || got >= baseProtocolLength+2+extraHi {
+			t.Fatalf("write %d: expected high-priority code, got %d", i, got)
+		}
+	}
+
+	// The next message must be the low-priority one (code 1), forced
+	// through by the starvation guard.
+	if got, want := readCode(t, remote), uint64(baseProtocolLength+1); got != want {
+		t.Fatalf("starvation guard failed: next code = %d, want lo=%d", got, want)
+	}
+	if err := <-loCh; err != nil {
+		t.Fatalf("lo write: %v", err)
+	}
+
+	// Drain the remaining high-priority write so the test goroutines exit
+	// cleanly.
+	_ = readCode(t, remote)
+	for i := 0; i < extraHi; i++ {
+		if err := <-hiCh; err != nil {
+			t.Fatalf("hi write %d: %v", i, err)
+		}
+	}
+}
+
+// TestSendPriorityFallback verifies that SendPriority falls back to the
+// regular WriteMsg path on writers that do not implement PriorityMsgWriter.
+func TestSendPriorityFallback(t *testing.T) {
+	mw := &capturingWriter{}
+	if err := SendPriority(mw, 42, []uint{1, 2}); err != nil {
+		t.Fatalf("SendPriority: %v", err)
+	}
+	if !mw.called {
+		t.Fatal("WriteMsg was not called on fallback writer")
+	}
+	if mw.code != 42 {
+		t.Fatalf("code: got %d, want 42", mw.code)
+	}
+}
+
+type capturingWriter struct {
+	called bool
+	code   uint64
+}
+
+func (w *capturingWriter) WriteMsg(msg Msg) error {
+	w.called = true
+	w.code = msg.Code
+	return msg.Discard()
+}
+
+// priorityCapturingRW is a MsgReadWriter that records whether the high or low
+// lane was used for the last write. It is used to verify that a wrapping
+// MsgReadWriter (such as msgEventer) preserves the PriorityMsgWriter
+// interface to the underlying transport.
+type priorityCapturingRW struct {
+	last Msg
+	high bool
+	used bool // true if WriteMsgPriority was used
+}
+
+func (rw *priorityCapturingRW) ReadMsg() (Msg, error)  { return Msg{}, io.EOF }
+func (rw *priorityCapturingRW) WriteMsg(msg Msg) error { rw.last = msg; rw.used = false; return nil }
+func (rw *priorityCapturingRW) WriteMsgPriority(msg Msg, high bool) error {
+	rw.last = msg
+	rw.high = high
+	rw.used = true
+	return nil
+}
+
+// TestMsgEventerForwardsPriority verifies that msgEventer preserves the
+// PriorityMsgWriter contract: a SendPriority call through the wrapper still
+// reaches the underlying writer's high-priority lane, and the corresponding
+// PeerEventTypeMsgSend event is emitted.
+func TestMsgEventerForwardsPriority(t *testing.T) {
+	inner := &priorityCapturingRW{}
+	feed := new(event.Feed)
+	ch := make(chan *PeerEvent, 1)
+	sub := feed.Subscribe(ch)
+	defer sub.Unsubscribe()
+
+	ev := newMsgEventer(inner, feed, enode.ID{}, "test", "", "")
+
+	if _, ok := MsgReadWriter(ev).(PriorityMsgWriter); !ok {
+		t.Fatal("msgEventer does not implement PriorityMsgWriter")
+	}
+	if err := SendPriority(ev, 7, []uint{1}); err != nil {
+		t.Fatalf("SendPriority: %v", err)
+	}
+	if !inner.used {
+		t.Fatal("priority lane was not used on inner writer")
+	}
+	if !inner.high {
+		t.Fatal("high flag was not propagated to inner writer")
+	}
+	if inner.last.Code != 7 {
+		t.Fatalf("code: got %d, want 7", inner.last.Code)
+	}
+	select {
+	case e := <-ch:
+		if e.Type != PeerEventTypeMsgSend {
+			t.Fatalf("event type: got %v, want %v", e.Type, PeerEventTypeMsgSend)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no PeerEventTypeMsgSend emitted")
+	}
+}
+
+// TestPeerWriteLoEventuallyServedUnderSustainedHiPressure verifies the
+// strict starvation guard: even when high-priority writes are arriving
+// continuously (both preloaded and produced in the background while the
+// peer is draining), a single low-priority write is forced through after
+// at most writePriorityStarveLimit consecutive high-priority writes.
+//
+// The deterministic upper bound is writePriorityStarveLimit; we allow a
+// small slack of 2 to absorb any single-iteration race between the
+// arbiter's blocking select and the lo writer's loPending increment.
+func TestPeerWriteLoEventuallyServedUnderSustainedHiPressure(t *testing.T) {
+	rwc := make(chan MsgReadWriter, 1)
+	stop := make(chan struct{})
+	proto := Protocol{
+		Name:   "a",
+		Length: 4096,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-stop
+			return nil
+		},
+	}
+	var gate *writeGateTransport
+	closer, remote, _, _ := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newWriteGateTransport(inner)
+		return gate
+	})
+	defer closer()
+	defer close(stop)
+
+	rw := <-rwc
+	hooks := hookProtoWriteQueues(t, rw)
+	defer hooks.close()
+
+	// Park the arbiter on an initial in-flight write so we can pre-load
+	// both lanes deterministically before any traffic reaches the wire.
+	first := make(chan error, 1)
+	go func() { first <- SendItems(rw, 0) }()
+	awaitSignal(t, gate.started, "first write to reach the transport")
+
+	// Enqueue the single low-priority write (code 1) that the test will
+	// look for on the wire.
+	loCh := make(chan error, 1)
+	go func() { loCh <- SendItems(rw, 1) }()
+	awaitSignal(t, hooks.loQueued, "low-priority request to enqueue")
+
+	// Pre-load a burst of high-priority writes so the hi lane is already
+	// saturated before draining begins.
+	const preHi = writePriorityStarveLimit * 3
+	hiCh := make(chan error, preHi)
+	for i := 0; i < preHi; i++ {
+		code := uint64(100 + i)
+		go func() { hiCh <- SendPriority(rw, code, []uint{}) }()
+	}
+	for i := 0; i < preHi; i++ {
+		awaitSignal(t, hooks.hiQueued, "preloaded hi to enqueue")
+	}
+
+	// Start a producer that keeps issuing high-priority writes while the
+	// test drains the wire, modelling unbounded sustained hi pressure.
+	// It exits on producerStop or when the peer closes (deferred teardown
+	// unblocks any in-flight SendPriority call with ErrShuttingDown).
+	producerStop := make(chan struct{})
+	go func() {
+		code := uint64(10000)
+		for {
+			select {
+			case <-producerStop:
+				return
+			default:
+			}
+			if err := SendPriority(rw, code, []uint{}); err != nil {
+				return
+			}
+			code++
+		}
+	}()
+
+	gate.unblockFirstWrite()
+
+	// Drain the initial in-flight write (code 0).
+	if got, want := readCode(t, remote), uint64(baseProtocolLength+0); got != want {
+		t.Fatalf("initial code: got %d, want %d", got, want)
+	}
+	if err := <-first; err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+
+	// Read messages until we see the lo (code 1). The strict guard caps
+	// the wait at writePriorityStarveLimit hi writes; allow +2 slack.
+	const bound = writePriorityStarveLimit + 2
+	hiBefore := 0
+	for i := 0; i < bound; i++ {
+		got := readCode(t, remote)
+		if got == baseProtocolLength+1 {
+			close(producerStop)
+			if err := <-loCh; err != nil {
+				t.Fatalf("lo write: %v", err)
+			}
+			return
+		}
+		hiBefore++
+	}
+	close(producerStop)
+	t.Fatalf("lo write not served within %d hi writes under sustained hi pressure (saw %d hi)", bound, hiBefore)
+}

--- a/p2p/peer_priority_test.go
+++ b/p2p/peer_priority_test.go
@@ -17,12 +17,15 @@
 package p2p
 
 import (
+	"bytes"
 	"io"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/event"
+	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
 )
 
@@ -45,6 +48,208 @@ func awaitSignal(t *testing.T, ch <-chan struct{}, label string) {
 	case <-ch:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) WriteMsg(msg Msg) error {
+	if msg.Payload == nil {
+		return nil
+	}
+	return msg.Discard()
+}
+
+func awaitQueueDepth(t *testing.T, ch <-chan *writeRequest, want int, label string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(ch) == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s: got depth %d want %d", label, len(ch), want)
+}
+
+func TestProtoRWWriteQueueDepthSamplesWritersAhead(t *testing.T) {
+	metrics.Enable()
+	writeQueueHiDepth.Clear()
+
+	var hiPend atomic.Int64
+	hiPend.Store(1)
+	writeReq := make(chan *writeRequest, 2)
+	writeReq <- &writeRequest{high: true, done: make(chan error, 1), pend: &hiPend}
+	closed := make(chan struct{})
+	rw := &protoRW{
+		Protocol: Protocol{Length: 1},
+		closed:   closed,
+		writeReq: writeReq,
+		hiPend:   &hiPend,
+		w:        discardWriter{},
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- rw.WriteMsgPriority(Msg{Code: 0, Payload: bytes.NewReader(nil)}, true)
+	}()
+
+	awaitQueueDepth(t, writeReq, 2, "priority queue to contain preload plus new writer")
+	after := writeQueueHiDepth.Snapshot()
+	if got := after.Count(); got != 1 {
+		t.Fatalf("histogram samples: got %d want 1", got)
+	}
+	if got := after.Sum(); got != 1 {
+		t.Fatalf("queued writers ahead: got %d want 1", got)
+	}
+
+	<-writeReq
+	req := <-writeReq
+	req.done <- nil
+	if err := <-result; err != nil {
+		t.Fatalf("WriteMsgPriority: %v", err)
+	}
+	close(closed)
+}
+
+func TestProtoRWWriteQueueDepthIncludesPendingRequestsOutsideIngress(t *testing.T) {
+	metrics.Enable()
+	writeQueueHiDepth.Clear()
+
+	var hiPend atomic.Int64
+	hiPend.Store(1)
+	writeReq := make(chan *writeRequest, 1)
+	closed := make(chan struct{})
+	rw := &protoRW{
+		Protocol: Protocol{Length: 1},
+		closed:   closed,
+		writeReq: writeReq,
+		hiPend:   &hiPend,
+		w:        discardWriter{},
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- rw.WriteMsgPriority(Msg{Code: 0, Payload: bytes.NewReader(nil)}, true)
+	}()
+
+	awaitQueueDepth(t, writeReq, 1, "priority ingress to receive the new writer")
+	after := writeQueueHiDepth.Snapshot()
+	if got := after.Count(); got != 1 {
+		t.Fatalf("histogram samples: got %d want 1", got)
+	}
+	if got := after.Sum(); got != 1 {
+		t.Fatalf("queued writers ahead: got %d want 1", got)
+	}
+
+	req := <-writeReq
+	req.done <- nil
+	if err := <-result; err != nil {
+		t.Fatalf("WriteMsgPriority: %v", err)
+	}
+	close(closed)
+}
+
+func TestProtoRWWriteQueueBlockedMeterCountsFullQueueWait(t *testing.T) {
+	metrics.Enable()
+
+	writeReq := make(chan *writeRequest, 1)
+	writeReq <- &writeRequest{high: true, done: make(chan error, 1)}
+	closed := make(chan struct{})
+	rw := &protoRW{
+		Protocol: Protocol{Length: 1},
+		closed:   closed,
+		writeReq: writeReq,
+		hiPend:   new(atomic.Int64),
+		w:        discardWriter{},
+	}
+
+	before := writeQueueHiBlocked.Snapshot().Count()
+	result := make(chan error, 1)
+	go func() {
+		result <- rw.WriteMsgPriority(Msg{Code: 0, Payload: bytes.NewReader(nil)}, true)
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("WriteMsgPriority returned before queue space was freed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	requests := make(chan *writeRequest, 1)
+	go func() {
+		<-writeReq
+		requests <- <-writeReq
+	}()
+
+	req := <-requests
+	req.done <- nil
+	if err := <-result; err != nil {
+		t.Fatalf("WriteMsgPriority: %v", err)
+	}
+	after := writeQueueHiBlocked.Snapshot().Count()
+	if got := after - before; got != 1 {
+		t.Fatalf("blocked meter delta: got %d want 1", got)
+	}
+	close(closed)
+}
+
+func TestEnqueueWriteRequestPendingAccountingRace(t *testing.T) {
+	t.Helper()
+
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(2))
+
+	for i := 0; i < 1000; i++ {
+		var pend atomic.Int64
+		reqCh := make(chan *writeRequest)
+		closed := make(chan struct{})
+		req := &writeRequest{done: make(chan error, 1), pend: &pend}
+		finished := make(chan struct{})
+
+		go func() {
+			received := <-reqCh
+			received.finish(nil)
+			close(finished)
+		}()
+
+		if err := enqueueWriteRequest(reqCh, closed, req, nil); err != nil {
+			t.Fatalf("enqueueWriteRequest: %v", err)
+		}
+		<-finished
+		if got := pend.Load(); got != 0 {
+			t.Fatalf("iteration %d: pending count = %d, want 0", i, got)
+		}
+		if err := <-req.done; err != nil {
+			t.Fatalf("iteration %d: completion error = %v", i, err)
+		}
+		close(closed)
+	}
+}
+
+func TestWriteRequestQueuePreservesFIFOAndReusesStorage(t *testing.T) {
+	queue := newWriteRequestQueue()
+	first := &writeRequest{done: make(chan error, 1)}
+	second := &writeRequest{done: make(chan error, 1)}
+	third := &writeRequest{done: make(chan error, 1)}
+
+	queue.push(first)
+	queue.push(second)
+	if got := queue.pop(); got != first {
+		t.Fatalf("first pop: got %p want %p", got, first)
+	}
+	queue.push(third)
+
+	if got := queue.pop(); got != second {
+		t.Fatalf("second pop: got %p want %p", got, second)
+	}
+	if got := queue.pop(); got != third {
+		t.Fatalf("third pop: got %p want %p", got, third)
+	}
+	if got := queue.len(); got != 0 {
+		t.Fatalf("queue length: got %d want 0", got)
+	}
+	if got := queue.storageLen(); got != 0 {
+		t.Fatalf("storage length after draining: got %d want 0", got)
 	}
 }
 
@@ -72,6 +277,59 @@ func (t *writeGateTransport) WriteMsg(msg Msg) error {
 }
 
 func (t *writeGateTransport) unblockFirstWrite() {
+	close(t.release)
+}
+
+type writeNilGateTransport struct {
+	transport
+	started chan struct{}
+	release chan struct{}
+	blocked int32
+}
+
+type stuckWriteTransport struct {
+	transport
+	started chan struct{}
+	block   chan struct{}
+	blocked int32
+}
+
+func newStuckWriteTransport(inner transport) *stuckWriteTransport {
+	return &stuckWriteTransport{
+		transport: inner,
+		started:   make(chan struct{}),
+		block:     make(chan struct{}),
+	}
+}
+
+func (t *stuckWriteTransport) WriteMsg(msg Msg) error {
+	if atomic.CompareAndSwapInt32(&t.blocked, 0, 1) {
+		close(t.started)
+	}
+	<-t.block
+	return t.transport.WriteMsg(msg)
+}
+
+func newWriteNilGateTransport(inner transport) *writeNilGateTransport {
+	return &writeNilGateTransport{
+		transport: inner,
+		started:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+}
+
+func (t *writeNilGateTransport) WriteMsg(msg Msg) error {
+	if atomic.CompareAndSwapInt32(&t.blocked, 0, 1) {
+		close(t.started)
+		<-t.release
+	}
+	if msg.Payload != nil {
+		_ = msg.Discard()
+	}
+	return nil
+}
+
+func (t *writeNilGateTransport) unblockFirstWrite() {
 	close(t.release)
 }
 
@@ -118,17 +376,14 @@ type writeQueueHooks struct {
 	loQueued chan struct{}
 	stop     chan struct{}
 	proto    *protoRW
-	origHi   chan<- *writeSlot
-	origLo   chan<- *writeSlot
+	origReq  chan *writeRequest
+	closed   <-chan struct{}
 }
 
-// hookProtoWriteQueues replaces a protoRW's hi/lo request channels with
-// observable proxies, so tests can detect the exact moment a write request
-// is enqueued. It mutates proto.hiReq/loReq directly; this is safe only
-// because the swap happens before any concurrent writer is started in the
-// test (production code writes these fields once in startProtocols and
-// treats them as read-only thereafter).
-func hookProtoWriteQueues(t *testing.T, rw MsgReadWriter) *writeQueueHooks {
+// hookProtoWriteRequests replaces a protoRW's write ingress with an observable
+// proxy, allowing tests to confirm request admission without depending on the
+// peer arbiter's internal per-priority queue representation.
+func hookProtoWriteRequests(t *testing.T, rw MsgReadWriter) *writeQueueHooks {
 	t.Helper()
 
 	proto, ok := rw.(*protoRW)
@@ -140,39 +395,53 @@ func hookProtoWriteQueues(t *testing.T, rw MsgReadWriter) *writeQueueHooks {
 		loQueued: make(chan struct{}, writeReqQueueSize),
 		stop:     make(chan struct{}),
 		proto:    proto,
-		origHi:   proto.hiReq,
-		origLo:   proto.loReq,
+		origReq:  proto.writeReq,
+		closed:   proto.closed,
 	}
-	hiProxy := make(chan *writeSlot, writeReqQueueSize)
-	loProxy := make(chan *writeSlot, writeReqQueueSize)
-	proto.hiReq = hiProxy
-	proto.loReq = loProxy
+	proxy := make(chan *writeRequest, writeReqQueueSize)
+	proto.writeReq = proxy
 
-	go forwardWriteSlots(hiProxy, hooks.origHi, hooks.hiQueued, hooks.stop)
-	go forwardWriteSlots(loProxy, hooks.origLo, hooks.loQueued, hooks.stop)
+	go forwardWriteRequests(proxy, hooks.origReq, hooks.closed, hooks.hiQueued, hooks.loQueued, hooks.stop)
 
 	return hooks
 }
 
-func forwardWriteSlots(in <-chan *writeSlot, out chan<- *writeSlot, ack chan<- struct{}, stop <-chan struct{}) {
+func forwardWriteRequests(in <-chan *writeRequest, out chan *writeRequest, closed <-chan struct{}, hiAck, loAck chan<- struct{}, stop <-chan struct{}) {
 	for {
 		select {
-		case slot := <-in:
+		case req := <-in:
 			select {
-			case out <- slot:
-				ack <- struct{}{}
+			case <-closed:
+				req.done <- ErrShuttingDown
+				continue
+			default:
+			}
+			select {
+			case out <- req:
+				if req.high {
+					hiAck <- struct{}{}
+				} else {
+					loAck <- struct{}{}
+				}
+			case <-closed:
+				req.done <- ErrShuttingDown
 			case <-stop:
+				req.done <- ErrShuttingDown
 				return
 			}
+		case <-closed:
+			drainQueuedWriteRequests(in, ErrShuttingDown)
+			drainQueuedWriteRequests(out, ErrShuttingDown)
+			return
 		case <-stop:
+			drainQueuedWriteRequests(in, ErrShuttingDown)
 			return
 		}
 	}
 }
 
 func (h *writeQueueHooks) close() {
-	h.proto.hiReq = h.origHi
-	h.proto.loReq = h.origLo
+	h.proto.writeReq = h.origReq
 	close(h.stop)
 }
 
@@ -200,7 +469,7 @@ func TestPeerWritePriorityPreemption(t *testing.T) {
 	defer close(stop)
 
 	rw := <-rwc
-	hooks := hookProtoWriteQueues(t, rw)
+	hooks := hookProtoWriteRequests(t, rw)
 	defer hooks.close()
 
 	// Slot 1: low priority. The send blocks at the transport because nobody
@@ -248,9 +517,9 @@ func TestPeerWritePriorityPreemption(t *testing.T) {
 	}
 }
 
-// TestPeerPingLoopUsesQueuedWriteSlot verifies that pingLoop does not write
+// TestPeerPingLoopUsesQueuedWriteRequest verifies that pingLoop does not write
 // directly to the transport while another write is in flight.
-func TestPeerPingLoopUsesQueuedWriteSlot(t *testing.T) {
+func TestPeerPingLoopUsesQueuedWriteRequest(t *testing.T) {
 	rwc := make(chan MsgReadWriter, 1)
 	stop := make(chan struct{})
 	proto := Protocol{
@@ -322,7 +591,7 @@ func TestPeerWriteStarvationGuard(t *testing.T) {
 	defer close(stop)
 
 	rw := <-rwc
-	hooks := hookProtoWriteQueues(t, rw)
+	hooks := hookProtoWriteRequests(t, rw)
 	defer hooks.close()
 
 	// Block the arbiter on an initial low-priority in-flight write so we
@@ -443,7 +712,7 @@ func TestMsgEventerForwardsPriority(t *testing.T) {
 	sub := feed.Subscribe(ch)
 	defer sub.Unsubscribe()
 
-	ev := newMsgEventer(inner, feed, enode.ID{}, "test", "", "")
+	ev := newMsgEventer(inner, feed, enode.ID{}, "test", "remote:30303", "local:30303")
 
 	if _, ok := MsgReadWriter(ev).(PriorityMsgWriter); !ok {
 		t.Fatal("msgEventer does not implement PriorityMsgWriter")
@@ -465,6 +734,12 @@ func TestMsgEventerForwardsPriority(t *testing.T) {
 		if e.Type != PeerEventTypeMsgSend {
 			t.Fatalf("event type: got %v, want %v", e.Type, PeerEventTypeMsgSend)
 		}
+		if e.LocalAddress != "local:30303" {
+			t.Fatalf("local address: got %q, want %q", e.LocalAddress, "local:30303")
+		}
+		if e.RemoteAddress != "remote:30303" {
+			t.Fatalf("remote address: got %q, want %q", e.RemoteAddress, "remote:30303")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("no PeerEventTypeMsgSend emitted")
 	}
@@ -476,9 +751,9 @@ func TestMsgEventerForwardsPriority(t *testing.T) {
 // peer is draining), a single low-priority write is forced through after
 // at most writePriorityStarveLimit consecutive high-priority writes.
 //
-// The deterministic upper bound is writePriorityStarveLimit; we allow a
-// small slack of 2 to absorb any single-iteration race between the
-// arbiter's blocking select and the lo writer's loPending increment.
+// The deterministic upper bound is exactly writePriorityStarveLimit. Once
+// the starvation guard trips and a low-priority write is pending, the next
+// scheduled request must come from the low-priority lane.
 func TestPeerWriteLoEventuallyServedUnderSustainedHiPressure(t *testing.T) {
 	rwc := make(chan MsgReadWriter, 1)
 	stop := make(chan struct{})
@@ -500,7 +775,7 @@ func TestPeerWriteLoEventuallyServedUnderSustainedHiPressure(t *testing.T) {
 	defer close(stop)
 
 	rw := <-rwc
-	hooks := hookProtoWriteQueues(t, rw)
+	hooks := hookProtoWriteRequests(t, rw)
 	defer hooks.close()
 
 	// Park the arbiter on an initial in-flight write so we can pre-load
@@ -557,9 +832,9 @@ func TestPeerWriteLoEventuallyServedUnderSustainedHiPressure(t *testing.T) {
 		t.Fatalf("initial write: %v", err)
 	}
 
-	// Read messages until we see the lo (code 1). The strict guard caps
-	// the wait at writePriorityStarveLimit hi writes; allow +2 slack.
-	const bound = writePriorityStarveLimit + 2
+	// Read messages until we see the lo (code 1). A strict starvation
+	// guard must schedule it after exactly writePriorityStarveLimit hi writes.
+	const bound = writePriorityStarveLimit
 	hiBefore := 0
 	for i := 0; i < bound; i++ {
 		got := readCode(t, remote)
@@ -572,6 +847,141 @@ func TestPeerWriteLoEventuallyServedUnderSustainedHiPressure(t *testing.T) {
 		}
 		hiBefore++
 	}
+	if got := readCode(t, remote); got == baseProtocolLength+1 {
+		close(producerStop)
+		if err := <-loCh; err != nil {
+			t.Fatalf("lo write: %v", err)
+		}
+		return
+	}
 	close(producerStop)
 	t.Fatalf("lo write not served within %d hi writes under sustained hi pressure (saw %d hi)", bound, hiBefore)
+}
+
+func TestPeerWriteShutdownPreservesInflightTransportError(t *testing.T) {
+	rwc := make(chan MsgReadWriter, 1)
+	stop := make(chan struct{})
+	proto := Protocol{
+		Name:   "a",
+		Length: 64,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-stop
+			return nil
+		},
+	}
+	var gate *writeGateTransport
+	closer, _, peer, _ := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newWriteGateTransport(inner)
+		return gate
+	})
+	defer close(stop)
+
+	rw := <-rwc
+
+	first := make(chan error, 1)
+	go func() { first <- SendItems(rw, 1) }()
+	awaitSignal(t, gate.started, "first write to reach the transport")
+
+	secondReq := &writeRequest{
+		msg:  Msg{Code: baseProtocolLength + 2, Size: 0, Payload: bytes.NewReader(nil)},
+		done: make(chan error, 1),
+	}
+	if err := enqueueWriteRequest(peer.writeReq, peer.closed, secondReq, nil); err != nil {
+		t.Fatalf("enqueue second request: %v", err)
+	}
+
+	closer()
+	gate.unblockFirstWrite()
+
+	if err := <-first; err == nil || err == ErrShuttingDown {
+		t.Fatalf("first write error: got %v, want non-nil transport error distinct from %v", err, ErrShuttingDown)
+	}
+	if err := <-secondReq.done; err != ErrShuttingDown {
+		t.Fatalf("second write error: got %v, want %v", err, ErrShuttingDown)
+	}
+}
+
+func TestPeerDisconnectPreservesReasonWhenInflightWriteReturnsNil(t *testing.T) {
+	rwc := make(chan MsgReadWriter, 1)
+	proto := Protocol{
+		Name:   "a",
+		Length: 64,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-p.closed
+			return nil
+		},
+	}
+
+	var gate *writeNilGateTransport
+	closer, _, peer, errc := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newWriteNilGateTransport(inner)
+		return gate
+	})
+	defer closer()
+
+	rw := <-rwc
+	first := make(chan error, 1)
+	go func() { first <- SendItems(rw, 1) }()
+	awaitSignal(t, gate.started, "first write to reach the transport")
+
+	peer.Disconnect(DiscRequested)
+	gate.unblockFirstWrite()
+
+	if err := <-first; err != nil {
+		t.Fatalf("first write error: got %v, want nil", err)
+	}
+	if err := <-errc; err != DiscRequested {
+		t.Fatalf("peer run error: got %v, want %v", err, DiscRequested)
+	}
+}
+
+func TestPeerDisconnectDoesNotHangOnStuckInflightWrite(t *testing.T) {
+	origTimeout := inflightWriteDrainTimeout
+	inflightWriteDrainTimeout = 50 * time.Millisecond
+	defer func() { inflightWriteDrainTimeout = origTimeout }()
+
+	rwc := make(chan MsgReadWriter, 1)
+	proto := Protocol{
+		Name:   "a",
+		Length: 64,
+		Run: func(p *Peer, rw MsgReadWriter) error {
+			rwc <- rw
+			<-p.closed
+			return nil
+		},
+	}
+
+	var gate *stuckWriteTransport
+	closer, _, peer, errc := testPeerWithTransport([]Protocol{proto}, func(inner transport) transport {
+		gate = newStuckWriteTransport(inner)
+		return gate
+	})
+	defer closer()
+
+	rw := <-rwc
+	writeErr := make(chan error, 1)
+	go func() { writeErr <- SendItems(rw, 1) }()
+
+	awaitSignal(t, gate.started, "first write to reach stuck transport")
+	peer.Disconnect(DiscRequested)
+
+	select {
+	case err := <-errc:
+		if err != DiscRequested {
+			t.Fatalf("peer run error: got %v, want %v", err, DiscRequested)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("peer run did not return while in-flight write was stuck")
+	}
+
+	select {
+	case err := <-writeErr:
+		if err != ErrShuttingDown {
+			t.Fatalf("write error: got %v, want %v", err, ErrShuttingDown)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("write call did not return after peer shutdown")
+	}
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -44,9 +44,16 @@ var discard = Protocol{
 }
 
 func testPeer(protos []Protocol) (func(), *conn, *Peer, <-chan error) {
+	return testPeerWithTransport(protos, nil)
+}
+
+func testPeerWithTransport(protos []Protocol, wrap func(transport) transport) (func(), *conn, *Peer, <-chan error) {
 	fd1, fd2 := net.Pipe()
 	c1 := &conn{fd: fd1, node: newNode(randomID(), nil), transport: newTestTransport(&newkey().PublicKey, fd1)}
 	c2 := &conn{fd: fd2, node: newNode(randomID(), nil), transport: newTestTransport(&newkey().PublicKey, fd2)}
+	if wrap != nil {
+		c1.transport = wrap(c1.transport)
+	}
 	for _, p := range protos {
 		c1.caps = append(c1.caps, p.cap())
 		c2.caps = append(c2.caps, p.cap())
@@ -194,34 +201,6 @@ func TestPeerDisconnectRace(t *testing.T) {
 			// show the stacks.
 			panic("Peer.run took to long to return.")
 		}
-	}
-}
-
-func TestPeerRunDisconnectsPairPeer(t *testing.T) {
-	closer, _, peer, errc := testPeer(nil)
-	defer closer()
-
-	pairPeer := &Peer{
-		disc:   make(chan DiscReason, 1),
-		closed: make(chan struct{}),
-	}
-	peer.SetPairPeer(pairPeer)
-
-	closer()
-
-	select {
-	case <-errc:
-	case <-time.After(2 * time.Second):
-		t.Fatal("peer did not stop")
-	}
-
-	select {
-	case reason := <-pairPeer.disc:
-		if reason != DiscPairPeerStop {
-			t.Fatalf("unexpected pair disconnect reason: got %v want %v", reason, DiscPairPeerStop)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("pair peer was not disconnected")
 	}
 }
 

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -17,8 +17,10 @@
 package p2p
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"reflect"
@@ -154,6 +156,108 @@ func TestPeerDisconnect(t *testing.T) {
 	}
 }
 
+func TestProtoRWCloseUnblocksReadMsg(t *testing.T) {
+	rwReady := make(chan interface{ Close() error }, 1)
+	readDone := make(chan error, 1)
+
+	proto := Protocol{
+		Name:   "block",
+		Length: 1,
+		Run: func(peer *Peer, rw MsgReadWriter) error {
+			closer, ok := rw.(interface{ Close() error })
+			if !ok {
+				return errors.New("protocol reader is not closable")
+			}
+			rwReady <- closer
+			_, err := rw.ReadMsg()
+			readDone <- err
+			return err
+		},
+	}
+
+	closer, _, _, errc := testPeer([]Protocol{proto})
+	defer closer()
+
+	var protoCloser interface{ Close() error }
+	select {
+	case protoCloser = <-rwReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("protocol did not start")
+	}
+	if err := protoCloser.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	select {
+	case err := <-readDone:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("unexpected read error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("protocol read did not unblock")
+	}
+
+	select {
+	case <-errc:
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer run did not exit")
+	}
+}
+
+func TestProtoRWCloseUnblocksReadMsgWithoutPeerClosed(t *testing.T) {
+	rw := &protoRW{
+		in:      make(chan Msg),
+		closed:  make(chan struct{}),
+		closing: make(chan struct{}),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := rw.ReadMsg()
+		errCh <- err
+	}()
+
+	if err := rw.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("unexpected read error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadMsg did not unblock after protoRW.Close")
+	}
+}
+
+func TestProtoRWCloseUnblocksWriteMsgWithoutPeerClosed(t *testing.T) {
+	rw := &protoRW{
+		Protocol: Protocol{Length: 1},
+		closed:   make(chan struct{}),
+		closing:  make(chan struct{}),
+		writeReq: make(chan *writeRequest),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- rw.WriteMsg(Msg{Code: 0, Payload: bytes.NewReader(nil)})
+	}()
+
+	if err := rw.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, ErrShuttingDown) {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteMsg did not unblock after protoRW.Close")
+	}
+}
+
 // This test is supposed to verify that Peer can reliably handle
 // multiple causes of disconnection occurring at the same time.
 func TestPeerDisconnectRace(t *testing.T) {
@@ -223,10 +327,16 @@ func TestNewPeer(t *testing.T) {
 }
 
 func TestMatchProtocols(t *testing.T) {
+	type protoExpectation struct {
+		Name    string
+		Version uint
+		offset  uint64
+	}
+
 	tests := []struct {
 		Remote []Cap
 		Local  []Protocol
-		Match  map[string]protoRW
+		Match  map[string]protoExpectation
 	}{
 		{
 			// No remote capabilities
@@ -245,13 +355,13 @@ func TestMatchProtocols(t *testing.T) {
 			// Some matches, some differences
 			Remote: []Cap{{Name: "local"}, {Name: "match1"}, {Name: "match2"}},
 			Local:  []Protocol{{Name: "match1"}, {Name: "match2"}, {Name: "remote"}},
-			Match:  map[string]protoRW{"match1": {Protocol: Protocol{Name: "match1"}}, "match2": {Protocol: Protocol{Name: "match2"}}},
+			Match:  map[string]protoExpectation{"match1": {Name: "match1"}, "match2": {Name: "match2"}},
 		},
 		{
 			// Various alphabetical ordering
 			Remote: []Cap{{Name: "aa"}, {Name: "ab"}, {Name: "bb"}, {Name: "ba"}},
 			Local:  []Protocol{{Name: "ba"}, {Name: "bb"}, {Name: "ab"}, {Name: "aa"}},
-			Match:  map[string]protoRW{"aa": {Protocol: Protocol{Name: "aa"}}, "ab": {Protocol: Protocol{Name: "ab"}}, "ba": {Protocol: Protocol{Name: "ba"}}, "bb": {Protocol: Protocol{Name: "bb"}}},
+			Match:  map[string]protoExpectation{"aa": {Name: "aa"}, "ab": {Name: "ab"}, "ba": {Name: "ba"}, "bb": {Name: "bb"}},
 		},
 		{
 			// No mutual versions
@@ -262,25 +372,25 @@ func TestMatchProtocols(t *testing.T) {
 			// Multiple versions, single common
 			Remote: []Cap{{Version: 1}, {Version: 2}},
 			Local:  []Protocol{{Version: 2}, {Version: 3}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 2}}},
+			Match:  map[string]protoExpectation{"": {Version: 2}},
 		},
 		{
 			// Multiple versions, multiple common
 			Remote: []Cap{{Version: 1}, {Version: 2}, {Version: 3}, {Version: 4}},
 			Local:  []Protocol{{Version: 2}, {Version: 3}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 3}}},
+			Match:  map[string]protoExpectation{"": {Version: 3}},
 		},
 		{
 			// Various version orderings
 			Remote: []Cap{{Version: 4}, {Version: 1}, {Version: 3}, {Version: 2}},
 			Local:  []Protocol{{Version: 2}, {Version: 3}, {Version: 1}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 3}}},
+			Match:  map[string]protoExpectation{"": {Version: 3}},
 		},
 		{
 			// Versions overriding sub-protocol lengths
 			Remote: []Cap{{Version: 1}, {Version: 2}, {Version: 3}, {Name: "a"}},
 			Local:  []Protocol{{Version: 1, Length: 1}, {Version: 2, Length: 2}, {Version: 3, Length: 3}, {Name: "a"}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 3}}, "a": {Protocol: Protocol{Name: "a"}, offset: 3}},
+			Match:  map[string]protoExpectation{"": {Version: 3}, "a": {Name: "a", offset: 3}},
 		},
 	}
 

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -295,10 +295,7 @@ func (srv *Server) LocalNode() *enode.LocalNode {
 	return srv.localnode
 }
 
-// Peers returns the public view of connected remote nodes.
-//
-// The returned slice contains one entry per remote NodeID, so multiple physical
-// connections associated with the same node are represented by a single entry.
+// Peers returns all connected peers.
 func (srv *Server) Peers() []*Peer {
 	var ps []*Peer
 	select {
@@ -316,11 +313,7 @@ func (srv *Server) Peers() []*Peer {
 	return ps
 }
 
-// PeerCount returns the number of connected remote nodes.
-//
-// Multiple physical connections associated with the same remote NodeID
-// (for example pair peers) are counted once because the public peer view is
-// keyed by NodeID.
+// PeerCount returns the number of connected peers.
 func (srv *Server) PeerCount() int {
 	var count int
 	select {
@@ -751,11 +744,7 @@ running:
 				name := truncateName(c.name)
 				p.log.Debug("Adding p2p peer", "addr", p.RemoteAddr(), "peers", len(peers)+1, "name", name)
 				go srv.runPeer(p)
-				if peers[c.node.ID()] != nil {
-					peers[c.node.ID()].SetPairPeer(p)
-				} else {
-					peers[c.node.ID()] = p
-				}
+				peers[c.node.ID()] = p
 				if p.Inbound() {
 					inboundCount++
 					serveSuccessMeter.Mark(1)
@@ -807,18 +796,6 @@ running:
 	}
 }
 
-func removePeerTracking(peers map[enode.ID]*Peer, pd peerDrop, connCount int) int {
-	if connCount > 0 {
-		connCount--
-	}
-	if current := peers[pd.ID()]; current == pd.Peer {
-		delete(peers, pd.ID())
-	} else if current != nil {
-		current.ClearPairPeer(pd.Peer)
-	}
-	return connCount
-}
-
 func (srv *Server) protoHandshakeChecks(peers map[enode.ID]*Peer, inboundCount int, c *conn) error {
 	// Drop connections with no matching protocols.
 	if len(srv.Protocols) > 0 && countMatchingProtocols(srv.Protocols, c.caps) == 0 {
@@ -836,11 +813,7 @@ func (srv *Server) encHandshakeChecks(peers map[enode.ID]*Peer, inboundCount int
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
 		return DiscTooManyPeers
 	case peers[c.node.ID()] != nil:
-		existingPeer := peers[c.node.ID()]
-		if existingPeer.PairPeer() != nil {
-			return DiscAlreadyConnected
-		}
-		return nil
+		return DiscAlreadyConnected
 	case c.node.ID() == srv.localnode.ID():
 		return DiscSelf
 	default:

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -473,6 +473,29 @@ func TestServerPeerLimits(t *testing.T) {
 	conn.Close()
 }
 
+func removePeerTracking(peers map[enode.ID]*Peer, pd peerDrop, connCount int) int {
+	if _, exists := peers[pd.ID()]; exists {
+		delete(peers, pd.ID())
+		connCount--
+	}
+	return connCount
+}
+
+func TestRemovePeerTracking(t *testing.T) {
+	id := randomID()
+	primary := newPeer(&conn{node: newNode(id, nil)}, nil)
+
+	peers := map[enode.ID]*Peer{id: primary}
+	connCount := removePeerTracking(peers, peerDrop{Peer: primary}, 1)
+
+	if connCount != 0 {
+		t.Fatalf("unexpected connection count: got %d want %d", connCount, 0)
+	}
+	if _, exists := peers[id]; exists {
+		t.Fatal("primary peer was not removed on drop")
+	}
+}
+
 func TestServerSetupConn(t *testing.T) {
 	var (
 		clientkey, srvkey = newkey(), newkey()
@@ -612,7 +635,7 @@ func randomID() (id enode.ID) {
 	return id
 }
 
-func TestEncHandshakeChecksAllowsSecondConnectionUntilPaired(t *testing.T) {
+func TestEncHandshakeChecksRejectsAlreadyConnectedPeer(t *testing.T) {
 	db, _ := enode.OpenDB("")
 	srv := &Server{
 		Config:    Config{MaxPeers: 10},
@@ -622,30 +645,11 @@ func TestEncHandshakeChecksAllowsSecondConnectionUntilPaired(t *testing.T) {
 
 	id := randomID()
 	existing := &Peer{rw: &conn{node: newNode(id, nil)}}
-	c := &conn{node: newNode(id, nil)}
-
-	err := srv.encHandshakeChecks(map[enode.ID]*Peer{id: existing}, 0, c)
-	if err != nil {
-		t.Fatalf("expected second connection to be allowed before pairing, got %v", err)
-	}
-}
-
-func TestEncHandshakeChecksRejectsWhenPaired(t *testing.T) {
-	db, _ := enode.OpenDB("")
-	srv := &Server{
-		Config:    Config{MaxPeers: 10},
-		localnode: enode.NewLocalNode(db, newkey()),
-	}
-	defer db.Close()
-
-	id := randomID()
-	existing := &Peer{rw: &conn{node: newNode(id, nil)}}
-	existing.SetPairPeer(&Peer{})
 	c := &conn{node: newNode(id, nil)}
 
 	err := srv.encHandshakeChecks(map[enode.ID]*Peer{id: existing}, 0, c)
 	if err != DiscAlreadyConnected {
-		t.Fatalf("expected paired peer to reject second connection, got %v", err)
+		t.Fatalf("expected %v, got %v", DiscAlreadyConnected, err)
 	}
 }
 
@@ -660,24 +664,5 @@ func TestRemovePeerTrackingDeletesPrimaryPeer(t *testing.T) {
 	}
 	if peers[id] != nil {
 		t.Fatal("expected primary peer to be removed from tracking")
-	}
-}
-
-func TestRemovePeerTrackingClearsPairPeer(t *testing.T) {
-	id := randomID()
-	primary := &Peer{rw: &conn{node: newNode(id, nil)}}
-	pair := &Peer{rw: &conn{node: newNode(id, nil)}}
-	primary.SetPairPeer(pair)
-	peers := map[enode.ID]*Peer{id: primary}
-
-	remaining := removePeerTracking(peers, peerDrop{Peer: pair}, 2)
-	if remaining != 1 {
-		t.Fatalf("unexpected connection count: got %d want 1", remaining)
-	}
-	if peers[id] != primary {
-		t.Fatal("expected primary peer to remain tracked")
-	}
-	if primary.PairPeer() != nil {
-		t.Fatal("expected pair peer link to be cleared")
 	}
 }

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -37,6 +37,42 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/rpc"
 )
 
+func TestRunTestReusedPeerIDDoesNotPanic(t *testing.T) {
+	svc := &testService{peers: make(map[enode.ID]*testPeer)}
+	id := enode.ID{1}
+	peer := p2p.NewPeer(id, "peer", nil)
+
+	runOnce := func() error {
+		local, remote := p2p.MsgPipe()
+		defer local.Close()
+
+		remoteErr := make(chan error, 1)
+		go func() {
+			defer remote.Close()
+			for _, code := range []uint64{2, 1, 0} {
+				if err := svc.handshake(remote, code); err != nil {
+					remoteErr <- err
+					return
+				}
+			}
+			remoteErr <- nil
+		}()
+
+		err := svc.RunTest(peer, local)
+		if remoteErr := <-remoteErr; remoteErr != nil {
+			return remoteErr
+		}
+		return err
+	}
+
+	for i := 0; i < 2; i++ {
+		err := runOnce()
+		if err != nil && err != p2p.ErrPipeClosed {
+			t.Fatalf("run %d returned %v, want nil or %v", i+1, err, p2p.ErrPipeClosed)
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())
@@ -73,6 +109,16 @@ func newTestService(ctx *adapters.ServiceContext, stack *node.Node) (node.Lifecy
 type testPeer struct {
 	testReady chan struct{}
 	dumReady  chan struct{}
+	testOnce  sync.Once
+	dumOnce   sync.Once
+}
+
+func (p *testPeer) signalTestReady() {
+	p.testOnce.Do(func() { close(p.testReady) })
+}
+
+func (p *testPeer) signalDumReady() {
+	p.dumOnce.Do(func() { close(p.dumReady) })
 }
 
 func (t *testService) peer(id enode.ID) *testPeer {
@@ -161,7 +207,7 @@ func (t *testService) RunTest(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	}
 
 	// close the testReady channel so that other protocols can run
-	close(peer.testReady)
+	peer.signalTestReady()
 
 	// track the peer
 	atomic.AddInt64(&t.peerCount, 1)
@@ -188,7 +234,7 @@ func (t *testService) RunDum(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	}
 
 	// close the dumReady channel so that other protocols can run
-	close(peer.dumReady)
+	peer.signalDumReady()
 
 	// block until the peer is dropped
 	for {

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -72,9 +73,6 @@ func newTestService(ctx *adapters.ServiceContext, stack *node.Node) (node.Lifecy
 type testPeer struct {
 	testReady chan struct{}
 	dumReady  chan struct{}
-	testOnce  sync.Once
-	dumOnce   sync.Once
-	testRuns  int
 }
 
 func (t *testService) peer(id enode.ID) *testPeer {
@@ -163,24 +161,11 @@ func (t *testService) RunTest(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	}
 
 	// close the testReady channel so that other protocols can run
-	peer.testOnce.Do(func() { close(peer.testReady) })
+	close(peer.testReady)
 
-	// Track unique active test sessions per peer ID. Duplicate protocol runs for
-	// the same remote peer should not inflate peerCount.
-	t.peersMtx.Lock()
-	peer.testRuns++
-	if peer.testRuns == 1 {
-		atomic.AddInt64(&t.peerCount, 1)
-	}
-	t.peersMtx.Unlock()
-	defer func() {
-		t.peersMtx.Lock()
-		peer.testRuns--
-		if peer.testRuns == 0 {
-			atomic.AddInt64(&t.peerCount, -1)
-		}
-		t.peersMtx.Unlock()
-	}()
+	// track the peer
+	atomic.AddInt64(&t.peerCount, 1)
+	defer atomic.AddInt64(&t.peerCount, -1)
 
 	// block until the peer is dropped
 	for {
@@ -203,7 +188,7 @@ func (t *testService) RunDum(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	}
 
 	// close the dumReady channel so that other protocols can run
-	peer.dumOnce.Do(func() { close(peer.dumReady) })
+	close(peer.dumReady)
 
 	// block until the peer is dropped
 	for {
@@ -466,20 +451,11 @@ loop:
 				Proto: event.Msg.Protocol,
 				Code:  int64(event.Msg.Code),
 			}
-			expectedCount, ok := expected[filter]
-			if !ok {
-				t.Fatalf("received unexpected msg for filter: %v", filter)
-			}
 			actual[filter]++
-
-			allReached := true
-			for wantFilter, wantCount := range expected {
-				if actual[wantFilter] < wantCount {
-					allReached = false
-					break
-				}
+			if actual[filter] > expected[filter] {
+				t.Fatalf("received too many msgs for filter: %v", filter)
 			}
-			if allReached && actual[filter] >= expectedCount {
+			if reflect.DeepEqual(actual, expected) {
 				return
 			}
 


### PR DESCRIPTION
# Proposed changes

This PR close issue #2359 and replace PR #2351

Replace the pair-peer dual-link write model with a single peer-owned write ingress backed by internal high/low priority queues.

Preserve BFT message priority across wrapper layers, keep synchronous write errors visible to callers, and make queued versus in-flight shutdown handling deterministic.

Update queue metrics and add regression coverage for priority preemption, starvation bounds, ping serialization, wrapper forwarding, and shutdown behavior.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [X] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
