### PR TITLE
fix(eth): filter BFT broadcast to xdpos2+ peers only

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -535,45 +535,48 @@ func (ps *peerSet) PeersWithoutTx(hash common.Hash) []*peer {
 	return list
 }
 
-// PeersWithoutVote retrieves a list of peers that do not have a given block in
-// their set of known hashes.
+// PeersWithoutVote retrieves a list of peers that do not have a given vote in
+// their set of known hashes. Only peers supporting the XDC BFT protocol
+// (version >= xdc100) are returned.
 func (ps *peerSet) PeersWithoutVote(hash common.Hash) []*peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	list := make([]*peer, 0, len(ps.peers))
 	for _, p := range ps.peers {
-		if !p.knownVote.Contains(hash) {
+		if p.version >= xdc100 && !p.knownVote.Contains(hash) {
 			list = append(list, p)
 		}
 	}
 	return list
 }
 
-// PeersWithoutTimeout retrieves a list of peers that do not have a given block in
-// their set of known hashes.
+// PeersWithoutTimeout retrieves a list of peers that do not have a given timeout in
+// their set of known hashes. Only peers supporting the XDC BFT protocol
+// (version >= xdc100) are returned.
 func (ps *peerSet) PeersWithoutTimeout(hash common.Hash) []*peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	list := make([]*peer, 0, len(ps.peers))
 	for _, p := range ps.peers {
-		if !p.knownTimeout.Contains(hash) {
+		if p.version >= xdc100 && !p.knownTimeout.Contains(hash) {
 			list = append(list, p)
 		}
 	}
 	return list
 }
 
-// PeersWithoutSyncInfo retrieves a list of peers that do not have a given block in
-// their set of known hashes.
+// PeersWithoutSyncInfo retrieves a list of peers that do not have a given sync
+// info in their set of known hashes. Only peers supporting the XDC BFT protocol
+// (version >= xdc100) are returned.
 func (ps *peerSet) PeersWithoutSyncInfo(hash common.Hash) []*peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	list := make([]*peer, 0, len(ps.peers))
 	for _, p := range ps.peers {
-		if !p.knownSyncInfo.Contains(hash) {
+		if p.version >= xdc100 && !p.knownSyncInfo.Contains(hash) {
 			list = append(list, p)
 		}
 	}

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -33,17 +33,17 @@ import (
 const (
 	eth62  = 62
 	eth63  = 63
-	xdpos2 = 100
+	xdc100 = 100
 )
 
 // protocolName is the official short name of the protocol used during capability negotiation.
 var protocolName = "eth"
 
 // ProtocolVersions are the supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{xdpos2, eth63}
+var ProtocolVersions = []uint{xdc100, eth63}
 
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
-var protocolLengths = map[uint]uint64{xdpos2: 227, eth63: 17, eth62: 8}
+var protocolLengths = map[uint]uint64{xdc100: 227, eth63: 17, eth62: 8}
 
 const protocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
 
@@ -66,7 +66,7 @@ const (
 	GetReceiptsMsg = 0x0f
 	ReceiptsMsg    = 0x10
 
-	// Protocol messages belonging to xdpos2/100
+	// Protocol messages belonging to xdc/100
 	VoteMsg     = 0xe0
 	TimeoutMsg  = 0xe1
 	SyncInfoMsg = 0xe2


### PR DESCRIPTION
# Proposed changes

PeersWithoutVote, PeersWithoutTimeout and PeersWithoutSyncInfo now skip peers whose protocol version is below xdpos2 (100). BFT messages use opcodes 0xe0-0xe2 which are only defined in the 227-length xdpos2 protocol; sending them to eth/63 or eth/62 peers would always fail and trigger a spurious removePeer.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
