### PR TITLE
fix(eth/downloader): fix sync fall behind because peer was reported timeout

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -55,10 +55,10 @@ var (
 
 	MaxForkAncestry  = 3 * params.EpochDuration // Maximum chain reorganisation
 	rttMinEstimate   = 2 * time.Second          // Minimum round-trip time to target for download requests
-	rttMaxEstimate   = 5 * time.Second          // Maximum rount-trip time to target for download requests
+	rttMaxEstimate   = 20 * time.Second         // Maximum round-trip time to target for download requests
 	rttMinConfidence = 0.1                      // Worse confidence factor in our estimated RTT value
-	ttlScaling       = 2                        // Constant scaling factor for RTT -> TTL conversion
-	ttlLimit         = 5 * time.Second          // Maximum TTL allowance to prevent reaching crazy timeouts
+	ttlScaling       = 3                        // Constant scaling factor for RTT -> TTL conversion
+	ttlLimit         = time.Minute              // Maximum TTL allowance to prevent reaching crazy timeouts
 
 	qosTuningPeers   = 5    // Number of peers to tune based on (best peers)
 	qosConfidenceCap = 10   // Number of peers above which not to modify RTT confidence

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -2273,3 +2273,37 @@ func TestFastSyncGapPivotSync(t *testing.T) {
 		t.Errorf("snapshot hash mismatch: have %v, want %v", snap.Hash, gapBlockHash)
 	}
 }
+
+// TestRequestTTL verifies that the request timeout scales with the measured
+// round-trip time instead of being pinned to a value so small that responsive
+// peers are still reported as timing out and get dropped.
+func TestRequestTTL(t *testing.T) {
+	tests := []struct {
+		name       string
+		rtt        time.Duration
+		confidence float64
+		want       time.Duration
+	}{
+		{"minimum rtt", rttMinEstimate, 1, 6 * time.Second},
+		{"maximum rtt", rttMaxEstimate, 1, time.Minute},
+		{"halved confidence", 5 * time.Second, 0.5, 30 * time.Second},
+		{"minimum confidence", rttMinEstimate, rttMinConfidence, time.Minute},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := new(Downloader)
+			atomic.StoreUint64(&d.rttEstimate, uint64(tt.rtt))
+			atomic.StoreUint64(&d.rttConfidence, uint64(tt.confidence*1000000))
+
+			if got := d.requestTTL(); got != tt.want {
+				t.Fatalf("request TTL mismatch: have %v, want %v", got, tt.want)
+			}
+		})
+	}
+	// A peer must always be granted at least one full worst case round trip
+	// before the downloader gives up on it, otherwise a lagging node drops its
+	// healthy peers faster than it can replace them.
+	if ttlLimit < rttMaxEstimate {
+		t.Fatalf("ttlLimit (%v) is below rttMaxEstimate (%v)", ttlLimit, rttMaxEstimate)
+	}
+}


### PR DESCRIPTION
# Proposed changes

The QoS constants were shrunk relative to upstream go-ethereum, which pinned requestTTL() to a hard 5 second ceiling: ttlLimit was 5s while ttlScaling (2) multiplied by rttMaxEstimate (5s) already exceeded it, so neither the measured RTT nor the confidence factor could ever influence the timeout.

Any peer that did not answer a single header request within 5 seconds was therefore reported as errTimeout and dropped. On a busy network this made a node that had fallen behind unable to recover: every sync round died in fetchHeight, the node dropped healthy peers faster than it could replace them, and it only advanced through propagated blocks, which cannot close a multi-thousand block gap.

Restore rttMaxEstimate, ttlScaling and ttlLimit to the upstream values so the timeout scales with the observed round-trip time again, and add a test covering requestTTL().


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
