### PR TITLE
fix(eth/downloader): include xdc164 peers in idle peer selection

### DIFF
--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -37,6 +37,8 @@ import (
 const (
 	maxLackingHashes  = 4096 // Maximum number of entries allowed on the list or lacking items
 	measurementImpact = 0.1  // The impact a single measurement has on a peer's final throughput value.
+
+	maxProtocolVer = 164 // xdc164
 )
 
 var (
@@ -474,7 +476,7 @@ func (ps *peerSet) HeaderIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.headerThroughput
 	}
-	return ps.idlePeers(62, 101, idle, throughput)
+	return ps.idlePeers(62, maxProtocolVer, idle, throughput)
 }
 
 // BodyIdlePeers retrieves a flat list of all the currently body-idle peers within
@@ -488,7 +490,7 @@ func (ps *peerSet) BodyIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.blockThroughput
 	}
-	return ps.idlePeers(62, 101, idle, throughput)
+	return ps.idlePeers(62, maxProtocolVer, idle, throughput)
 }
 
 // ReceiptIdlePeers retrieves a flat list of all the currently receipt-idle peers
@@ -502,7 +504,7 @@ func (ps *peerSet) ReceiptIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.receiptThroughput
 	}
-	return ps.idlePeers(63, 101, idle, throughput)
+	return ps.idlePeers(63, maxProtocolVer, idle, throughput)
 }
 
 // NodeDataIdlePeers retrieves a flat list of all the currently node-data-idle
@@ -516,7 +518,7 @@ func (ps *peerSet) NodeDataIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.stateThroughput
 	}
-	return ps.idlePeers(63, 101, idle, throughput)
+	return ps.idlePeers(63, maxProtocolVer, idle, throughput)
 }
 
 // idlePeers retrieves a flat list of all currently idle peers satisfying the

--- a/eth/downloader/peer_test.go
+++ b/eth/downloader/peer_test.go
@@ -17,9 +17,42 @@
 package downloader
 
 import (
+	"fmt"
 	"sort"
 	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/log"
 )
+
+// TestIdlePeersProtocolVersions verifies that peers running every supported
+// protocol version (eth63, xdc100, xdc164) are eligible for concurrent
+// downloads. A regression here silently disables skeleton filling and body,
+// receipt and state fetches, stalling any node that falls behind.
+func TestIdlePeersProtocolVersions(t *testing.T) {
+	ps := newPeerSet()
+	for i, version := range []int{63, 100, 164} {
+		id := fmt.Sprintf("peer-%d", i)
+		if err := ps.Register(newPeerConnection(id, version, nil, log.New("id", id))); err != nil {
+			t.Fatalf("failed to register version %d peer: %v", version, err)
+		}
+	}
+	tests := []struct {
+		name  string
+		peers func() ([]*peerConnection, int)
+		total int
+	}{
+		{"HeaderIdlePeers", ps.HeaderIdlePeers, 3},
+		{"BodyIdlePeers", ps.BodyIdlePeers, 3},
+		{"ReceiptIdlePeers", ps.ReceiptIdlePeers, 3},
+		{"NodeDataIdlePeers", ps.NodeDataIdlePeers, 3},
+	}
+	for _, tt := range tests {
+		idle, total := tt.peers()
+		if len(idle) != tt.total || total != tt.total {
+			t.Errorf("%s: got %d idle / %d total, want %d / %d", tt.name, len(idle), total, tt.total, tt.total)
+		}
+	}
+}
 
 func TestPeerThroughputSorting(t *testing.T) {
 	a := &peerConnection{


### PR DESCRIPTION
# Proposed changes

This PR fixes the bug: "no peers available or all tried for download" which is introduced in #2470 and cause network stuck.

The xdc/164 protocol (EIP-2364 handshake) was added without updating the idlePeers version ceiling, which was still capped at 101 from the xdc100 era. Once all peers negotiate version 164, HeaderIdlePeers, BodyIdlePeers, ReceiptIdlePeers and NodeDataIdlePeers return empty sets, so fetchParts aborts every skeleton/body/receipt/state fetch with errPeersUnavailable (surfacing as "retrieved hash chain is invalid: no peers available or all tried for download"). Any node falling more than a few blocks behind can then never sync again.

Replace the hardcoded ceilings with a maxProtocolVersion constant covering xdc164 and add a regression test asserting that peers of every supported protocol version are eligible for concurrent downloads.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
