### PR TITLE
fix(core/bloombits): use single channel for shutdown to fix flaky TestMatcherIntermittent #20878

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -155,7 +155,6 @@ func (m *Matcher) Start(ctx context.Context, begin, end uint64, results chan uin
 	session := &MatcherSession{
 		matcher: m,
 		quit:    make(chan struct{}),
-		kill:    make(chan struct{}),
 		ctx:     ctx,
 	}
 	for _, scheduler := range m.schedulers {
@@ -386,10 +385,8 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 		requests   = make(map[uint][]uint64) // Per-bit list of section requests, ordered by section number
 		unallocs   = make(map[uint]struct{}) // Bits with pending requests but not allocated to any retriever
 		retrievers chan chan uint            // Waiting retrievers (toggled to nil if unallocs is empty)
-	)
-	var (
-		allocs   int            // Number of active allocations to handle graceful shutdown requests
-		shutdown = session.quit // Shutdown request channel, will gracefully wait for pending requests
+		allocs     int                       // Number of active allocations to handle graceful shutdown requests
+		shutdown   = session.quit            // Shutdown request channel, will gracefully wait for pending requests
 	)
 
 	// assign is a helper method fo try to assign a pending bit an actively
@@ -409,15 +406,12 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 	for {
 		select {
 		case <-shutdown:
-			// Graceful shutdown requested, wait until all pending requests are honoured
+			// Shutdown requested. No more retrievers can be allocated,
+			// but we still need to wait until all pending requests have returned.
+			shutdown = nil
 			if allocs == 0 {
 				return
 			}
-			shutdown = nil
-
-		case <-session.kill:
-			// Pending requests not honoured in time, hard terminate
-			return
 
 		case req := <-dist:
 			// New retrieval request arrived to be distributed to some fetcher process
@@ -499,8 +493,9 @@ func (m *Matcher) distributor(dist chan *request, session *MatcherSession) {
 					assign(result.Bit)
 				}
 			}
-			// If we're in the process of shutting down, terminate
-			if allocs == 0 && shutdown == nil {
+
+			// End the session when all pending deliveries have arrived.
+			if shutdown == nil && allocs == 0 {
 				return
 			}
 		}
@@ -514,7 +509,6 @@ type MatcherSession struct {
 
 	closer sync.Once     // Sync object to ensure we only ever close once
 	quit   chan struct{} // Quit channel to request pipeline termination
-	kill   chan struct{} // Term channel to signal non-graceful forced shutdown
 
 	ctx context.Context // Context used by the light client to abort filtering
 	err atomic.Value    // Global error to track retrieval failures deep in the chain
@@ -529,7 +523,6 @@ func (s *MatcherSession) Close() {
 	s.closer.Do(func() {
 		// Signal termination and wait for all goroutines to tear down
 		close(s.quit)
-		time.AfterFunc(time.Second, func() { close(s.kill) })
 		s.pend.Wait()
 	})
 }
@@ -542,10 +535,10 @@ func (s *MatcherSession) Error() error {
 	return nil
 }
 
-// AllocateRetrieval assigns a bloom bit index to a client process that can either
-// immediately reuest and fetch the section contents assigned to this bit or wait
+// allocateRetrieval assigns a bloom bit index to a client process that can either
+// immediately request and fetch the section contents assigned to this bit or wait
 // a little while for more sections to be requested.
-func (s *MatcherSession) AllocateRetrieval() (uint, bool) {
+func (s *MatcherSession) allocateRetrieval() (uint, bool) {
 	fetcher := make(chan uint)
 
 	select {
@@ -557,9 +550,9 @@ func (s *MatcherSession) AllocateRetrieval() (uint, bool) {
 	}
 }
 
-// PendingSections returns the number of pending section retrievals belonging to
+// pendingSections returns the number of pending section retrievals belonging to
 // the given bloom bit index.
-func (s *MatcherSession) PendingSections(bit uint) int {
+func (s *MatcherSession) pendingSections(bit uint) int {
 	fetcher := make(chan uint)
 
 	select {
@@ -571,9 +564,9 @@ func (s *MatcherSession) PendingSections(bit uint) int {
 	}
 }
 
-// AllocateSections assigns all or part of an already allocated bit-task queue
+// allocateSections assigns all or part of an already allocated bit-task queue
 // to the requesting process.
-func (s *MatcherSession) AllocateSections(bit uint, count int) []uint64 {
+func (s *MatcherSession) allocateSections(bit uint, count int) []uint64 {
 	fetcher := make(chan *Retrieval)
 
 	select {
@@ -589,14 +582,10 @@ func (s *MatcherSession) AllocateSections(bit uint, count int) []uint64 {
 	}
 }
 
-// DeliverSections delivers a batch of section bit-vectors for a specific bloom
+// deliverSections delivers a batch of section bit-vectors for a specific bloom
 // bit index to be injected into the processing pipeline.
-func (s *MatcherSession) DeliverSections(bit uint, sections []uint64, bitsets [][]byte) {
-	select {
-	case <-s.kill:
-		return
-	case s.matcher.deliveries <- &Retrieval{Bit: bit, Sections: sections, Bitsets: bitsets}:
-	}
+func (s *MatcherSession) deliverSections(bit uint, sections []uint64, bitsets [][]byte) {
+	s.matcher.deliveries <- &Retrieval{Bit: bit, Sections: sections, Bitsets: bitsets}
 }
 
 // Multiplex polls the matcher session for rerieval tasks and multiplexes it into
@@ -611,17 +600,17 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 
 	for {
 		// Allocate a new bloom bit index to retrieve data for, stopping when done
-		bit, ok := s.AllocateRetrieval()
+		bit, ok := s.allocateRetrieval()
 		if !ok {
 			return
 		}
 		// Bit allocated, throttle a bit if we're below our batch limit
-		if s.PendingSections(bit) < batch {
+		if s.pendingSections(bit) < batch {
 			select {
 			case <-s.quit:
 				// Session terminating, we can't meaningfully service, abort
-				s.AllocateSections(bit, 0)
-				s.DeliverSections(bit, []uint64{}, [][]byte{})
+				s.allocateSections(bit, 0)
+				s.deliverSections(bit, []uint64{}, [][]byte{})
 				return
 
 			case <-ticker.C:
@@ -629,13 +618,13 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 			}
 		}
 		// Allocate as much as we can handle and request servicing
-		sections := s.AllocateSections(bit, batch)
+		sections := s.allocateSections(bit, batch)
 		request := make(chan *Retrieval)
 
 		select {
 		case <-s.quit:
 			// Session terminating, we can't meaningfully service, abort
-			s.DeliverSections(bit, sections, make([][]byte, len(sections)))
+			s.deliverSections(bit, sections, make([][]byte, len(sections)))
 			return
 
 		case mux <- request:
@@ -647,7 +636,7 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 				s.err.Store(result.Error)
 				s.Close()
 			}
-			s.DeliverSections(result.Bit, result.Sections, result.Bitsets)
+			s.deliverSections(result.Bit, result.Sections, result.Bitsets)
 		}
 	}
 }


### PR DESCRIPTION
# Proposed changes

This replaces the two-stage shutdown scheme with the one we use almost everywhere else: a single quit channel signalling termination.

fix flaky test:

```text
panic: test timed out after 45m0s
	running tests:
		TestMatcherIntermittent (45m0s)

goroutine 107075 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:2682 +0x359
created by time.goFunc
	/opt/hostedtoolcache/go/1.25.12/x64/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive, 44 minutes]:
testing.(*T).Run(0xc0001121c0, {0x66d016?, 0x0?}, 0x67ac60)
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:2005 +0x485
testing.runTests.func1(0xc0001121c0)
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:2477 +0x3e
testing.tRunner(0xc0001121c0, 0xc000151c70)
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:1934 +0xea
testing.runTests(0xc000012138, {0x91d7e0, 0xb, 0xb}, {0x7?, 0xc000174780?, 0x952b40?})
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:2475 +0x4b4
testing.(*M).Run(0xc000108e60)
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:2337 +0x63a
main.main()
	_testmain.go:75 +0x9b

goroutine 81 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.testMatcher(0xc00023ee00, {0xc0003fa810, 0x2, 0x2}, 0x0, 0x186a0, 0x1, 0x51, 0x1)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:197 +0x52f
github.com/XinFinOrg/XDPoSChain/core/bloombits.testMatcherDiffBatches(0xc00023ee00, {0xc0003fa810, 0x2, 0x2}, 0x0, 0x186a0, 0x1, 0x51)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:123 +0x65
github.com/XinFinOrg/XDPoSChain/core/bloombits.TestMatcherIntermittent(0xc00023ee00)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:68 +0x18a
testing.tRunner(0xc00023ee00, 0x67ac60)
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.25.12/x64/src/testing/testing.go:1997 +0x465

goroutine 103816 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc00021e888?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103804 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc0001d27b0?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103815 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103198 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleRequests(0xc00056ec48, 0xc0002f10e0, 0xc00041bd50, 0xc0002f11d0, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:92 +0x145
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:65 +0x38
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103806 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc00021e708?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103796 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).distributor(0xc0000c8050, 0xc00041bd50, 0xc00021f380)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:410 +0x345
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).run in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:251 +0x276

goroutine 103814 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc000584770?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103808 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc00051a150?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103807 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103798 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc0000f7770?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103801 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103197 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleDeliveries(0xc00056ec30, 0xc0002f0ff0, 0xc0002844d0, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:138 +0x13b
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:66 +0x33
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103800 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc0000f3770?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103817 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103805 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103794 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).subMatch.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:291 +0x1d5
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).subMatch in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:277 +0x239

goroutine 103802 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc00021e708?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103193 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleDeliveries(0xc00056ec18, 0xc0002f0e10, 0xc000284000, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:152 +0x246
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:66 +0x33
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103812 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc000354ee8?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6

goroutine 103797 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).Start.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:173 +0x15f
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).Start in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:168 +0x373

goroutine 103803 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103809 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103811 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103795 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).subMatch.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:327 +0x165
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).subMatch in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:320 +0x2fb

goroutine 103813 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103200 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleRequests(0xc00056ec60, 0xc0002f12c0, 0xc00041bd50, 0xc0002f13b0, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:92 +0x145
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:65 +0x38
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103199 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleDeliveries(0xc00056ec48, 0xc0002f11d0, 0xc000284620, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:138 +0x13b
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:66 +0x33
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103799 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:224 +0xba
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:221 +0x4e

goroutine 103196 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleRequests(0xc00056ec30, 0xc0002f0f00, 0xc00041bd50, 0xc0002f0ff0, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:92 +0x145
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func1()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:65 +0x38
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103195 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).subMatch.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:342 +0x737
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.(*Matcher).subMatch in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:320 +0x2fb

goroutine 103201 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleDeliveries(0xc00056ec60, 0xc0002f13b0, 0xc0002849a0, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:138 +0x13b
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:66 +0x33
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103191 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).scheduleDeliveries(0xc00056ec00, 0xc0002f0c30, 0xc00041bf10, 0xc0002e23f0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:152 +0x246
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*scheduler).run.func2()
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/scheduler.go:66 +0x33
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 81
	/opt/hostedtoolcache/go/1.25.12/x64/src/sync/waitgroup.go:237 +0x73

goroutine 103810 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).AllocateRetrieval(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:551
github.com/XinFinOrg/XDPoSChain/core/bloombits.(*MatcherSession).Multiplex(0xc00021f380, 0x1, 0xc000354ee8?, 0xc0002e24d0)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher.go:614 +0x18b
created by github.com/XinFinOrg/XDPoSChain/core/bloombits.startRetrievers in goroutine 81
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/bloombits/matcher_test.go:218 +0xc6
FAIL	github.com/XinFinOrg/XDPoSChain/core/bloombits	2700.008s
```

Ref: #20878

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [X] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
