### PR TITLE
feat(cmd/puppeth): set required XDC fork fields in XDPoS genesis

### DIFF
--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -53,6 +53,8 @@ type GenesisInput struct {
 	TimeoutPeriod           int
 	TimeoutSyncThreshold    int
 	V2SwitchBlock           uint64
+	TIPTRC21FeeBlock        uint64
+	Gas50xBlock             uint64
 	CertThreshold           float64
 	MasternodesOwner        common.Address
 	Masternodes             []common.Address
@@ -72,6 +74,8 @@ func NewGenesisInput() *GenesisInput {
 		TimeoutPeriod:           10,
 		TimeoutSyncThreshold:    3,
 		V2SwitchBlock:           0,
+		TIPTRC21FeeBlock:        0,
+		Gas50xBlock:             0,
 		CertThreshold:           0.667,
 		StakingThreshold:        10_000_000, // 10M
 		RewardYield:             10,
@@ -327,6 +331,42 @@ func (w *wizard) makeGenesis() {
 			genesis.Config.XDPoS.FoundationWalletAddr = input.FoundationWalletAddress
 		} else {
 			genesis.Config.XDPoS.FoundationWalletAddr = w.readDefaultAddress(common.FoundationAddrBinary)
+		}
+
+		// XDC system contract addresses, required by the chain config validator.
+		// Hardcoded to the canonical mainnet values.
+		genesis.Config.TRC21IssuerSMC = params.XDCMainnetChainConfig.TRC21IssuerSMC
+		genesis.Config.XDCXListingSMC = params.XDCMainnetChainConfig.XDCXListingSMC
+		genesis.Config.RelayerRegistrationSMC = params.XDCMainnetChainConfig.RelayerRegistrationSMC
+		genesis.Config.LendingRegistrationSMC = params.XDCMainnetChainConfig.LendingRegistrationSMC
+
+		// TIPTRC21FeeBlock and Gas50xBlock are required forks; Gas50xBlock must
+		// activate no earlier than TIPTRC21FeeBlock.
+		fmt.Println()
+		fmt.Println("Which block number activates the TRC21 fee fork (TIPTRC21FeeBlock)? (default = 0)")
+		if input != nil {
+			genesis.Config.TIPTRC21FeeBlock = new(big.Int).SetUint64(input.TIPTRC21FeeBlock)
+		} else {
+			genesis.Config.TIPTRC21FeeBlock = w.readDefaultBigInt(big.NewInt(0))
+		}
+
+		fmt.Println()
+		fmt.Println("Which block number activates the 50x gas fork (Gas50xBlock)? (default = 0)")
+		if input != nil {
+			genesis.Config.Gas50xBlock = new(big.Int).SetUint64(input.Gas50xBlock)
+			if genesis.Config.Gas50xBlock.Cmp(genesis.Config.TIPTRC21FeeBlock) < 0 {
+				log.Crit("Invalid Gas50xBlock, must be greater than or equal to TIPTRC21FeeBlock",
+					"Gas50xBlock", genesis.Config.Gas50xBlock, "TIPTRC21FeeBlock", genesis.Config.TIPTRC21FeeBlock)
+			}
+		} else {
+			for {
+				genesis.Config.Gas50xBlock = w.readDefaultBigInt(new(big.Int).Set(genesis.Config.TIPTRC21FeeBlock))
+				if genesis.Config.Gas50xBlock.Cmp(genesis.Config.TIPTRC21FeeBlock) >= 0 {
+					break
+				}
+				log.Error("Invalid input, Gas50xBlock must be greater than or equal to TIPTRC21FeeBlock",
+					"Gas50xBlock", genesis.Config.Gas50xBlock, "TIPTRC21FeeBlock", genesis.Config.TIPTRC21FeeBlock)
+			}
 		}
 
 		// Validator Smart Contract Code


### PR DESCRIPTION
# Proposed changes

PR #2329 promoted six XDC fork settings to top-level ChainConfig fields and added validation that rejects an XDPoS genesis missing them. The puppeth wizard was not updated, so generated XDPoS genesis files failed with 'invalid chain config: missing fork switch: TRC21IssuerSMC'.

Hardcode the four system contract addresses (TRC21IssuerSMC, XDCXListingSMC, RelayerRegistrationSMC, LendingRegistrationSMC) to their canonical mainnet values, and prompt for TIPTRC21FeeBlock and Gas50xBlock via the wizard. Gas50xBlock input is validated to be greater than or equal to TIPTRC21FeeBlock, with interactive re-entry on invalid values.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
