### PR TITLE
fix(core,core/rawdb): clean up XDPoS snapshot on SetHead

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -841,6 +841,9 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64) error {
 			rawdb.DeleteBody(db, hash, num)
 			rawdb.DeleteReceipts(db, hash, num)
 		}
+		if bc.chainConfig.XDPoS != nil && (num+bc.chainConfig.XDPoS.Gap)%bc.chainConfig.XDPoS.Epoch == 0 {
+			rawdb.DeleteXdposSnapshot(db, hash)
+		}
 		// Todo(rjl493456442) txlookup, bloombits, etc
 	}
 	bc.hc.SetHead(head, updateFn, delFn)

--- a/core/blockchain_sethead_test.go
+++ b/core/blockchain_sethead_test.go
@@ -313,3 +313,73 @@ func TestSetHeadCleansOnlyBadBlocksAboveHead(t *testing.T) {
 		t.Fatalf("remaining bad block has wrong hash: got %x, want %x", remaining.Hash(), badBlockLow.Hash())
 	}
 }
+
+// TestSetHeadCleansOnlyXdposSnapshotsAboveHead verifies that SetHead removes
+// XDPoS snapshots strictly above the target height while preserving snapshots
+// at or below the new head.
+func TestSetHeadCleansOnlyXdposSnapshotsAboveHead(t *testing.T) {
+	var (
+		engine  = ethash.NewFaker()
+		genesis = &Genesis{
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.AllEthashProtocolChanges,
+		}
+		db = rawdb.NewMemoryDatabase()
+	)
+	chain, err := NewBlockChain(db, &CacheConfig{TrieDirtyDisabled: true}, genesis, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create chain: %v", err)
+	}
+	defer chain.Stop()
+
+	// Build a chain 0..25.
+	blocks, _ := GenerateChain(genesis.Config, chain.Genesis(), engine, db, 25, nil)
+	if _, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+
+	// Enable XDPoS snapshot-number gating for SetHead cleanup only.
+	// (Applied after import to avoid triggering UpdateM1 on ethash blocks.)
+	configWithXdpos := genesis.Config.Clone()
+	configWithXdpos.XDPoS = &params.XDPoSConfig{Epoch: 5, Gap: 4}
+	chain.SetChainConfig(configWithXdpos)
+
+	// Create snapshot records with mutually exclusive versions per hash.
+	low := blocks[5]         // height 6, should be kept by SetHead(10)
+	highV2 := blocks[15]     // height 16, should be removed via V2 path
+	highV1Only := blocks[20] // height 21, should be removed via V1 fallback path
+
+	if err := rawdb.WriteXdposV1Snapshot(db, low.Hash(), []byte(`{"number":6}`)); err != nil {
+		t.Fatalf("failed to write v1 low snapshot: %v", err)
+	}
+	if err := rawdb.WriteXdposV2Snapshot(db, highV2.Hash(), []byte(`{"number":16}`)); err != nil {
+		t.Fatalf("failed to write v2 high snapshot: %v", err)
+	}
+	if err := rawdb.WriteXdposV1Snapshot(db, highV1Only.Hash(), []byte(`{"number":21}`)); err != nil {
+		t.Fatalf("failed to write v1 high-only snapshot: %v", err)
+	}
+
+	if _, err := rawdb.ReadXdposV1Snapshot(db, low.Hash()); err != nil {
+		t.Fatalf("expected v1 low snapshot to exist before SetHead: %v", err)
+	}
+	if _, err := rawdb.ReadXdposV2Snapshot(db, highV2.Hash()); err != nil {
+		t.Fatalf("expected v2 high snapshot to exist before SetHead: %v", err)
+	}
+	if _, err := rawdb.ReadXdposV1Snapshot(db, highV1Only.Hash()); err != nil {
+		t.Fatalf("expected v1 high-only snapshot to exist before SetHead: %v", err)
+	}
+
+	if err := chain.SetHead(10); err != nil {
+		t.Fatalf("failed to set head: %v", err)
+	}
+
+	if _, err := rawdb.ReadXdposV1Snapshot(db, low.Hash()); err != nil {
+		t.Fatalf("expected v1 low snapshot to be kept after SetHead: %v", err)
+	}
+	if _, err := rawdb.ReadXdposV2Snapshot(db, highV2.Hash()); err == nil {
+		t.Fatalf("expected v2 high snapshot to be removed after SetHead")
+	}
+	if _, err := rawdb.ReadXdposV1Snapshot(db, highV1Only.Hash()); err == nil {
+		t.Fatalf("expected v1 high-only snapshot to be removed after SetHead")
+	}
+}

--- a/core/rawdb/accessors_xdc.go
+++ b/core/rawdb/accessors_xdc.go
@@ -58,6 +58,16 @@ func WriteXdposV2Snapshot(db ethdb.KeyValueWriter, hash common.Hash, blob []byte
 	return nil
 }
 
+// DeleteXdposSnapshot removes the snapshot entry for a block hash.
+func DeleteXdposSnapshot(db ethdb.KeyValueWriter, hash common.Hash) {
+	if err := db.Delete(xdposV2Key(hash)); err != nil {
+		log.Crit("Failed to delete SnapshotV2", "err", err)
+	}
+	if err := db.Delete(xdposV1Key(hash)); err != nil {
+		log.Crit("Failed to delete SnapshotV1", "err", err)
+	}
+}
+
 // ReadSectionHead retrieves the last block hash of a processed section
 // from the database.
 func ReadSectionHead(db ethdb.KeyValueReader, section uint64) common.Hash {


### PR DESCRIPTION
# Proposed changes

Restrict SetHead snapshot cleanup to block numbers that can persist XDPoS snapshots based on epoch/gap rules.

Keep unified deletion semantics (V2 first, then V1 fallback) and align SetHead tests with XDPoS gating.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
