### PR TITLE
fix(params): log v2 allconfigs mismatch context

### DIFF
--- a/params/config_compat.go
+++ b/params/config_compat.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/log"
 )
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -190,16 +191,50 @@ func checkXDCSystemContractCompatible(stored, newcfg *ChainConfig, head *big.Int
 
 // checkV2ScheduleCompatible compares the historically active V2 round configs
 // between stored and new chain config.
-func checkV2ScheduleCompatible(stored, newcfg *V2, xdposRound *uint64) *ConfigCompatError {
-	activeRound := v2ActiveCompatRound(stored, newcfg, xdposRound)
-	for _, round := range v2HistoricalRounds(stored, newcfg, activeRound) {
+func checkV2ScheduleCompatible(stored, candidate *V2, xdposRound *uint64) *ConfigCompatError {
+	activeRound := v2ActiveCompatRound(stored, candidate, xdposRound)
+	for _, round := range v2HistoricalRounds(stored, candidate, activeRound) {
 		storedCfg, storedOK := stored.AllConfigs[round]
-		newCfg, newOK := newcfg.AllConfigs[round]
-		if !storedOK || !newOK || !v2ConsensusConfigEqual(storedCfg, newCfg) {
-			return newCompatError(fmt.Sprintf("XDPoS.V2 config at round %d", round), xdposV2CompatBlock(stored), xdposV2CompatBlock(newcfg))
+		candidateCfg, newOK := candidate.AllConfigs[round]
+		if !storedOK || !newOK || !v2ConsensusConfigEqual(storedCfg, candidateCfg) {
+			log.Warn(strings.Repeat("-", 153))
+			log.Warn("V2 config mismatch", "stored", stored.StableLogValue())
+			log.Warn(strings.Repeat("-", 153))
+			log.Warn("V2 config mismatch", "candidate", candidate.StableLogValue())
+			log.Warn(strings.Repeat("-", 153))
+			log.Warn("V2 config mismatch",
+				"round", round,
+				"activeRound", activeRound,
+				"storedOK", storedOK,
+				"newOK", newOK,
+				"storedCfg", v2ConsensusConfigSnapshot(storedCfg),
+				"candidateCfg", v2ConsensusConfigSnapshot(candidateCfg),
+			)
+			log.Warn(strings.Repeat("-", 153))
+			return newCompatError(fmt.Sprintf("XDPoS.V2 config at round %d", round), xdposV2CompatBlock(stored), xdposV2CompatBlock(candidate))
 		}
 	}
 	return nil
+}
+
+func v2ConsensusConfigSnapshot(cfg *V2Config) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	return map[string]any{
+		"maxMasternodes":            cfg.MaxMasternodes,
+		"maxProtectorNodes":         cfg.MaxProtectorNodes,
+		"maxObverserNodes":          cfg.MaxObverserNodes,
+		"switchRound":               cfg.SwitchRound,
+		"minePeriod":                cfg.MinePeriod,
+		"certThreshold":             cfg.CertThreshold,
+		"masternodeReward":          cfg.MasternodeReward,
+		"protectorReward":           cfg.ProtectorReward,
+		"observerReward":            cfg.ObserverReward,
+		"minimumMinerBlockPerEpoch": cfg.MinimumMinerBlockPerEpoch,
+		"limitPenaltyEpoch":         cfg.LimitPenaltyEpoch,
+		"minimumSigningTx":          cfg.MinimumSigningTx,
+	}
 }
 
 // v2ActiveCompatRound returns the latest round whose config must remain stable

--- a/params/config_xdpos.go
+++ b/params/config_xdpos.go
@@ -521,6 +521,54 @@ func (v2 *V2) String() string {
 	return fmt.Sprintf("V2{SwitchEpoch: %v, SwitchBlock: %v, %s}", snapshot.switchEpoch, snapshot.switchBlock, snapshot.currentConfig.String())
 }
 
+type stableLogConfigEntry struct {
+	Round  uint64    `json:"round"`
+	Config *V2Config `json:"config"`
+}
+
+type stableLogView struct {
+	SwitchEpoch   uint64                 `json:"switchEpoch"`
+	SwitchBlock   string                 `json:"switchBlock"`
+	CurrentConfig *V2Config              `json:"currentConfig"`
+	AllConfigs    []stableLogConfigEntry `json:"allConfigs"`
+	ConfigIndex   []uint64               `json:"configIndex"`
+}
+
+// StableLogValue returns a full, deterministic structured value for startup
+// logs. Callers can pass the returned object directly as a field value to
+// avoid JSON string escaping in terminal log output.
+func (v2 *V2) StableLogValue() stableLogView {
+	if v2 == nil {
+		return stableLogView{}
+	}
+
+	snapshot := snapshotV2ReadOnly(v2)
+
+	keys := slices.Collect(maps.Keys(snapshot.allConfigs))
+	slices.Sort(keys)
+
+	allConfigs := make([]stableLogConfigEntry, 0, len(keys))
+	for _, round := range keys {
+		allConfigs = append(allConfigs, stableLogConfigEntry{
+			Round:  round,
+			Config: snapshot.allConfigs[round].Clone(),
+		})
+	}
+
+	var switchBlock string
+	if snapshot.switchBlock != nil {
+		switchBlock = snapshot.switchBlock.String()
+	}
+
+	return stableLogView{
+		SwitchEpoch:   snapshot.switchEpoch,
+		SwitchBlock:   switchBlock,
+		CurrentConfig: snapshot.currentConfig.Clone(),
+		AllConfigs:    allConfigs,
+		ConfigIndex:   append([]uint64(nil), snapshot.configIndex...),
+	}
+}
+
 // Description returns a human-readable description of V2
 // NOTE: don't append "\n" to end
 func (v2 *V2) Description(indent int) string {

--- a/params/config_xdpos_test.go
+++ b/params/config_xdpos_test.go
@@ -19,6 +19,7 @@ package params
 import (
 	"encoding/json"
 	"math/big"
+	"strings"
 	"sync"
 	"testing"
 
@@ -190,6 +191,44 @@ func TestV2StringConcurrentWithUpdateConfig(t *testing.T) {
 
 	close(start)
 	wg.Wait()
+}
+
+func TestV2StableLogValueDeterministicAndComplete(t *testing.T) {
+	v2 := &V2{
+		SwitchEpoch: 63143,
+		SwitchBlock: big.NewInt(56828700),
+		CurrentConfig: &V2Config{
+			MaxMasternodes: 15,
+		},
+		AllConfigs: map[uint64]*V2Config{
+			10: {SwitchRound: 10, MaxMasternodes: 16},
+			0:  {SwitchRound: 0, MaxMasternodes: 15},
+		},
+		configIndex: []uint64{10, 0},
+	}
+
+	firstBytes, err := json.Marshal(v2.StableLogValue())
+	assert.NoError(t, err)
+	secondBytes, err := json.Marshal(v2.StableLogValue())
+	assert.NoError(t, err)
+
+	first := string(firstBytes)
+	second := string(secondBytes)
+	assert.Equal(t, first, second)
+
+	assert.Contains(t, first, `"switchEpoch":63143`)
+	assert.Contains(t, first, `"switchBlock":"56828700"`)
+	assert.Contains(t, first, `"configIndex":[10,0]`)
+	assert.Contains(t, first, `"currentConfig"`)
+
+	idxRound0 := strings.Index(first, `"round":0`)
+	idxRound10 := strings.Index(first, `"round":10`)
+	if idxRound0 == -1 || idxRound10 == -1 {
+		t.Fatalf("expected allConfigs rounds in stable log output, got %q", first)
+	}
+	if idxRound0 > idxRound10 {
+		t.Fatalf("expected allConfigs rounds sorted ascending, got %q", first)
+	}
 }
 
 func TestBuildConfigIndex(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Add a warning log before returning V2 compatibility errors to expose round-level mismatch context.

Include active round, map key presence flags, and consensus field snapshots for stored/new configs.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
