### PR TITLE
fix(miner): fix timer handshake deadlock in `worker.update()`

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -144,7 +144,6 @@ type worker struct {
 	chainHeadSub event.Subscription
 	chainSideCh  chan core.ChainSideEvent
 	chainSideSub event.Subscription
-	resetCh      chan time.Duration // Channel to request timer resets
 
 	wg sync.WaitGroup
 
@@ -194,7 +193,6 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		txsCh:          make(chan core.NewTxsEvent, txChanSize),
 		chainHeadCh:    make(chan core.ChainHeadEvent, chainHeadChanSize),
 		chainSideCh:    make(chan core.ChainSideEvent, chainSideChanSize),
-		resetCh:        make(chan time.Duration, 1),
 		chainDb:        eth.ChainDb(),
 		recv:           make(chan *Result, resultQueueSize),
 		chain:          eth.BlockChain(),
@@ -387,58 +385,49 @@ func (w *worker) update() {
 
 	timeout := time.NewTimer(time.Duration(minePeriod) * time.Second)
 	defer timeout.Stop()
-	c := make(chan struct{}, 1)
-	defer close(c)
-	finish := make(chan struct{})
-	defer close(finish)
 
-	go func() {
-		for {
-			// A real event arrived, process interesting content
+	// resetTimer rearms the mining timer, which is owned by the update loop and
+	// therefore never accessed from another goroutine. It must only ever be
+	// called from the loop below. Driving the timer from a dedicated goroutine
+	// would require a two-way channel handshake, which deadlocks as soon as
+	// both directions are full: the loop blocks handing over the new duration
+	// while the helper blocks handing over the expiry notification. The
+	// stop-drain-reset sequence follows the standard Timer.Reset pattern from
+	// the time package.
+	resetTimer := func(d time.Duration) {
+		if !timeout.Stop() {
+			// Drain the timer channel if it had already expired.
 			select {
-			case d := <-w.resetCh:
-				// Reset the timer to the new duration.
-				if !timeout.Stop() {
-					// Drain the timer channel if it had already expired.
-					select {
-					case <-timeout.C:
-					default:
-					}
-				}
-				timeout.Reset(d)
 			case <-timeout.C:
-				c <- struct{}{}
-			case <-finish:
-				return
+			default:
 			}
 		}
-	}()
+		timeout.Reset(d)
+	}
+
 	for {
 		// A real event arrived, process interesting content
 		select {
 		case v := <-minePeriodCh:
 			log.Info("[worker] update wait period", "period", v)
 			minePeriod = v
-			w.resetCh <- time.Duration(minePeriod) * time.Second
+			resetTimer(time.Duration(minePeriod) * time.Second)
 
-		case <-c:
+		case <-timeout.C:
 			if atomic.LoadInt32(&w.mining) == 1 {
 				w.commitNewWork()
 			}
-			resetTime := getResetTime(w.chain, minePeriod)
-			w.resetCh <- resetTime
+			resetTimer(getResetTime(w.chain, minePeriod))
 
 		// Handle ChainHeadEvent
 		case <-w.chainHeadCh:
 			w.commitNewWork()
-			resetTime := getResetTime(w.chain, minePeriod)
-			w.resetCh <- resetTime
+			resetTimer(getResetTime(w.chain, minePeriod))
 
 		// Handle new round
 		case <-newRoundCh:
 			w.commitNewWork()
-			resetTime := getResetTime(w.chain, minePeriod)
-			w.resetCh <- resetTime
+			resetTimer(getResetTime(w.chain, minePeriod))
 
 		// Handle ChainSideEvent
 		case <-w.chainSideCh:

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -50,7 +50,6 @@ func TestWorkerUpdateNonXDPoSStaysRunning(t *testing.T) {
 		engine:       ethash.NewFaker(),
 		chainHeadSub: newBlockingSubscription(),
 		chainSideSub: newBlockingSubscription(),
-		resetCh:      make(chan time.Duration, 1),
 	}
 
 	done := make(chan struct{})
@@ -78,6 +77,97 @@ func TestWorkerUpdateNonXDPoSStaysRunning(t *testing.T) {
 	select {
 	case <-done:
 		// Expected: update exits after subscription error.
+	case <-time.After(time.Second):
+		t.Fatal("worker.update did not return after unsubscribe")
+	}
+}
+
+// TestWorkerUpdateKeepsDrainingChainHead ensures the mining timer never stops
+// the update loop from servicing chain events.
+//
+// The timer used to be owned by a dedicated goroutine that exchanged
+// notifications with the update loop over two buffered channels: the loop sent
+// the next duration on resetCh and the goroutine reported expiries on c. Once
+// both buffers were full the two goroutines blocked on each other forever. The
+// worker then stopped draining chainHeadCh, which in turn blocked every
+// producer of chain events (block insertion posts them synchronously) and
+// wedged the whole node.
+func TestWorkerUpdateKeepsDrainingChainHead(t *testing.T) {
+	chainConfig := &params.ChainConfig{
+		ChainID:        big.NewInt(1338),
+		HomesteadBlock: new(big.Int),
+		Ethash:         new(params.EthashConfig),
+	}
+	genesis := &core.Genesis{
+		Config: chainConfig,
+		// Anchor the genesis at the current time so getResetTime returns a
+		// positive duration and the mining timer stays armed throughout the
+		// test: block time plus the mine period starts just ahead of "now",
+		// letting the timer expiry path run while the loop keeps servicing
+		// chain head events.
+		Timestamp:  uint64(time.Now().Unix()),
+		Difficulty: big.NewInt(1),
+		GasLimit:   params.XDCGenesisGasLimit,
+	}
+	db := rawdb.NewMemoryDatabase()
+	engine := ethash.NewFaker()
+	chain, err := core.NewBlockChain(db, nil, genesis, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create blockchain: %v", err)
+	}
+	defer chain.Stop()
+
+	head := chain.GetBlockByNumber(0)
+	if head == nil {
+		t.Fatal("expected genesis block")
+	}
+
+	// announceTxs is false and mining is 0, so commitNewWork bails out early in
+	// checkPreCommit and the loop stays cheap.
+	worker := &worker{
+		chainConfig:  chainConfig,
+		engine:       engine,
+		chain:        chain,
+		chainHeadCh:  make(chan core.ChainHeadEvent, chainHeadChanSize),
+		chainSideCh:  make(chan core.ChainSideEvent, chainSideChanSize),
+		chainHeadSub: newBlockingSubscription(),
+		chainSideSub: newBlockingSubscription(),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		worker.update()
+		close(done)
+	}()
+
+	// drainTimeout bounds how long a single send may block before the test
+	// concludes that worker.update stopped draining chain events. It is reused
+	// across iterations instead of calling time.After per send, which would
+	// allocate a fresh timer on every iteration.
+	drainTimeout := time.NewTimer(time.Second)
+	defer drainTimeout.Stop()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case worker.chainHeadCh <- core.ChainHeadEvent{Block: head}:
+			// Rearm the timeout for the next send, draining the channel first
+			// if the timer already expired.
+			if !drainTimeout.Stop() {
+				select {
+				case <-drainTimeout.C:
+				default:
+				}
+			}
+			drainTimeout.Reset(time.Second)
+		case <-drainTimeout.C:
+			t.Fatal("worker.update stopped draining chainHeadCh")
+		}
+	}
+
+	worker.chainHeadSub.Unsubscribe()
+	select {
+	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("worker.update did not return after unsubscribe")
 	}


### PR DESCRIPTION
# Proposed changes

The mining timer was owned by a dedicated goroutine that exchanged notifications with the update loop over two buffered channels: the loop sent the next duration on resetCh and the goroutine reported expiries on c. Both channels have a capacity of one, so once both buffers were full the two goroutines blocked on each other forever.

When that happened the worker stopped draining chainHeadCh and chainSideCh. Chain events are posted synchronously, so block insertion blocked in event.Feed.Send, the downloader never finished its sync round, and the node stopped importing blocks entirely.

Own the timer from the update loop itself, which removes the handshake and therefore the cycle.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
