### PR TITLE
fix(consensus/signingTX): fix signingTX mempool flood issue, #2358

### DIFF
--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -84,9 +84,7 @@ func CreateTransactionSign(chainConfig *params.ChainConfig, pool *txpool.TxPool,
 			}
 		}
 
-		// Use the pool's pending nonce so imported-block signing does not reuse
-		// an already-pending nonce and trigger replacement-underpriced errors.
-		nonce := pool.PoolNonce(account.Address)
+		nonce := pool.Nonce(account.Address)
 		tx := CreateTxSign(block.Number(), block.Hash(), nonce, common.BlockSignersBinary)
 		txSigned, err := wallet.SignTx(account, tx, chainConfig.ChainID)
 		if err != nil {

--- a/contracts/utils_test.go
+++ b/contracts/utils_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
-	"errors"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -501,8 +500,12 @@ func (s *nonceGuardSubPool) SetSigner(f func(address common.Address) bool) {}
 
 func (s *nonceGuardSubPool) IsSigner(addr common.Address) bool { return false }
 
-// TestCreateTransactionSignUsesPoolNonce tests create transaction sign uses pool nonce.
-func TestCreateTransactionSignUsesPoolNonce(t *testing.T) {
+// TestCreateTransactionSignUsesOnchainNonce verifies CreateTransactionSign signs
+// with the account's on-chain nonce (pool.Nonce), not the pending nonce
+// (pool.PoolNonce). Reusing the on-chain nonce is intentional: a fresher signing
+// tx replaces a stale one at the same nonce instead of queueing behind it, which
+// avoids flooding the pool when a signing tx is slow to be mined.
+func TestCreateTransactionSignUsesOnchainNonce(t *testing.T) {
 	password := "test-pass"
 	ks := keystore.NewKeyStore(t.TempDir(), keystore.LightScryptN, keystore.LightScryptP)
 
@@ -529,28 +532,17 @@ func TestCreateTransactionSignUsesPoolNonce(t *testing.T) {
 		t.Fatal("test requires XDPoS chain config")
 	}
 
-	seedTx := CreateTxSign(big.NewInt(0), common.Hash{0x1}, 0, common.BlockSignersBinary)
-	seedSigned, err := types.SignTx(seedTx, types.LatestSignerForChainID(chainConfig.ChainID), acc1Key)
-	if err != nil {
-		t.Fatalf("failed to sign seed tx: %v", err)
-	}
-	if err := pool.AddLocal(seedSigned, true); err != nil {
-		t.Fatalf("failed to seed pending nonce 0 tx: %v", err)
-	}
-
 	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
-	err = CreateTransactionSign(chainConfig, pool, manager, block, rawdb.NewMemoryDatabase(), account.Address)
-	if errors.Is(err, txpool.ErrReplaceUnderpriced) {
-		t.Fatalf("CreateTransactionSign reused pending nonce and hit replacement rejection: %v", err)
-	}
-	if err != nil {
+	if err := CreateTransactionSign(chainConfig, pool, manager, block, rawdb.NewMemoryDatabase(), account.Address); err != nil {
 		t.Fatalf("CreateTransactionSign failed: %v", err)
 	}
 
-	if len(subpool.added) < 2 {
-		t.Fatalf("expected seed tx and tx sign to be added, got %d txs", len(subpool.added))
+	if len(subpool.added) != 1 {
+		t.Fatalf("expected exactly the signing tx to be added, got %d txs", len(subpool.added))
 	}
-	if got := subpool.added[1].Nonce(); got != 1 {
-		t.Fatalf("tx sign nonce mismatch: got %d, want 1", got)
+	// The empty test state reports on-chain nonce 0, while the pool's pending
+	// nonce (mock Nonce) is 1; the signing tx must use the on-chain nonce.
+	if got := subpool.added[0].Nonce(); got != 0 {
+		t.Fatalf("tx sign used nonce %d, want on-chain nonce 0 (not pending nonce 1)", got)
 	}
 }

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -544,6 +544,173 @@ func TestPromoteSpecialTxReplacementAvoidsIntermediateOverflow(t *testing.T) {
 	}
 }
 
+// TestListAddSpecialTxReplacement verifies that a pending special (block-signing)
+// transaction can be replaced by another special transaction at the same nonce,
+// while a regular transaction cannot evict it.
+func TestListAddSpecialTxReplacement(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	// Two distinct special (block-signing) txs sharing nonce 0; the differing
+	// payload gives them different hashes.
+	oldSpecial, err := types.SignTx(types.NewTransaction(0, common.BlockSignersBinary, common.Big0, 100000, big.NewInt(1), []byte{0x01}), types.HomesteadSigner{}, key)
+	if err != nil {
+		t.Fatalf("failed to sign old special tx: %v", err)
+	}
+	newSpecial, err := types.SignTx(types.NewTransaction(0, common.BlockSignersBinary, common.Big0, 100000, big.NewInt(1), []byte{0x02}), types.HomesteadSigner{}, key)
+	if err != nil {
+		t.Fatalf("failed to sign new special tx: %v", err)
+	}
+	regular, err := types.SignTx(types.NewTransaction(0, common.Address{}, common.Big0, 21000, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	if err != nil {
+		t.Fatalf("failed to sign regular tx: %v", err)
+	}
+	if !oldSpecial.IsSpecialTransaction() || !newSpecial.IsSpecialTransaction() || regular.IsSpecialTransaction() {
+		t.Fatal("test setup: tx special-ness is wrong")
+	}
+
+	l := newList(true)
+
+	// Seed the pending list with a special tx.
+	if inserted, _ := l.Add(oldSpecial, 0); !inserted {
+		t.Fatal("failed to insert baseline special tx")
+	}
+
+	// A regular tx must NOT replace the pending special tx.
+	if inserted, _ := l.Add(regular, 0); inserted {
+		t.Fatal("regular tx should not be able to replace a special tx")
+	}
+	if tx := l.txs.Get(0); tx == nil || tx.Hash() != oldSpecial.Hash() {
+		t.Fatal("special tx should still occupy the nonce after a rejected regular replacement")
+	}
+
+	// A special tx must be able to evict a pending regular tx at the same nonce.
+	l2 := newList(true)
+	if inserted, _ := l2.Add(regular, 0); !inserted {
+		t.Fatal("failed to insert baseline regular tx")
+	}
+	if inserted, replaced := l2.Add(oldSpecial, 0); !inserted || replaced == nil || replaced.Hash() != regular.Hash() {
+		t.Fatal("special tx should evict a pending regular tx at the same nonce")
+	}
+	if tx := l2.txs.Get(0); tx == nil || tx.Hash() != oldSpecial.Hash() {
+		t.Fatal("special tx should occupy the nonce after evicting the regular tx")
+	}
+
+	// Another special tx MUST replace the pending special tx.
+	inserted, replaced := l.Add(newSpecial, 0)
+	if !inserted {
+		t.Fatal("special tx should replace existing special tx")
+	}
+	if replaced == nil || replaced.Hash() != oldSpecial.Hash() {
+		t.Fatal("replaced tx should be the old special tx")
+	}
+	if tx := l.txs.Get(0); tx == nil || tx.Hash() != newSpecial.Hash() {
+		t.Fatal("new special tx should occupy the nonce")
+	}
+
+	// Total cost should reflect only the surviving (new) tx.
+	want, overflow := uint256.FromBig(newSpecial.Cost())
+	if overflow {
+		t.Fatal("special tx cost overflowed uint256 in test setup")
+	}
+	if l.totalcost.Cmp(want) != 0 {
+		t.Fatalf("totalcost mismatch after special replacement: have %v want %v", l.totalcost, want)
+	}
+}
+
+// TestSpecialTxReplacementThroughPool exercises the special-tx replacement rules
+// end-to-end through the pool's add path (which routes a same-nonce tx into
+// list.Add): a regular tx cannot evict a pending special tx, a special tx
+// replaces a pending special tx, and a special tx evicts a pending regular tx.
+func TestSpecialTxReplacementThroughPool(t *testing.T) {
+	t.Parallel()
+
+	// A nonzero price keeps validation simple; list.Add bypasses the price-bump
+	// rules for special txs regardless of the actual price.
+	price := new(big.Int).Add(new(big.Int).Set(common.MinGasPrice), big.NewInt(1))
+	mkSpecial := func(key *ecdsa.PrivateKey, payload []byte) *types.Transaction {
+		tx, err := types.SignTx(types.NewTransaction(0, common.BlockSignersBinary, big.NewInt(0), 100000, price, payload), types.HomesteadSigner{}, key)
+		if err != nil {
+			t.Fatalf("failed to sign special tx: %v", err)
+		}
+		return tx
+	}
+
+	// Case 1: a regular tx must NOT evict a pending special tx at the same nonce.
+	t.Run("regular cannot evict special", func(t *testing.T) {
+		pool, _ := setupPool()
+		defer pool.Close()
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		testAddBalance(pool, addr, big.NewInt(1_000_000_000_000_000))
+
+		special := mkSpecial(key, []byte{0x01})
+		if err := pool.addRemoteSync(special); err != nil {
+			t.Fatalf("failed to add special tx: %v", err)
+		}
+		regular := pricedTransaction(0, 100000, new(big.Int).Add(new(big.Int).Set(price), big.NewInt(1000)), key)
+		if err := pool.addRemoteSync(regular); !errors.Is(err, txpool.ErrReplaceUnderpriced) {
+			t.Fatalf("regular tx should be rejected, got err: %v", err)
+		}
+		if pool.all.Get(special.Hash()) == nil {
+			t.Fatal("special tx should still be present")
+		}
+		if pool.all.Get(regular.Hash()) != nil {
+			t.Fatal("rejected regular tx should not be present")
+		}
+	})
+
+	// Case 2: a fresh special tx replaces a pending special tx at the same nonce.
+	t.Run("special replaces special", func(t *testing.T) {
+		pool, _ := setupPool()
+		defer pool.Close()
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		testAddBalance(pool, addr, big.NewInt(1_000_000_000_000_000))
+
+		oldSpecial := mkSpecial(key, []byte{0x01})
+		newSpecial := mkSpecial(key, []byte{0x02})
+		if err := pool.addRemoteSync(oldSpecial); err != nil {
+			t.Fatalf("failed to add old special tx: %v", err)
+		}
+		if err := pool.addRemoteSync(newSpecial); err != nil {
+			t.Fatalf("special-replaces-special should succeed, got err: %v", err)
+		}
+		if pool.all.Get(oldSpecial.Hash()) != nil {
+			t.Fatal("old special tx should have been replaced")
+		}
+		if pool.all.Get(newSpecial.Hash()) == nil {
+			t.Fatal("new special tx should be present")
+		}
+	})
+
+	// Case 3: a special tx evicts a pending regular tx at the same nonce.
+	t.Run("special evicts regular", func(t *testing.T) {
+		pool, _ := setupPool()
+		defer pool.Close()
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		testAddBalance(pool, addr, big.NewInt(1_000_000_000_000_000))
+
+		regular := pricedTransaction(0, 100000, new(big.Int).Add(new(big.Int).Set(price), big.NewInt(1000)), key)
+		if err := pool.addRemoteSync(regular); err != nil {
+			t.Fatalf("failed to add regular tx: %v", err)
+		}
+		special := mkSpecial(key, []byte{0x01})
+		if err := pool.addRemoteSync(special); err != nil {
+			t.Fatalf("special tx should evict regular tx, got err: %v", err)
+		}
+		if pool.all.Get(regular.Hash()) != nil {
+			t.Fatal("regular tx should have been evicted")
+		}
+		if pool.all.Get(special.Hash()) == nil {
+			t.Fatal("special tx should be present")
+		}
+	})
+}
+
 // TestPromoteSpecialTxOverflowReturnsErrorWithoutMutation tests promote special tx overflow returns error without mutation.
 func TestPromoteSpecialTxOverflowReturnsErrorWithoutMutation(t *testing.T) {
 	pool, key := setupPool()

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -315,9 +315,9 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 		//   new special               -> replace: a special (block-signing/randomize)
 		//                                 tx always claims its nonce, evicting whatever
 		//                                 is there, bypassing the price-bump rules.
-		//                                 Signing txs carry a fixed 0 gas price and are
-		//                                 consensus-critical, so they must never be
-		//                                 blocked by a same-nonce tx.
+		//                                 These txs are typically generated with a 0
+		//                                 gas price and are consensus-critical, so they
+		//                                 must never be blocked by a same-nonce tx.
 		//   old special, new regular  -> reject: a regular tx must not evict a pending
 		//                                 special tx.
 		//   old regular, new regular  -> replace only if the new tx beats the old on

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -309,27 +309,47 @@ func (l *list) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Transa
 	// If there's an older better transaction, abort
 	old := l.txs.Get(tx.Nonce())
 	if old != nil {
-		if old.IsSpecialTransaction() {
+		// A transaction already occupies this nonce; decide whether the incoming
+		// one may replace it. Cases by (old, new) kind:
+		//
+		//   new special               -> replace: a special (block-signing/randomize)
+		//                                 tx always claims its nonce, evicting whatever
+		//                                 is there, bypassing the price-bump rules.
+		//                                 Signing txs carry a fixed 0 gas price and are
+		//                                 consensus-critical, so they must never be
+		//                                 blocked by a same-nonce tx.
+		//   old special, new regular  -> reject: a regular tx must not evict a pending
+		//                                 special tx.
+		//   old regular, new regular  -> replace only if the new tx beats the old on
+		//                                 both fee cap and tip by at least priceBump%.
+		//
+		// In every accepted case we fall through to the cost accounting below.
+		if tx.IsSpecialTransaction() {
+			// new special: always wins its nonce, no further checks.
+		} else if old.IsSpecialTransaction() {
+			// old special, new regular: protect the pending special tx.
 			return false, nil
-		}
-		if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
-			return false, nil
-		}
-		// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
-		a := big.NewInt(100 + int64(priceBump))
-		aFeeCap := new(big.Int).Mul(a, old.GasFeeCap())
-		aTip := a.Mul(a, old.GasTipCap())
+		} else {
+			// regular replacing regular: enforce the price-bump rules.
+			if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
+				return false, nil
+			}
+			// thresholdFeeCap = oldFC  * (100 + priceBump) / 100
+			a := big.NewInt(100 + int64(priceBump))
+			aFeeCap := new(big.Int).Mul(a, old.GasFeeCap())
+			aTip := a.Mul(a, old.GasTipCap())
 
-		// thresholdTip    = oldTip * (100 + priceBump) / 100
-		b := big.NewInt(100)
-		thresholdFeeCap := aFeeCap.Div(aFeeCap, b)
-		thresholdTip := aTip.Div(aTip, b)
+			// thresholdTip    = oldTip * (100 + priceBump) / 100
+			b := big.NewInt(100)
+			thresholdFeeCap := aFeeCap.Div(aFeeCap, b)
+			thresholdTip := aTip.Div(aTip, b)
 
-		// Have to ensure that either the new fee cap or tip is higher than the
-		// old ones as well as checking the percentage threshold to ensure that
-		// this is accurate for low (Wei-level) gas price replacements
-		if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
-			return false, nil
+			// Have to ensure that either the new fee cap or tip is higher than the
+			// old ones as well as checking the percentage threshold to ensure that
+			// this is accurate for low (Wei-level) gas price replacements
+			if tx.GasFeeCapIntCmp(thresholdFeeCap) < 0 || tx.GasTipCapIntCmp(thresholdTip) < 0 {
+				return false, nil
+			}
 		}
 		// Old is being replaced, subtract old cost
 		if _, underflow := base.SubOverflow(base, uint256.MustFromBig(old.Cost())); underflow {

--- a/eth/hooks/engine_v2_hooks.go
+++ b/eth/hooks/engine_v2_hooks.go
@@ -180,6 +180,7 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 						}
 					}
 					// Check signer signed?
+					// TODO: check here needs dedup?
 					for _, tx := range signingTxs {
 						blkHash := common.BytesToHash(tx.Data()[len(tx.Data())-32:])
 						from := *tx.From()
@@ -250,6 +251,7 @@ func AttachConsensusV2Hooks(adaptor *XDPoS.XDPoS, bc *core.BlockChain, chainConf
 						}
 					}
 					// Check signer signed?
+					// TODO: check here needs dedup?
 					for _, tx := range signingTxs {
 						blkHash := common.BytesToHash(tx.Data()[len(tx.Data())-32:])
 						from := *tx.From()

--- a/miner/ordering_test.go
+++ b/miner/ordering_test.go
@@ -196,8 +196,11 @@ func TestNewTransactionsByPriceAndNonce_SpecialSeparation(t *testing.T) {
 		tx, _ := types.SignTx(types.NewTransaction(nonce, common.HexToAddress("0x1234567890123456789012345678901234567890"), big.NewInt(1), 21000, big.NewInt(1), nil), signer, key)
 		return &txpool.LazyTransaction{Tx: tx, Hash: tx.Hash(), Time: tx.Time(), GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()), GasTipCap: uint256.MustFromBig(tx.GasTipCap())}
 	}
-	genSpecialTx := func(nonce uint64, key *ecdsa.PrivateKey) *txpool.LazyTransaction {
-		tx, _ := types.SignTx(types.NewTransaction(nonce, common.BlockSignersBinary, big.NewInt(1), 21000, big.NewInt(1), nil), signer, key)
+	// Special txs are classified by recipient (IsSpecialTransaction), which covers
+	// both the block-signer and the randomize contract; parameterize over the
+	// target so both are exercised.
+	genSpecialTx := func(nonce uint64, to common.Address, key *ecdsa.PrivateKey) *txpool.LazyTransaction {
+		tx, _ := types.SignTx(types.NewTransaction(nonce, to, big.NewInt(1), 21000, big.NewInt(1), nil), signer, key)
 		return &txpool.LazyTransaction{Tx: tx, Hash: tx.Hash(), Time: tx.Time(), GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()), GasTipCap: uint256.MustFromBig(tx.GasTipCap())}
 	}
 
@@ -229,7 +232,13 @@ func TestNewTransactionsByPriceAndNonce_SpecialSeparation(t *testing.T) {
 				txs = append(txs, genNormalTx(uint64(i), key))
 			}
 			for i := 0; i < tc.specialCount; i++ {
-				txs = append(txs, genSpecialTx(uint64(tc.normalCount+i), key))
+				// Alternate between the two special-contract recipients so both
+				// the block-signer and randomize routing paths are covered.
+				to := common.BlockSignersBinary
+				if i%2 == 1 {
+					to = common.RandomizeSMCBinary
+				}
+				txs = append(txs, genSpecialTx(uint64(tc.normalCount+i), to, key))
 			}
 			group := map[common.Address][]*txpool.LazyTransaction{}
 			if len(txs) > 0 {
@@ -242,7 +251,7 @@ func TestNewTransactionsByPriceAndNonce_SpecialSeparation(t *testing.T) {
 				t.Errorf("expected %d special txs, got %d", tc.expectSpecial, len(specialTxs))
 			}
 			for _, tx := range specialTxs {
-				if tx.To() == nil || *tx.To() != common.BlockSignersBinary {
+				if !tx.IsSpecialTransaction() {
 					t.Errorf("specialTxs contains non-special tx: %v", tx)
 				}
 			}
@@ -251,8 +260,8 @@ func TestNewTransactionsByPriceAndNonce_SpecialSeparation(t *testing.T) {
 			normalCount := 0
 			for tx := txset.Peek(); tx != nil; tx = txset.Peek() {
 				resolved := tx.Resolve()
-				if resolved == nil || resolved.To() == nil || *resolved.To() == common.BlockSignersBinary {
-					t.Errorf("txset contains special or nil-to tx: %v", resolved)
+				if resolved == nil || resolved.IsSpecialTransaction() {
+					t.Errorf("txset contains special tx: %v", resolved)
 				}
 				normalCount++
 				txset.Shift()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1153,7 +1153,7 @@ func (w *Work) commitTransactions(mux *event.TypeMux, balanceFee map[common.Addr
 				continue
 			}
 			blkNumber := new(big.Int).SetBytes(data[4:36]).Uint64()
-			if blkNumber >= w.header.Number.Uint64() || blkNumber+w.config.XDPoS.Epoch*2 <= w.header.Number.Uint64() {
+			if blkNumber >= w.header.Number.Uint64() {
 				log.Trace("Data special transaction invalid number", "hash", hash, "blkNumber", blkNumber, "miner", w.header.Number)
 				continue
 			}


### PR DESCRIPTION
# Proposed changes
ref: https://github.com/XinFinOrg/XDPoSChain/issues/2358

A single masternode (`0x22f69af9…EaEDD`) flooded devnet mempools with ~4,700 zero-gas `BlockSigners.sign()` txs that can't mine. 

Many dimensions to the problem, multiple bugs and behavior change came to cause current issue.


**Proposing**
1. Allowing of replacement of specialTXs with the same nonce.
2. Making sign() method refer to on-chain nonce instead of pending mempool nonce. 

This will prevent potential flooding if a signing transaction was unable to be mined, it will get replaced by the next TX in 15 blocks instead of having subsequent tx stacks behind it at increasing nonces.

3. Dropped the "1800 blocks acceptance window" as a safety measure to not have lingering signingTX in mempool. This doesn't affect reward and penalty calculation in any way.

(refer to reference issue for more detail https://github.com/XinFinOrg/XDPoSChain/issues/2358)


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [x] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [x] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
