### PR TITLE
fix(contracts): use pending nonce for signer txs

### DIFF
--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -84,7 +84,7 @@ func CreateTransactionSign(chainConfig *params.ChainConfig, pool *txpool.TxPool,
 			}
 		}
 
-		nonce := pool.Nonce(account.Address)
+		nonce := pool.PoolNonce(account.Address)
 		tx := CreateTxSign(block.Number(), block.Hash(), nonce, common.BlockSignersBinary)
 		txSigned, err := wallet.SignTx(account, tx, chainConfig.ChainID)
 		if err != nil {

--- a/contracts/utils_test.go
+++ b/contracts/utils_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
-	"errors"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -501,7 +500,7 @@ func (s *nonceGuardSubPool) SetSigner(f func(address common.Address) bool) {}
 
 func (s *nonceGuardSubPool) IsSigner(addr common.Address) bool { return false }
 
-func TestCreateTransactionSignUsesStateNonce(t *testing.T) {
+func TestCreateTransactionSignUsesPendingNonce(t *testing.T) {
 	password := "test-pass"
 	ks := keystore.NewKeyStore(t.TempDir(), keystore.LightScryptN, keystore.LightScryptP)
 
@@ -548,24 +547,21 @@ func TestCreateTransactionSignUsesStateNonce(t *testing.T) {
 		t.Fatalf("failed to seed pending nonce 0 tx: %v", err)
 	}
 
-	// CreateTransactionSign must derive the nonce from chain STATE (0), not the
-	// pending nonce (1). Its sign tx therefore lands on the already-pending nonce 0
-	// and the pool rejects the duplicate with ErrReplaceUnderpriced. Had it used the
-	// pending nonce (1) there would be no collision and a second sign tx would be
-	// added at nonce 1 -- which the length check below rules out. The duplicate
-	// rejection is the expected outcome (whether surfaced or swallowed); any other
-	// error is a real failure.
+	// CreateTransactionSign must derive the nonce from pool pending state (1), not
+	// from chain state (0). Since nonce 0 is already pending, using pending nonce 1
+	// should add a second tx successfully without replacement errors.
 	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(0)})
-	if err := CreateTransactionSign(chainConfig, pool, manager, block, rawdb.NewMemoryDatabase(), account.Address); err != nil && !errors.Is(err, txpool.ErrReplaceUnderpriced) {
-		t.Fatalf("unexpected error from CreateTransactionSign: %v", err)
+	if err := CreateTransactionSign(chainConfig, pool, manager, block, rawdb.NewMemoryDatabase(), account.Address); err != nil {
+		t.Fatalf("CreateTransactionSign returned error: %v", err)
 	}
 
-	// Only the seeded tx is present: the colliding sign tx at state nonce 0 was
-	// rejected. A second entry (at nonce 1) would mean the pending nonce was used.
-	if len(subpool.added) != 1 {
-		t.Fatalf("expected only the seeded tx (sign tx should collide at state nonce 0), got %d txs", len(subpool.added))
+	if len(subpool.added) != 2 {
+		t.Fatalf("expected seed tx plus a new sign tx at pending nonce, got %d txs", len(subpool.added))
 	}
 	if got := subpool.added[0].Nonce(); got != 0 {
 		t.Fatalf("seeded tx nonce mismatch: got %d, want 0", got)
+	}
+	if got := subpool.added[1].Nonce(); got != 1 {
+		t.Fatalf("newly added sign tx nonce mismatch: got %d, want 1", got)
 	}
 }


### PR DESCRIPTION
# Proposed changes

Use the txpool pending nonce when creating block signer transactions so retries do not collide with an existing pending nonce and trigger replacement transaction underpriced.

fix error:

```text
ERROR[06-23|00:32:34.488] Fail to add tx sign to local pool.       error="replacement transaction underpriced" number=83,413,035 hash=0x67834104299fb6edf2a95c317f5c6f49ba48de53213952dd16bc835c92df4f3e from=0xB84BF95eaf3F18F4893a1f3057F38FB0544aC2AA nonce=1,728,855
ERROR[06-23|00:32:34.488] Can't sign the imported block            err="fail to create tx sign for importing block: replacement transaction underpriced"
```


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [X] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
