### PR TITLE
fix(eth/fetcher): correct propagated block broadcast handling

### DIFF
--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -744,6 +744,9 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 		if !fastBroadCast {
 			propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			go f.broadcastBlock(block, true)
+		} else {
+			propAnnounceOutTimer.UpdateSince(block.ReceivedAt)
+			go f.broadcastBlock(block, false)
 		}
 	}()
 }

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -706,7 +706,6 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 				go f.broadcastBlock(block, true)
 				if err := f.prepareBlock(block); err != nil {
 					log.Debug("Propagated block prepare failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
-					return
 				}
 				return
 			}

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -709,7 +709,7 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 				}
 				return
 			}
-			log.Debug("Append M2 to header block", "numer", block.NumberU64(), "hahs", block.Hash())
+			log.Debug("Append M2 to header block", "number", block.NumberU64(), "hash", block.Hash())
 			if err := f.prepareBlock(block); err != nil {
 				log.Debug("Propagated block prepare failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
 				return

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -683,8 +683,8 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 		switch err {
 		case nil:
 			// All ok, quickly propagate to our peers
-			propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			if fastBroadCast {
+				propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 				go f.broadcastBlock(block, true)
 			}
 		case consensus.ErrFutureBlock:
@@ -703,6 +703,7 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 				}
 			}
 			if !isM2 {
+				propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 				go f.broadcastBlock(block, true)
 				if err := f.prepareBlock(block); err != nil {
 					log.Debug("Propagated block prepare failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
@@ -740,8 +741,8 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 			log.Warn("[insert] Unable to handle new proposed block", "err", err, "number", block.Number(), "hash", block.Hash())
 		}
 		// If import succeeded, broadcast the block
-		propAnnounceOutTimer.UpdateSince(block.ReceivedAt)
 		if !fastBroadCast {
+			propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			go f.broadcastBlock(block, true)
 		}
 	}()

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -676,14 +676,14 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 			log.Debug("Unknown parent of propagated block", "peer", peer, "number", block.Number(), "hash", hash, "parent", block.ParentHash())
 			return
 		}
-		fastBroadCast := true
+		isM2 := false
 	again:
 		err := f.verifyHeader(block.Header())
 		// Quickly validate the header and propagate the block if it passes
 		switch err {
 		case nil:
 			// All ok, quickly propagate to our peers
-			if fastBroadCast {
+			if !isM2 {
 				propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 				go f.broadcastBlock(block, true)
 			}
@@ -695,7 +695,6 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 		case consensus.ErrNoValidatorSignature:
 			newBlock := block
 			var errM2 error
-			isM2 := false
 			if f.appendM2HeaderHook != nil {
 				if newBlock, isM2, errM2 = f.appendM2HeaderHook(block); errM2 != nil {
 					log.Error("Append m2 to block header fail", "err", errM2)
@@ -716,7 +715,6 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 				return
 			}
 			block = newBlock
-			fastBroadCast = false
 			goto again
 		default:
 			// Something went very wrong, drop the peer
@@ -741,7 +739,7 @@ func (f *Fetcher) insert(peer string, block *types.Block) {
 			log.Warn("[insert] Unable to handle new proposed block", "err", err, "number", block.Number(), "hash", block.Hash())
 		}
 		// If import succeeded, broadcast the block
-		if !fastBroadCast {
+		if isM2 {
 			propBroadcastOutTimer.UpdateSince(block.ReceivedAt)
 			go f.broadcastBlock(block, true)
 		} else {


### PR DESCRIPTION
# Proposed changes

## Summary

Fix propagated block broadcast handling in the fetcher so outbound propagation metrics are recorded only when a send actually happens, and imported fast-broadcast blocks are announced after successful import.

This also simplifies the post-import M2 broadcast state by reusing the M2 detection result instead of carrying a separate fast-broadcast flag through the header retry path.

## Changes

- Remove unnecessary return statement.
- Correct a typo in the propagated block log message.
- Move broadcast and announce timer updates into the branches that actually send blocks.
- Announce successfully imported fast-broadcast blocks so peers receive the hash notification.
- Reuse the M2 state to drive post-import broadcast behavior and simplify the control flow.

## Motivation and Impact

Previously, outbound fetcher timing metrics could be updated even when no broadcast was sent, and fast-broadcast blocks were propagated before import but not announced after import. This made metrics less accurate and skipped the expected hash announcement stage for successfully imported propagated blocks.

With this change, fetcher propagation metrics better reflect actual network sends, and imported propagated blocks follow the intended broadcast/announce flow while preserving the special M2 post-import broadcast behavior.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
