### PR TITLE
fix(core): prevent --set-head startup rewind overshooting to N-1, close #2465

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -970,7 +970,7 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 func (bc *BlockChain) repair(head **types.Block) error {
 	for {
 		// Abort if we've rewound to a head block that does have associated state
-		if (common.RollbackNumber == 0) || ((*head).Number().Uint64() < common.RollbackNumber) {
+		if (common.RollbackNumber == 0) || ((*head).Number().Uint64() <= common.RollbackNumber) {
 			if bc.HasState((*head).Root()) {
 				log.Info("Rewound blockchain to past state", "number", (*head).Number(), "hash", (*head).Hash())
 				engine, ok := bc.Engine().(*XDPoS.XDPoS)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -573,6 +573,59 @@ func TestNewBlockChainRepairsMissingHeadStateConsistently(t *testing.T) {
 	}
 }
 
+// TestNewBlockChainRepairsMissingHeadStateRespectsRollbackTarget ensures
+// startup repair does not rewind below the user-requested rollback target.
+func TestNewBlockChainRepairsMissingHeadStateRespectsRollbackTarget(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+	)
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, nil, gspec, ethash.NewFaker(), vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create chain: %v", err)
+	}
+
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 3, nil)
+	if n, err := chain.InsertChain(blocks); err != nil {
+		chain.Stop()
+		t.Fatalf("failed to insert block %d: %v", n, err)
+	}
+	head := blocks[len(blocks)-1]
+	target := blocks[len(blocks)-2]
+	chain.Stop()
+
+	rawdb.DeleteLegacyTrieNode(db, head.Root())
+
+	prevRollback := common.RollbackNumber
+	common.RollbackNumber = target.NumberU64()
+	t.Cleanup(func() {
+		common.RollbackNumber = prevRollback
+	})
+
+	reopened, err := NewBlockChain(db, nil, gspec, ethash.NewFaker(), vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to reopen repaired chain: %v", err)
+	}
+	defer reopened.Stop()
+
+	if got := reopened.CurrentBlock().Hash(); got != target.Hash() {
+		t.Fatalf("unexpected repaired current block: have %s want %s", got, target.Hash())
+	}
+	if got := reopened.CurrentSnapBlock().Hash(); got != target.Hash() {
+		t.Fatalf("unexpected repaired current snap block: have %s want %s", got, target.Hash())
+	}
+	if got := reopened.CurrentHeader().Hash(); got != target.Hash() {
+		t.Fatalf("unexpected repaired current header: have %s want %s", got, target.Hash())
+	}
+}
+
 // TestNewBlockChainReadOnlyFailsHeadStateRepair tests readonly options-based open fails when head state repair would mutate the database.
 func TestNewBlockChainReadOnlyFailsHeadStateRepair(t *testing.T) {
 	var (


### PR DESCRIPTION
# Proposed changes

Fix issue #2465: an off-by-one boundary in startup repair when RollbackNumber is set from --set-head.

Repair now accepts the target height (<=) so startup does not rewind past N and fail with 'can't rollback to N which is greater than current N-1'.

Add a regression test to ensure startup repair stops at the requested rollback block when state exists.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
