### PR TITLE
fix(eth/filters): return -32602 when exceeding the block range limit #34647

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -19,7 +19,6 @@ package filters
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -155,7 +154,7 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		return nil, err
 	}
 	if f.rangeLimit != 0 && (uint64(f.end)-uint64(f.begin)) > f.rangeLimit {
-		return nil, fmt.Errorf("exceed maximum block range: %d", f.rangeLimit)
+		return nil, invalidParamsErr("exceed maximum block range %d", f.rangeLimit)
 	}
 
 	logChan, errChan := f.rangeLogsAsync(ctx)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -19,6 +19,7 @@ package filters
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"strings"
 	"testing"
@@ -388,7 +389,19 @@ func TestRangeLimit(t *testing.T) {
 	// Set rangeLimit to 5, but request a range of 9 (end - begin = 9, from 0 to 9)
 	filter := sys.NewRangeFilter(0, 9, nil, nil, 5)
 	_, err = filter.Logs(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "exceed maximum block range") {
-		t.Fatalf("expected range limit error, got %v", err)
+	if err == nil {
+		t.Fatal("expected range limit error, got nil")
+	}
+
+	var re rpc.Error
+	if errors.As(err, &re) {
+		if re.ErrorCode() != -32602 {
+			t.Fatalf("expected error code -32602, got %d", re.ErrorCode())
+		}
+		if re.Error() != "exceed maximum block range 5" {
+			t.Fatalf("expected error message 'exceed maximum block range 5', got %q", re.Error())
+		}
+	} else {
+		t.Fatalf("expected rpc error, got %v", err)
 	}
 }


### PR DESCRIPTION
# Proposed changes

Ref: #34647

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
