### PR TITLE
fix(p2p/discover): return nil when v4 resolve cannot refresh node

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -289,7 +289,12 @@ func discv4Resolve(ctx *cli.Context) error {
 	disc := startV4(ctx)
 	defer disc.Close()
 
-	fmt.Println(disc.Resolve(n).String())
+	resolved := disc.Resolve(n)
+	if resolved == nil {
+		fmt.Println("unresolved")
+		return fmt.Errorf("could not resolve node %s", n.ID())
+	}
+	fmt.Println(resolved.String())
 	return nil
 }
 

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -175,7 +175,7 @@ func (t *UDPv4) Close() {
 }
 
 // Resolve searches for a specific node with the given ID and tries to get the most recent
-// version of the node record for it. It returns n if the node could not be resolved.
+// version of the node record for it. It returns nil if the node could not be resolved.
 func (t *UDPv4) Resolve(n *enode.Node) *enode.Node {
 	// Try asking directly. This works if the node is still responding on the endpoint we have.
 	if rn, err := t.RequestENR(n); err == nil {
@@ -191,7 +191,7 @@ func (t *UDPv4) Resolve(n *enode.Node) *enode.Node {
 	// Otherwise perform a network lookup.
 	var key enode.Secp256k1
 	if n.Load(&key) != nil {
-		return n // no secp256k1 key
+		return nil // no secp256k1 key
 	}
 	result := t.LookupPubkey((*ecdsa.PublicKey)(&key))
 	for _, rn := range result {
@@ -201,7 +201,7 @@ func (t *UDPv4) Resolve(n *enode.Node) *enode.Node {
 			}
 		}
 	}
-	return n
+	return nil
 }
 
 func (t *UDPv4) ourEndpoint() v4wire.Endpoint {

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -184,6 +184,41 @@ func TestUDPv4_pingTimeout(t *testing.T) {
 	}
 }
 
+func TestUDPv4_resolveReturnsNilWhenUnresolved(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	var r enr.Record
+	ip := net.IP{127, 0, 0, 1}
+	id := enode.ID{9}
+	r.Set(enr.IP(ip))
+	r.Set(enr.UDP(30303))
+	n := enode.SignNull(&r, id)
+
+	// Avoid triggering the extra bonding ping path in requestENR.
+	test.udp.db.UpdateLastPingReceived(id, ip, time.Now())
+
+	if resolved := test.udp.Resolve(n); resolved != nil {
+		t.Fatalf("expected nil for unresolved node, got: %v", resolved)
+	}
+}
+
+func TestUDPv4_resolveReturnsNilWhenLookupMisses(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.close()
+
+	key := newkey()
+	ip := net.IP{127, 0, 0, 1}
+	n := enode.NewV4(&key.PublicKey, ip, 30303, 30303)
+
+	// Avoid triggering the extra bonding ping path in requestENR.
+	test.udp.db.UpdateLastPingReceived(n.ID(), ip, time.Now())
+
+	if resolved := test.udp.Resolve(n); resolved != nil {
+		t.Fatalf("expected nil for unresolved node with secp256k1 key, got: %v", resolved)
+	}
+}
+
 type testPacket byte
 
 func (req testPacket) Kind() byte   { return byte(req) }


### PR DESCRIPTION
# Proposed changes

Restore Resolve failure semantics to return nil so dial backoff can detect unresolved nodes correctly.

Add a regression test covering unresolved ENR refresh paths.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
