### PR TITLE
fix(genesis): sync devnet alloc with DevnetAllocData to restore genesis hash

### DIFF
--- a/core/genesis_load_test.go
+++ b/core/genesis_load_test.go
@@ -1209,3 +1209,48 @@ func TestEmbeddedGenesisConfigMatchesParams(t *testing.T) {
 		})
 	}
 }
+
+// TestEmbeddedGenesisHashMatchesParams verifies that the genesis block hash
+// derived from each network's embedded JSON equals the canonical hash constant
+// in params.  A mismatch means `XDC init <network>` and `XDC --<network>`
+// would produce different block-0 headers, making nodes on each path unable to
+// peer with one another.
+//
+// Historical note: this divergence occurred for devnet when
+// core/genesis_alloc_devnet.go was updated by the May-2026 network reset
+// (#2347) without a corresponding update to genesis/devnet.json, causing the
+// two startup paths to silently generate different genesis hashes until the
+// alloc was re-synchronised in a follow-up fix.
+func TestEmbeddedGenesisHashMatchesParams(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      []byte
+		wantHash common.Hash
+	}{
+		{"mainnet", xdcgenesis.MainnetGenesis, params.MainnetGenesisHash},
+		{"testnet", xdcgenesis.TestnetGenesis, params.TestnetGenesisHash},
+		{"devnet", xdcgenesis.DevnetGenesis, params.DevnetGenesisHash},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			g := new(Genesis)
+			if err := json.Unmarshal(c.raw, g); err != nil {
+				t.Fatalf("unmarshal embedded %s genesis: %v", c.name, err)
+			}
+			got := g.ToBlock().Hash()
+			if got != c.wantHash {
+				t.Errorf("embedded %s genesis hash mismatch:\n  got  %s\n  want %s\nAlloc or header fields in the embedded JSON diverge from the Go-side genesis used to derive params.%sGenesisHash.",
+					c.name, got.Hex(), c.wantHash.Hex(), capitalize(c.name))
+			}
+		})
+	}
+}
+
+// capitalize upper-cases the first ASCII character of s.
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/genesis/devnet.json
+++ b/genesis/devnet.json
@@ -1049,6 +1049,15 @@
     },
     "b25193378f1ac1f13353a894b77292588f724490": {
       "balance": "0x115eec47f6cf7e35000000"
+    },
+    "4b1a14a10cb48e4cfddd17c379dfcaa358b011bc": {
+      "balance": "0xc9f2c9cd04674edea40000000"
+    },
+    "d16c20329d391104029d0a850dcdf9ed6e259b60": {
+      "balance": "0xc9f2c9cd04674edea40000000"
+    },
+    "cc08002e7e4baec892785887a74d35557e8d2c15": {
+      "balance": "0xc9f2c9cd04674edea40000000"
     }
   },
   "number": "0x0",


### PR DESCRIPTION
# Proposed changes

The devnet genesis hash exposed by `XDC init devnet` diverged from params.DevnetGenesisHash (used by `XDC --devnet` / DefaultDevnetGenesisBlock). The two paths would have produced different block 0, making nodes initialized via each method unable to peer with one another.

Root cause
----------
Commit 00be1f500 (chore(devnet): may 2026 devnet reset, #2347, 2026-05-25) updated core/genesis_alloc_devnet.go and common/constants.devnet.go as part of a devnet network reset.  It added three pre-funded accounts to DevnetAllocData:

  4b1a14a10cb48e4cfddd17c379dfcaa358b011bc
  d16c20329d391104029d0a850dcdf9ed6e259b60
  cc08002e7e4baec892785887a74d35557e8d2c15

params.DevnetGenesisHash was later updated to reflect the new state root in dfce638a1 (#2329, 2026-05-28).

genesis/devnet.json was NOT touched by either commit; its alloc still contained only the pre-May-2026 eight accounts.  Commit 1c0923db7 (#2354, 2026-07-06) then filled in the config section of devnet.json but again left the alloc unchanged, so the JSON-derived genesis hash remained 0x7dad95... while params.DevnetGenesisHash was 0xb8be00...

Fix
---
Add the three missing balance-only accounts to genesis/devnet.json alloc, bringing it into parity with DevnetAllocData.  After this change:

  json.Unmarshal(DevnetGenesis).ToBlock().Hash() == params.DevnetGenesisHash
                                                 == 0xb8be003946a9c268...

Verified by running TestEmbeddedGenesisConfigMatchesParams (all three networks pass) and a targeted hash-equality check.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
