### PR TITLE
feat(params,consensus/XDPoS): log stable structured v2 startup config

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -99,8 +99,6 @@ func New(chainConfig *params.ChainConfig, db ethdb.Database) (*XDPoS, error) {
 		return nil, errors.New("missing XDPoS config")
 	}
 
-	log.Info("xdc config loading", "v2 config", config.V2)
-
 	minePeriodCh := make(chan int)
 	newRoundCh := make(chan types.Round, newRoundChanSize)
 	engineV2, err := engine_v2.New(chainConfig, db, minePeriodCh, newRoundCh)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -149,6 +149,7 @@ func New(stack *node.Node, config *ethconfig.Config, XDCXServ *XDCx.XDCX, lendin
 	if err != nil {
 		return nil, err
 	}
+	logXDPoSConfig(chainConfig, compatErr)
 
 	// Assemble the Ethereum object.
 	eth := &Ethereum{
@@ -460,6 +461,14 @@ func (e *Ethereum) APIs() []rpc.API {
 			Service:   e.netRPCService,
 		},
 	}...)
+}
+
+func logXDPoSConfig(chainConfig *params.ChainConfig, compatErr *params.ConfigCompatError) {
+	if compatErr != nil || chainConfig == nil || chainConfig.XDPoS == nil || chainConfig.XDPoS.V2 == nil {
+		return
+	}
+
+	log.Info("Load xdc config", "config.V2", chainConfig.XDPoS.V2.StableLogValue())
 }
 
 func (e *Ethereum) ResetWithGenesisBlock(gb *types.Block) {

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -1,8 +1,10 @@
 package eth
 
 import (
+	"bytes"
 	"encoding/json"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
@@ -10,6 +12,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/eth/util"
+	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
 )
 
@@ -41,6 +44,29 @@ func TestRewardInflationUsesChainConfigTIPNoHalvingMNReward(t *testing.T) {
 	reward := util.RewardInflation(testChainReader{cfg: config}, chainReward, 20, 10)
 	if reward.Cmp(new(big.Int).Mul(new(big.Int).SetUint64(250), new(big.Int).SetUint64(params.Ether))) != 0 {
 		t.Fatalf("unexpected reward with no-halving fork: have %v", reward)
+	}
+}
+
+func TestLogXDPoSConfigSkipsOnCompatError(t *testing.T) {
+	var logBuf bytes.Buffer
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelTrace, false))
+	glog.Verbosity(log.LevelTrace)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	logXDPoSConfig(params.TestnetChainConfig, &params.ConfigCompatError{What: "XDPoS.V2"})
+	if got := logBuf.String(); got != "" {
+		t.Fatalf("expected no XDPoS config log on compat error, got %q", got)
+	}
+
+	logXDPoSConfig(params.TestnetChainConfig, nil)
+	got := logBuf.String()
+	if !strings.Contains(got, "Load xdc config") {
+		t.Fatalf("expected XDPoS config log on healthy startup, got %q", got)
+	}
+	if !strings.Contains(got, "config.V2") {
+		t.Fatalf("expected V2 config details in startup log, got %q", got)
 	}
 }
 

--- a/params/config_xdpos.go
+++ b/params/config_xdpos.go
@@ -521,6 +521,54 @@ func (v2 *V2) String() string {
 	return fmt.Sprintf("V2{SwitchEpoch: %v, SwitchBlock: %v, %s}", snapshot.switchEpoch, snapshot.switchBlock, snapshot.currentConfig.String())
 }
 
+type stableLogConfigEntry struct {
+	Round  uint64    `json:"round"`
+	Config *V2Config `json:"config"`
+}
+
+type stableLogView struct {
+	SwitchEpoch   uint64                 `json:"switchEpoch"`
+	SwitchBlock   string                 `json:"switchBlock"`
+	CurrentConfig *V2Config              `json:"currentConfig"`
+	AllConfigs    []stableLogConfigEntry `json:"allConfigs"`
+	ConfigIndex   []uint64               `json:"configIndex"`
+}
+
+// StableLogValue returns a full, deterministic structured value for startup
+// logs. Callers can pass the returned object directly as a field value to
+// avoid JSON string escaping in terminal log output.
+func (v2 *V2) StableLogValue() stableLogView {
+	if v2 == nil {
+		return stableLogView{}
+	}
+
+	snapshot := snapshotV2ReadOnly(v2)
+
+	keys := slices.Collect(maps.Keys(snapshot.allConfigs))
+	slices.Sort(keys)
+
+	allConfigs := make([]stableLogConfigEntry, 0, len(keys))
+	for _, round := range keys {
+		allConfigs = append(allConfigs, stableLogConfigEntry{
+			Round:  round,
+			Config: snapshot.allConfigs[round].Clone(),
+		})
+	}
+
+	var switchBlock string
+	if snapshot.switchBlock != nil {
+		switchBlock = snapshot.switchBlock.String()
+	}
+
+	return stableLogView{
+		SwitchEpoch:   snapshot.switchEpoch,
+		SwitchBlock:   switchBlock,
+		CurrentConfig: snapshot.currentConfig.Clone(),
+		AllConfigs:    allConfigs,
+		ConfigIndex:   append([]uint64(nil), snapshot.configIndex...),
+	}
+}
+
 // Description returns a human-readable description of V2
 // NOTE: don't append "\n" to end
 func (v2 *V2) Description(indent int) string {

--- a/params/config_xdpos_test.go
+++ b/params/config_xdpos_test.go
@@ -19,6 +19,7 @@ package params
 import (
 	"encoding/json"
 	"math/big"
+	"strings"
 	"sync"
 	"testing"
 
@@ -190,6 +191,44 @@ func TestV2StringConcurrentWithUpdateConfig(t *testing.T) {
 
 	close(start)
 	wg.Wait()
+}
+
+func TestV2StableLogValueDeterministicAndComplete(t *testing.T) {
+	v2 := &V2{
+		SwitchEpoch: 63143,
+		SwitchBlock: big.NewInt(56828700),
+		CurrentConfig: &V2Config{
+			MaxMasternodes: 15,
+		},
+		AllConfigs: map[uint64]*V2Config{
+			10: {SwitchRound: 10, MaxMasternodes: 16},
+			0:  {SwitchRound: 0, MaxMasternodes: 15},
+		},
+		configIndex: []uint64{10, 0},
+	}
+
+	firstBytes, err := json.Marshal(v2.StableLogValue())
+	assert.NoError(t, err)
+	secondBytes, err := json.Marshal(v2.StableLogValue())
+	assert.NoError(t, err)
+
+	first := string(firstBytes)
+	second := string(secondBytes)
+	assert.Equal(t, first, second)
+
+	assert.Contains(t, first, `"switchEpoch":63143`)
+	assert.Contains(t, first, `"switchBlock":"56828700"`)
+	assert.Contains(t, first, `"configIndex":[10,0]`)
+	assert.Contains(t, first, `"currentConfig"`)
+
+	idxRound0 := strings.Index(first, `"round":0`)
+	idxRound10 := strings.Index(first, `"round":10`)
+	if idxRound0 == -1 || idxRound10 == -1 {
+		t.Fatalf("expected allConfigs rounds in stable log output, got %q", first)
+	}
+	if idxRound0 > idxRound10 {
+		t.Fatalf("expected allConfigs rounds sorted ascending, got %q", first)
+	}
 }
 
 func TestBuildConfigIndex(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Add V2.StableLogValue to expose full deterministic startup config data, including sorted allConfigs and explicit configIndex.

Switch XDPoS.New to log the structured stable view directly so terminal output avoids escaped JSON strings while retaining complete diagnostics coverage.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [X] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
