### PR TITLE
refactor(eth/downloader): drop eth/63

### DIFF
--- a/cmd/devp2p/internal/ethtest/conn.go
+++ b/cmd/devp2p/internal/ethtest/conn.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	ethProtoVersion63     uint = 63
 	ethProtoVersionXDpos2 uint = 100
 )
 
@@ -70,7 +69,6 @@ func (s *Suite) dialAs(key *ecdsa.PrivateKey) (*Conn, error) {
 	}
 	conn.caps = []p2p.Cap{
 		{Name: "eth", Version: ethProtoVersionXDpos2},
-		{Name: "eth", Version: ethProtoVersion63},
 	}
 	conn.ourHighestProtoVersion = ethProtoVersionXDpos2
 	return conn, nil

--- a/cmd/devp2p/internal/ethtest/conn_test.go
+++ b/cmd/devp2p/internal/ethtest/conn_test.go
@@ -10,7 +10,7 @@ import (
 func TestConnNegotiatesHighestSharedEthVersion(t *testing.T) {
 	c := &Conn{ourHighestProtoVersion: ethProtoVersionXDpos2}
 	remoteCaps := []p2p.Cap{
-		{Name: "eth", Version: ethProtoVersion63},
+		{Name: "eth", Version: 170}, // above ours, must be skipped
 		{Name: "eth", Version: ethProtoVersionXDpos2},
 	}
 
@@ -22,8 +22,8 @@ func TestConnNegotiatesHighestSharedEthVersion(t *testing.T) {
 }
 
 func TestConnNegotiatesZeroWhenNoSharedEthVersion(t *testing.T) {
-	c := &Conn{ourHighestProtoVersion: ethProtoVersion63}
-	remoteCaps := []p2p.Cap{{Name: "eth", Version: 70}}
+	c := &Conn{ourHighestProtoVersion: ethProtoVersionXDpos2}
+	remoteCaps := []p2p.Cap{{Name: "eth", Version: 170}}
 
 	c.negotiateEthProtocol(remoteCaps)
 
@@ -38,10 +38,10 @@ func TestMakeStatusPacketFromChain(t *testing.T) {
 		t.Fatalf("failed to load chain fixtures: %v", err)
 	}
 
-	status := makeStatusPacket(chain, ethProtoVersion63)
+	status := makeStatusPacket(chain, ethProtoVersionXDpos2)
 
-	if status.ProtocolVersion != uint32(ethProtoVersion63) {
-		t.Fatalf("wrong protocol version: have %d want %d", status.ProtocolVersion, ethProtoVersion63)
+	if status.ProtocolVersion != uint32(ethProtoVersionXDpos2) {
+		t.Fatalf("wrong protocol version: have %d want %d", status.ProtocolVersion, ethProtoVersionXDpos2)
 	}
 	if status.GenesisBlock != chain.blocks[0].Hash() {
 		t.Fatalf("wrong genesis hash in status: have %x want %x", status.GenesisBlock, chain.blocks[0].Hash())

--- a/cmd/devp2p/internal/ethtest/suite.go
+++ b/cmd/devp2p/internal/ethtest/suite.go
@@ -1066,7 +1066,7 @@ func (s *Suite) TestHelloWithDuplicateEthCaps(t *utesting.T) {
 func malformedHelloByCase(name string, pub0 []byte) *protoHandshake {
 	base := &protoHandshake{
 		Version: 5,
-		Caps:    []p2p.Cap{{Name: "eth", Version: 63}},
+		Caps:    []p2p.Cap{{Name: "eth", Version: ethProtoVersionXDpos2}},
 		ID:      pub0,
 	}
 	builders := map[string]func() *protoHandshake{
@@ -1109,13 +1109,13 @@ func malformedHelloByCase(name string, pub0 []byte) *protoHandshake {
 			return &protoHandshake{Version: base.Version, Caps: []p2p.Cap{}, ID: base.ID}
 		},
 		"HelloWithEmptyCapName": func() *protoHandshake {
-			return &protoHandshake{Version: base.Version, Caps: []p2p.Cap{{Name: "", Version: 63}}, ID: base.ID}
+			return &protoHandshake{Version: base.Version, Caps: []p2p.Cap{{Name: "", Version: ethProtoVersionXDpos2}}, ID: base.ID}
 		},
 		"HelloWithLongCapName": func() *protoHandshake {
 			return &protoHandshake{Version: base.Version, Caps: []p2p.Cap{{Name: strings.Repeat("x", 512), Version: 1}}, ID: base.ID}
 		},
 		"HelloWithNULCapName": func() *protoHandshake {
-			return &protoHandshake{Version: base.Version, Caps: []p2p.Cap{{Name: "et\x00h", Version: 63}}, ID: base.ID}
+			return &protoHandshake{Version: base.Version, Caps: []p2p.Cap{{Name: "et\x00h", Version: ethProtoVersionXDpos2}}, ID: base.ID}
 		},
 		"HelloWithMismatchedIDAndEmptyCaps": func() *protoHandshake {
 			mismatch := append([]byte(nil), pub0...)
@@ -1136,8 +1136,8 @@ func malformedHelloByCase(name string, pub0 []byte) *protoHandshake {
 			return &protoHandshake{
 				Version: base.Version,
 				Caps: []p2p.Cap{
-					{Name: "eth", Version: 63},
-					{Name: "eth", Version: 63},
+					{Name: "eth", Version: ethProtoVersionXDpos2},
+					{Name: "eth", Version: ethProtoVersionXDpos2},
 				},
 				ID: base.ID,
 			}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -95,7 +95,7 @@ var (
 	errCancelContentProcessing = errors.New("content processing canceled (requested)")
 	errCanceled                = errors.New("syncing canceled (requested)")
 	errNoSyncActive            = errors.New("no sync active")
-	errTooOld                  = errors.New("peer doesn't speak recent enough protocol version (need version >= 63)")
+	errTooOld                  = fmt.Errorf("peer doesn't speak recent enough protocol version (need version >= %d)", minProtocolVer)
 	errEnoughBlock             = errors.New("downloader download enough block")
 )
 
@@ -139,17 +139,17 @@ type Downloader struct {
 	pivotGapLock    sync.RWMutex // Protects pivotGapNumbers
 
 	// Channels
-	headerCh      chan dataPack        // [eth/62] Channel receiving inbound block headers
-	bodyCh        chan dataPack        // [eth/62] Channel receiving inbound block bodies
-	receiptCh     chan dataPack        // [eth/63] Channel receiving inbound receipts
-	bodyWakeCh    chan bool            // [eth/62] Channel to signal the block body fetcher of new tasks
-	receiptWakeCh chan bool            // [eth/63] Channel to signal the receipt fetcher of new tasks
-	headerProcCh  chan []*types.Header // [eth/62] Channel to feed the header processor new tasks
+	headerCh      chan dataPack        // Channel receiving inbound block headers
+	bodyCh        chan dataPack        // Channel receiving inbound block bodies
+	receiptCh     chan dataPack        // Channel receiving inbound receipts
+	bodyWakeCh    chan bool            // Channel to signal the block body fetcher of new tasks
+	receiptWakeCh chan bool            // Channel to signal the receipt fetcher of new tasks
+	headerProcCh  chan []*types.Header // Channel to feed the header processor new tasks
 
 	// for stateFetcher
 	stateSyncStart chan *stateSync
 	trackStateReq  chan *stateReq
-	stateCh        chan dataPack // [eth/63] Channel receiving inbound node state data
+	stateCh        chan dataPack // Channel receiving inbound node state data
 
 	// Cancellation and termination
 	cancelPeer string         // Identifier of the peer currently being used as the master (cancel on drop)
@@ -478,7 +478,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 			d.mux.Post(DoneEvent{})
 		}
 	}()
-	if p.version < 63 {
+	if p.version < minProtocolVer {
 		return errTooOld
 	}
 	mode := d.getMode()

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -45,6 +45,15 @@ func init() {
 	fsHeaderContCheck = 500 * time.Millisecond
 }
 
+// Protocol versions accepted by the downloader, mirroring the constants of the
+// eth package, which cannot be imported here without creating an import cycle.
+// xdc100 and xdc165 are the current minProtocolVer and maxProtocolVer bounds.
+const (
+	xdc100 = 100
+	xdc164 = 164
+	xdc165 = 165
+)
+
 // downloadTester is a test simulator for mocking out local block chain.
 // TODO(daniel): remove field triedb
 type downloadTester struct {
@@ -478,22 +487,29 @@ func assertOwnForkedChain(t *testing.T, tester *downloadTester, common int, leng
 // Tests that simple synchronization against a canonical chain works correctly.
 // In this test common ancestor lookup should be short circuited and not require
 // binary searching.
-
-// TestCanonicalSynchronisation63Full tests canonical synchronisation 63 full.
-func TestCanonicalSynchronisation63Full(t *testing.T) { testCanonicalSynchronisation(t, 63, FullSync) }
-
-// TestCanonicalSynchronisation63Fast tests canonical synchronisation 63 fast.
-func TestCanonicalSynchronisation63Fast(t *testing.T) { testCanonicalSynchronisation(t, 63, FastSync) }
-
-// TestCanonicalSynchronisation64Full tests canonical synchronisation 64 full.
-func TestCanonicalSynchronisation64Full(t *testing.T) { testCanonicalSynchronisation(t, 64, FullSync) }
-
-// TestCanonicalSynchronisation64Fast tests canonical synchronisation 64 fast.
-func TestCanonicalSynchronisation64Fast(t *testing.T) { testCanonicalSynchronisation(t, 64, FastSync) }
-
-// TestCanonicalSynchronisation64Light tests canonical synchronisation 64 light.
-func TestCanonicalSynchronisation64Light(t *testing.T) {
-	testCanonicalSynchronisation(t, 64, LightSync)
+func TestCanonicalSynchronisation100Full(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc100, FullSync)
+}
+func TestCanonicalSynchronisation100Fast(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc100, FastSync)
+}
+func TestCanonicalSynchronisation164Full(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc164, FullSync)
+}
+func TestCanonicalSynchronisation164Fast(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc164, FastSync)
+}
+func TestCanonicalSynchronisation164Light(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc164, LightSync)
+}
+func TestCanonicalSynchronisation165Full(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc165, FullSync)
+}
+func TestCanonicalSynchronisation165Fast(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc165, FastSync)
+}
+func TestCanonicalSynchronisation165Light(t *testing.T) {
+	testCanonicalSynchronisation(t, xdc165, LightSync)
 }
 
 func testCanonicalSynchronisation(t *testing.T, protocol int, mode SyncMode) {
@@ -515,18 +531,12 @@ func testCanonicalSynchronisation(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that if a large batch of blocks are being downloaded, it is throttled
 // until the cached blocks are retrieved.
-
-// TestThrottling63Full tests throttling 63 full.
-func TestThrottling63Full(t *testing.T) { testThrottling(t, 63, FullSync) }
-
-// TestThrottling63Fast tests throttling 63 fast.
-func TestThrottling63Fast(t *testing.T) { testThrottling(t, 63, FastSync) }
-
-// TestThrottling64Full tests throttling 64 full.
-func TestThrottling64Full(t *testing.T) { testThrottling(t, 64, FullSync) }
-
-// TestThrottling64Fast tests throttling 64 fast.
-func TestThrottling64Fast(t *testing.T) { testThrottling(t, 64, FastSync) }
+func TestThrottling100Full(t *testing.T) { testThrottling(t, xdc100, FullSync) }
+func TestThrottling100Fast(t *testing.T) { testThrottling(t, xdc100, FastSync) }
+func TestThrottling164Full(t *testing.T) { testThrottling(t, xdc164, FullSync) }
+func TestThrottling164Fast(t *testing.T) { testThrottling(t, xdc164, FastSync) }
+func TestThrottling165Full(t *testing.T) { testThrottling(t, xdc165, FullSync) }
+func TestThrottling165Fast(t *testing.T) { testThrottling(t, xdc165, FastSync) }
 
 func testThrottling(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -604,21 +614,14 @@ func testThrottling(t *testing.T, protocol int, mode SyncMode) {
 // Tests that simple synchronization against a forked chain works correctly. In
 // this test common ancestor lookup should *not* be short circuited, and a full
 // binary search should be executed.
-
-// TestForkedSync63Full tests forked sync 63 full.
-func TestForkedSync63Full(t *testing.T) { testForkedSync(t, 63, FullSync) }
-
-// TestForkedSync63Fast tests forked sync 63 fast.
-func TestForkedSync63Fast(t *testing.T) { testForkedSync(t, 63, FastSync) }
-
-// TestForkedSync64Full tests forked sync 64 full.
-func TestForkedSync64Full(t *testing.T) { testForkedSync(t, 64, FullSync) }
-
-// TestForkedSync64Fast tests forked sync 64 fast.
-func TestForkedSync64Fast(t *testing.T) { testForkedSync(t, 64, FastSync) }
-
-// TestForkedSync64Light tests forked sync 64 light.
-func TestForkedSync64Light(t *testing.T) { testForkedSync(t, 64, LightSync) }
+func TestForkedSync100Full(t *testing.T)  { testForkedSync(t, xdc100, FullSync) }
+func TestForkedSync100Fast(t *testing.T)  { testForkedSync(t, xdc100, FastSync) }
+func TestForkedSync164Full(t *testing.T)  { testForkedSync(t, xdc164, FullSync) }
+func TestForkedSync164Fast(t *testing.T)  { testForkedSync(t, xdc164, FastSync) }
+func TestForkedSync164Light(t *testing.T) { testForkedSync(t, xdc164, LightSync) }
+func TestForkedSync165Full(t *testing.T)  { testForkedSync(t, xdc165, FullSync) }
+func TestForkedSync165Fast(t *testing.T)  { testForkedSync(t, xdc165, FastSync) }
+func TestForkedSync165Light(t *testing.T) { testForkedSync(t, xdc165, LightSync) }
 
 func testForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -645,21 +648,14 @@ func testForkedSync(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that synchronising against a much shorter but much heavyer fork works
 // corrently and is not dropped.
-
-// TestHeavyForkedSync63Full tests heavy forked sync 63 full.
-func TestHeavyForkedSync63Full(t *testing.T) { testHeavyForkedSync(t, 63, FullSync) }
-
-// TestHeavyForkedSync63Fast tests heavy forked sync 63 fast.
-func TestHeavyForkedSync63Fast(t *testing.T) { testHeavyForkedSync(t, 63, FastSync) }
-
-// TestHeavyForkedSync64Full tests heavy forked sync 64 full.
-func TestHeavyForkedSync64Full(t *testing.T) { testHeavyForkedSync(t, 64, FullSync) }
-
-// TestHeavyForkedSync64Fast tests heavy forked sync 64 fast.
-func TestHeavyForkedSync64Fast(t *testing.T) { testHeavyForkedSync(t, 64, FastSync) }
-
-// TestHeavyForkedSync64Light tests heavy forked sync 64 light.
-func TestHeavyForkedSync64Light(t *testing.T) { testHeavyForkedSync(t, 64, LightSync) }
+func TestHeavyForkedSync100Full(t *testing.T)  { testHeavyForkedSync(t, xdc100, FullSync) }
+func TestHeavyForkedSync100Fast(t *testing.T)  { testHeavyForkedSync(t, xdc100, FastSync) }
+func TestHeavyForkedSync164Full(t *testing.T)  { testHeavyForkedSync(t, xdc164, FullSync) }
+func TestHeavyForkedSync164Fast(t *testing.T)  { testHeavyForkedSync(t, xdc164, FastSync) }
+func TestHeavyForkedSync164Light(t *testing.T) { testHeavyForkedSync(t, xdc164, LightSync) }
+func TestHeavyForkedSync165Full(t *testing.T)  { testHeavyForkedSync(t, xdc165, FullSync) }
+func TestHeavyForkedSync165Fast(t *testing.T)  { testHeavyForkedSync(t, xdc165, FastSync) }
+func TestHeavyForkedSync165Light(t *testing.T) { testHeavyForkedSync(t, xdc165, LightSync) }
 
 func testHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -688,21 +684,14 @@ func testHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 // Tests that chain forks are contained within a certain interval of the current
 // chain head, ensuring that malicious peers cannot waste resources by feeding
 // long dead chains.
-
-// TestBoundedForkedSync63Full tests bounded forked sync 63 full.
-func TestBoundedForkedSync63Full(t *testing.T) { testBoundedForkedSync(t, 63, FullSync) }
-
-// TestBoundedForkedSync63Fast tests bounded forked sync 63 fast.
-func TestBoundedForkedSync63Fast(t *testing.T) { testBoundedForkedSync(t, 63, FastSync) }
-
-// TestBoundedForkedSync64Full tests bounded forked sync 64 full.
-func TestBoundedForkedSync64Full(t *testing.T) { testBoundedForkedSync(t, 64, FullSync) }
-
-// TestBoundedForkedSync64Fast tests bounded forked sync 64 fast.
-func TestBoundedForkedSync64Fast(t *testing.T) { testBoundedForkedSync(t, 64, FastSync) }
-
-// TestBoundedForkedSync64Light tests bounded forked sync 64 light.
-func TestBoundedForkedSync64Light(t *testing.T) { testBoundedForkedSync(t, 64, LightSync) }
+func TestBoundedForkedSync100Full(t *testing.T)  { testBoundedForkedSync(t, xdc100, FullSync) }
+func TestBoundedForkedSync100Fast(t *testing.T)  { testBoundedForkedSync(t, xdc100, FastSync) }
+func TestBoundedForkedSync164Full(t *testing.T)  { testBoundedForkedSync(t, xdc164, FullSync) }
+func TestBoundedForkedSync164Fast(t *testing.T)  { testBoundedForkedSync(t, xdc164, FastSync) }
+func TestBoundedForkedSync164Light(t *testing.T) { testBoundedForkedSync(t, xdc164, LightSync) }
+func TestBoundedForkedSync165Full(t *testing.T)  { testBoundedForkedSync(t, xdc165, FullSync) }
+func TestBoundedForkedSync165Fast(t *testing.T)  { testBoundedForkedSync(t, xdc165, FastSync) }
+func TestBoundedForkedSync165Light(t *testing.T) { testBoundedForkedSync(t, xdc165, LightSync) }
 
 func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -730,21 +719,18 @@ func testBoundedForkedSync(t *testing.T, protocol int, mode SyncMode) {
 // Tests that chain forks are contained within a certain interval of the current
 // chain head for short but heavy forks too. These are a bit special because they
 // take different ancestor lookup paths.
-
-// TestBoundedHeavyForkedSync63Full tests bounded heavy forked sync 63 full.
-func TestBoundedHeavyForkedSync63Full(t *testing.T) { testBoundedHeavyForkedSync(t, 63, FullSync) }
-
-// TestBoundedHeavyForkedSync63Fast tests bounded heavy forked sync 63 fast.
-func TestBoundedHeavyForkedSync63Fast(t *testing.T) { testBoundedHeavyForkedSync(t, 63, FastSync) }
-
-// TestBoundedHeavyForkedSync64Full tests bounded heavy forked sync 64 full.
-func TestBoundedHeavyForkedSync64Full(t *testing.T) { testBoundedHeavyForkedSync(t, 64, FullSync) }
-
-// TestBoundedHeavyForkedSync64Fast tests bounded heavy forked sync 64 fast.
-func TestBoundedHeavyForkedSync64Fast(t *testing.T) { testBoundedHeavyForkedSync(t, 64, FastSync) }
-
-// TestBoundedHeavyForkedSync64Light tests bounded heavy forked sync 64 light.
-func TestBoundedHeavyForkedSync64Light(t *testing.T) { testBoundedHeavyForkedSync(t, 64, LightSync) }
+func TestBoundedHeavyForkedSync100Full(t *testing.T) { testBoundedHeavyForkedSync(t, xdc100, FullSync) }
+func TestBoundedHeavyForkedSync100Fast(t *testing.T) { testBoundedHeavyForkedSync(t, xdc100, FastSync) }
+func TestBoundedHeavyForkedSync164Full(t *testing.T) { testBoundedHeavyForkedSync(t, xdc164, FullSync) }
+func TestBoundedHeavyForkedSync164Fast(t *testing.T) { testBoundedHeavyForkedSync(t, xdc164, FastSync) }
+func TestBoundedHeavyForkedSync164Light(t *testing.T) {
+	testBoundedHeavyForkedSync(t, xdc164, LightSync)
+}
+func TestBoundedHeavyForkedSync165Full(t *testing.T) { testBoundedHeavyForkedSync(t, xdc165, FullSync) }
+func TestBoundedHeavyForkedSync165Fast(t *testing.T) { testBoundedHeavyForkedSync(t, xdc165, FastSync) }
+func TestBoundedHeavyForkedSync165Light(t *testing.T) {
+	testBoundedHeavyForkedSync(t, xdc165, LightSync)
+}
 
 func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -771,7 +757,7 @@ func testBoundedHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that an inactive downloader will not accept incoming block headers,
 // bodies and receipts.
-func TestInactiveDownloader63(t *testing.T) {
+func TestInactiveDownloader100(t *testing.T) {
 	t.Parallel()
 
 	tester := newTester()
@@ -790,21 +776,14 @@ func TestInactiveDownloader63(t *testing.T) {
 }
 
 // Tests that a canceled download wipes all previously accumulated state.
-
-// TestCancel63Full tests cancel 63 full.
-func TestCancel63Full(t *testing.T) { testCancel(t, 63, FullSync) }
-
-// TestCancel63Fast tests cancel 63 fast.
-func TestCancel63Fast(t *testing.T) { testCancel(t, 63, FastSync) }
-
-// TestCancel64Full tests cancel 64 full.
-func TestCancel64Full(t *testing.T) { testCancel(t, 64, FullSync) }
-
-// TestCancel64Fast tests cancel 64 fast.
-func TestCancel64Fast(t *testing.T) { testCancel(t, 64, FastSync) }
-
-// TestCancel64Light tests cancel 64 light.
-func TestCancel64Light(t *testing.T) { testCancel(t, 64, LightSync) }
+func TestCancel100Full(t *testing.T)  { testCancel(t, xdc100, FullSync) }
+func TestCancel100Fast(t *testing.T)  { testCancel(t, xdc100, FastSync) }
+func TestCancel164Full(t *testing.T)  { testCancel(t, xdc164, FullSync) }
+func TestCancel164Fast(t *testing.T)  { testCancel(t, xdc164, FastSync) }
+func TestCancel164Light(t *testing.T) { testCancel(t, xdc164, LightSync) }
+func TestCancel165Full(t *testing.T)  { testCancel(t, xdc165, FullSync) }
+func TestCancel165Fast(t *testing.T)  { testCancel(t, xdc165, FastSync) }
+func TestCancel165Light(t *testing.T) { testCancel(t, xdc165, LightSync) }
 
 func testCancel(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -831,21 +810,14 @@ func testCancel(t *testing.T, protocol int, mode SyncMode) {
 }
 
 // Tests that synchronisation from multiple peers works as intended (multi thread sanity test).
-
-// TestMultiSynchronisation63Full tests multi synchronisation 63 full.
-func TestMultiSynchronisation63Full(t *testing.T) { testMultiSynchronisation(t, 63, FullSync) }
-
-// TestMultiSynchronisation63Fast tests multi synchronisation 63 fast.
-func TestMultiSynchronisation63Fast(t *testing.T) { testMultiSynchronisation(t, 63, FastSync) }
-
-// TestMultiSynchronisation64Full tests multi synchronisation 64 full.
-func TestMultiSynchronisation64Full(t *testing.T) { testMultiSynchronisation(t, 64, FullSync) }
-
-// TestMultiSynchronisation64Fast tests multi synchronisation 64 fast.
-func TestMultiSynchronisation64Fast(t *testing.T) { testMultiSynchronisation(t, 64, FastSync) }
-
-// TestMultiSynchronisation64Light tests multi synchronisation 64 light.
-func TestMultiSynchronisation64Light(t *testing.T) { testMultiSynchronisation(t, 64, LightSync) }
+func TestMultiSynchronisation100Full(t *testing.T)  { testMultiSynchronisation(t, xdc100, FullSync) }
+func TestMultiSynchronisation100Fast(t *testing.T)  { testMultiSynchronisation(t, xdc100, FastSync) }
+func TestMultiSynchronisation164Full(t *testing.T)  { testMultiSynchronisation(t, xdc164, FullSync) }
+func TestMultiSynchronisation164Fast(t *testing.T)  { testMultiSynchronisation(t, xdc164, FastSync) }
+func TestMultiSynchronisation164Light(t *testing.T) { testMultiSynchronisation(t, xdc164, LightSync) }
+func TestMultiSynchronisation165Full(t *testing.T)  { testMultiSynchronisation(t, xdc165, FullSync) }
+func TestMultiSynchronisation165Fast(t *testing.T)  { testMultiSynchronisation(t, xdc165, FastSync) }
+func TestMultiSynchronisation165Light(t *testing.T) { testMultiSynchronisation(t, xdc165, LightSync) }
 
 func testMultiSynchronisation(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -869,21 +841,14 @@ func testMultiSynchronisation(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that synchronisations behave well in multi-version protocol environments
 // and not wreak havoc on other nodes in the network.
-
-// TestMultiProtoSynchronisation63Full tests multi proto synchronisation 63 full.
-func TestMultiProtoSynchronisation63Full(t *testing.T) { testMultiProtoSync(t, 63, FullSync) }
-
-// TestMultiProtoSynchronisation63Fast tests multi proto synchronisation 63 fast.
-func TestMultiProtoSynchronisation63Fast(t *testing.T) { testMultiProtoSync(t, 63, FastSync) }
-
-// TestMultiProtoSynchronisation64Full tests multi proto synchronisation 64 full.
-func TestMultiProtoSynchronisation64Full(t *testing.T) { testMultiProtoSync(t, 64, FullSync) }
-
-// TestMultiProtoSynchronisation64Fast tests multi proto synchronisation 64 fast.
-func TestMultiProtoSynchronisation64Fast(t *testing.T) { testMultiProtoSync(t, 64, FastSync) }
-
-// TestMultiProtoSynchronisation64Light tests multi proto synchronisation 64 light.
-func TestMultiProtoSynchronisation64Light(t *testing.T) { testMultiProtoSync(t, 64, LightSync) }
+func TestMultiProtoSynchronisation100Full(t *testing.T)  { testMultiProtoSync(t, xdc100, FullSync) }
+func TestMultiProtoSynchronisation100Fast(t *testing.T)  { testMultiProtoSync(t, xdc100, FastSync) }
+func TestMultiProtoSynchronisation164Full(t *testing.T)  { testMultiProtoSync(t, xdc164, FullSync) }
+func TestMultiProtoSynchronisation164Fast(t *testing.T)  { testMultiProtoSync(t, xdc164, FastSync) }
+func TestMultiProtoSynchronisation164Light(t *testing.T) { testMultiProtoSync(t, xdc164, LightSync) }
+func TestMultiProtoSynchronisation165Full(t *testing.T)  { testMultiProtoSync(t, xdc165, FullSync) }
+func TestMultiProtoSynchronisation165Fast(t *testing.T)  { testMultiProtoSync(t, xdc165, FastSync) }
+func TestMultiProtoSynchronisation165Light(t *testing.T) { testMultiProtoSync(t, xdc165, LightSync) }
 
 func testMultiProtoSync(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -895,8 +860,9 @@ func testMultiProtoSync(t *testing.T, protocol int, mode SyncMode) {
 	chain := testChainBase.shorten(blockCacheMaxItems - 15)
 
 	// Create peers of every type
-	tester.newPeer("peer 63", 63, chain)
-	tester.newPeer("peer 64", 64, chain)
+	tester.newPeer("peer 100", xdc100, chain)
+	tester.newPeer("peer 164", xdc164, chain)
+	tester.newPeer("peer 165", xdc165, chain)
 
 	// Synchronise with the requested peer and make sure all blocks were retrieved
 	if err := tester.sync(fmt.Sprintf("peer %d", protocol), nil, mode); err != nil {
@@ -905,7 +871,7 @@ func testMultiProtoSync(t *testing.T, protocol int, mode SyncMode) {
 	assertOwnChain(t, tester, chain.len())
 
 	// Check that no peers have been dropped off
-	for _, version := range []int{63, 64} {
+	for _, version := range []int{xdc100, xdc164, xdc165} {
 		peer := fmt.Sprintf("peer %d", version)
 		if _, ok := tester.peers[peer]; !ok {
 			t.Errorf("%s dropped", peer)
@@ -915,21 +881,14 @@ func testMultiProtoSync(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that if a block is empty (e.g. header only), no body request should be
 // made, and instead the header should be assembled into a whole block in itself.
-
-// TestEmptyShortCircuit63Full tests empty short circuit 63 full.
-func TestEmptyShortCircuit63Full(t *testing.T) { testEmptyShortCircuit(t, 63, FullSync) }
-
-// TestEmptyShortCircuit63Fast tests empty short circuit 63 fast.
-func TestEmptyShortCircuit63Fast(t *testing.T) { testEmptyShortCircuit(t, 63, FastSync) }
-
-// TestEmptyShortCircuit64Full tests empty short circuit 64 full.
-func TestEmptyShortCircuit64Full(t *testing.T) { testEmptyShortCircuit(t, 64, FullSync) }
-
-// TestEmptyShortCircuit64Fast tests empty short circuit 64 fast.
-func TestEmptyShortCircuit64Fast(t *testing.T) { testEmptyShortCircuit(t, 64, FastSync) }
-
-// TestEmptyShortCircuit64Light tests empty short circuit 64 light.
-func TestEmptyShortCircuit64Light(t *testing.T) { testEmptyShortCircuit(t, 64, LightSync) }
+func TestEmptyShortCircuit100Full(t *testing.T)  { testEmptyShortCircuit(t, xdc100, FullSync) }
+func TestEmptyShortCircuit100Fast(t *testing.T)  { testEmptyShortCircuit(t, xdc100, FastSync) }
+func TestEmptyShortCircuit164Full(t *testing.T)  { testEmptyShortCircuit(t, xdc164, FullSync) }
+func TestEmptyShortCircuit164Fast(t *testing.T)  { testEmptyShortCircuit(t, xdc164, FastSync) }
+func TestEmptyShortCircuit164Light(t *testing.T) { testEmptyShortCircuit(t, xdc164, LightSync) }
+func TestEmptyShortCircuit165Full(t *testing.T)  { testEmptyShortCircuit(t, xdc165, FullSync) }
+func TestEmptyShortCircuit165Fast(t *testing.T)  { testEmptyShortCircuit(t, xdc165, FastSync) }
+func TestEmptyShortCircuit165Light(t *testing.T) { testEmptyShortCircuit(t, xdc165, LightSync) }
 
 func testEmptyShortCircuit(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -977,21 +936,14 @@ func testEmptyShortCircuit(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that headers are enqueued continuously, preventing malicious nodes from
 // stalling the downloader by feeding gapped header chains.
-
-// TestMissingHeaderAttack63Full tests missing header attack 63 full.
-func TestMissingHeaderAttack63Full(t *testing.T) { testMissingHeaderAttack(t, 63, FullSync) }
-
-// TestMissingHeaderAttack63Fast tests missing header attack 63 fast.
-func TestMissingHeaderAttack63Fast(t *testing.T) { testMissingHeaderAttack(t, 63, FastSync) }
-
-// TestMissingHeaderAttack64Full tests missing header attack 64 full.
-func TestMissingHeaderAttack64Full(t *testing.T) { testMissingHeaderAttack(t, 64, FullSync) }
-
-// TestMissingHeaderAttack64Fast tests missing header attack 64 fast.
-func TestMissingHeaderAttack64Fast(t *testing.T) { testMissingHeaderAttack(t, 64, FastSync) }
-
-// TestMissingHeaderAttack64Light tests missing header attack 64 light.
-func TestMissingHeaderAttack64Light(t *testing.T) { testMissingHeaderAttack(t, 64, LightSync) }
+func TestMissingHeaderAttack100Full(t *testing.T)  { testMissingHeaderAttack(t, xdc100, FullSync) }
+func TestMissingHeaderAttack100Fast(t *testing.T)  { testMissingHeaderAttack(t, xdc100, FastSync) }
+func TestMissingHeaderAttack164Full(t *testing.T)  { testMissingHeaderAttack(t, xdc164, FullSync) }
+func TestMissingHeaderAttack164Fast(t *testing.T)  { testMissingHeaderAttack(t, xdc164, FastSync) }
+func TestMissingHeaderAttack164Light(t *testing.T) { testMissingHeaderAttack(t, xdc164, LightSync) }
+func TestMissingHeaderAttack165Full(t *testing.T)  { testMissingHeaderAttack(t, xdc165, FullSync) }
+func TestMissingHeaderAttack165Fast(t *testing.T)  { testMissingHeaderAttack(t, xdc165, FastSync) }
+func TestMissingHeaderAttack165Light(t *testing.T) { testMissingHeaderAttack(t, xdc165, LightSync) }
 
 func testMissingHeaderAttack(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1017,21 +969,14 @@ func testMissingHeaderAttack(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that if requested headers are shifted (i.e. first is missing), the queue
 // detects the invalid numbering.
-
-// TestShiftedHeaderAttack63Full tests shifted header attack 63 full.
-func TestShiftedHeaderAttack63Full(t *testing.T) { testShiftedHeaderAttack(t, 63, FullSync) }
-
-// TestShiftedHeaderAttack63Fast tests shifted header attack 63 fast.
-func TestShiftedHeaderAttack63Fast(t *testing.T) { testShiftedHeaderAttack(t, 63, FastSync) }
-
-// TestShiftedHeaderAttack64Full tests shifted header attack 64 full.
-func TestShiftedHeaderAttack64Full(t *testing.T) { testShiftedHeaderAttack(t, 64, FullSync) }
-
-// TestShiftedHeaderAttack64Fast tests shifted header attack 64 fast.
-func TestShiftedHeaderAttack64Fast(t *testing.T) { testShiftedHeaderAttack(t, 64, FastSync) }
-
-// TestShiftedHeaderAttack64Light tests shifted header attack 64 light.
-func TestShiftedHeaderAttack64Light(t *testing.T) { testShiftedHeaderAttack(t, 64, LightSync) }
+func TestShiftedHeaderAttack100Full(t *testing.T)  { testShiftedHeaderAttack(t, xdc100, FullSync) }
+func TestShiftedHeaderAttack100Fast(t *testing.T)  { testShiftedHeaderAttack(t, xdc100, FastSync) }
+func TestShiftedHeaderAttack164Full(t *testing.T)  { testShiftedHeaderAttack(t, xdc164, FullSync) }
+func TestShiftedHeaderAttack164Fast(t *testing.T)  { testShiftedHeaderAttack(t, xdc164, FastSync) }
+func TestShiftedHeaderAttack164Light(t *testing.T) { testShiftedHeaderAttack(t, xdc164, LightSync) }
+func TestShiftedHeaderAttack165Full(t *testing.T)  { testShiftedHeaderAttack(t, xdc165, FullSync) }
+func TestShiftedHeaderAttack165Fast(t *testing.T)  { testShiftedHeaderAttack(t, xdc165, FastSync) }
+func TestShiftedHeaderAttack165Light(t *testing.T) { testShiftedHeaderAttack(t, xdc165, LightSync) }
 
 func testShiftedHeaderAttack(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1062,13 +1007,11 @@ func testShiftedHeaderAttack(t *testing.T, protocol int, mode SyncMode) {
 // Tests that upon detecting an invalid header, the recent ones are rolled back
 // for various failure scenarios. Afterwards a full sync is attempted to make
 // sure no state was corrupted.
-func TestInvalidHeaderRollback63Fast(t *testing.T) { testInvalidHeaderRollback(t, 63, FastSync) }
-
-// TestInvalidHeaderRollback64Fast tests invalid header rollback 64 fast.
-func TestInvalidHeaderRollback64Fast(t *testing.T) { testInvalidHeaderRollback(t, 64, FastSync) }
-
-// TestInvalidHeaderRollback64Light tests invalid header rollback 64 light.
-func TestInvalidHeaderRollback64Light(t *testing.T) { testInvalidHeaderRollback(t, 64, LightSync) }
+func TestInvalidHeaderRollback100Fast(t *testing.T)  { testInvalidHeaderRollback(t, xdc100, FastSync) }
+func TestInvalidHeaderRollback164Fast(t *testing.T)  { testInvalidHeaderRollback(t, xdc164, FastSync) }
+func TestInvalidHeaderRollback164Light(t *testing.T) { testInvalidHeaderRollback(t, xdc164, LightSync) }
+func TestInvalidHeaderRollback165Fast(t *testing.T)  { testInvalidHeaderRollback(t, xdc165, FastSync) }
+func TestInvalidHeaderRollback165Light(t *testing.T) { testInvalidHeaderRollback(t, xdc165, LightSync) }
 
 func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1158,21 +1101,18 @@ func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that a peer advertising an high TD doesn't get to stall the downloader
 // afterwards by not sending any useful hashes.
-
-// TestHighTDStarvationAttack63Full tests high td starvation attack 63 full.
-func TestHighTDStarvationAttack63Full(t *testing.T) { testHighTDStarvationAttack(t, 63, FullSync) }
-
-// TestHighTDStarvationAttack63Fast tests high td starvation attack 63 fast.
-func TestHighTDStarvationAttack63Fast(t *testing.T) { testHighTDStarvationAttack(t, 63, FastSync) }
-
-// TestHighTDStarvationAttack64Full tests high td starvation attack 64 full.
-func TestHighTDStarvationAttack64Full(t *testing.T) { testHighTDStarvationAttack(t, 64, FullSync) }
-
-// TestHighTDStarvationAttack64Fast tests high td starvation attack 64 fast.
-func TestHighTDStarvationAttack64Fast(t *testing.T) { testHighTDStarvationAttack(t, 64, FastSync) }
-
-// TestHighTDStarvationAttack64Light tests high td starvation attack 64 light.
-func TestHighTDStarvationAttack64Light(t *testing.T) { testHighTDStarvationAttack(t, 64, LightSync) }
+func TestHighTDStarvationAttack100Full(t *testing.T) { testHighTDStarvationAttack(t, xdc100, FullSync) }
+func TestHighTDStarvationAttack100Fast(t *testing.T) { testHighTDStarvationAttack(t, xdc100, FastSync) }
+func TestHighTDStarvationAttack164Full(t *testing.T) { testHighTDStarvationAttack(t, xdc164, FullSync) }
+func TestHighTDStarvationAttack164Fast(t *testing.T) { testHighTDStarvationAttack(t, xdc164, FastSync) }
+func TestHighTDStarvationAttack164Light(t *testing.T) {
+	testHighTDStarvationAttack(t, xdc164, LightSync)
+}
+func TestHighTDStarvationAttack165Full(t *testing.T) { testHighTDStarvationAttack(t, xdc165, FullSync) }
+func TestHighTDStarvationAttack165Fast(t *testing.T) { testHighTDStarvationAttack(t, xdc165, FastSync) }
+func TestHighTDStarvationAttack165Light(t *testing.T) {
+	testHighTDStarvationAttack(t, xdc165, LightSync)
+}
 
 func testHighTDStarvationAttack(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1188,12 +1128,9 @@ func testHighTDStarvationAttack(t *testing.T, protocol int, mode SyncMode) {
 }
 
 // Tests that misbehaving peers are disconnected, whilst behaving ones are not.
-
-// TestBlockHeaderAttackerDropping63 tests block header attacker dropping 63.
-func TestBlockHeaderAttackerDropping63(t *testing.T) { testBlockHeaderAttackerDropping(t, 63) }
-
-// TestBlockHeaderAttackerDropping64 tests block header attacker dropping 64.
-func TestBlockHeaderAttackerDropping64(t *testing.T) { testBlockHeaderAttackerDropping(t, 64) }
+func TestBlockHeaderAttackerDropping100(t *testing.T) { testBlockHeaderAttackerDropping(t, xdc100) }
+func TestBlockHeaderAttackerDropping164(t *testing.T) { testBlockHeaderAttackerDropping(t, xdc164) }
+func TestBlockHeaderAttackerDropping165(t *testing.T) { testBlockHeaderAttackerDropping(t, xdc165) }
 
 func testBlockHeaderAttackerDropping(t *testing.T, protocol int) {
 	t.Parallel()
@@ -1253,7 +1190,7 @@ func TestSyncBatchAncestorErrDropPeer(t *testing.T) {
 			defer tester.terminate()
 
 			chain := testChainBase.shorten(blockCacheMaxItems - 15)
-			if err := tester.newPeer("peer", 64, chain); err != nil {
+			if err := tester.newPeer("peer", xdc164, chain); err != nil {
 				t.Fatalf("failed to register peer: %v", err)
 			}
 
@@ -1290,7 +1227,7 @@ func TestSyncBatchNoAncestorErrKeepPeer(t *testing.T) {
 			defer tester.terminate()
 
 			chain := testChainBase.shorten(blockCacheMaxItems - 15)
-			if err := tester.newPeer("peer", 64, chain); err != nil {
+			if err := tester.newPeer("peer", xdc164, chain); err != nil {
 				t.Fatalf("failed to register peer: %v", err)
 			}
 
@@ -1308,21 +1245,14 @@ func TestSyncBatchNoAncestorErrKeepPeer(t *testing.T) {
 
 // Tests that synchronisation progress (origin block number, current block number
 // and highest block number) is tracked and updated correctly.
-
-// TestSyncProgress63Full tests sync progress 63 full.
-func TestSyncProgress63Full(t *testing.T) { testSyncProgress(t, 63, FullSync) }
-
-// TestSyncProgress63Fast tests sync progress 63 fast.
-func TestSyncProgress63Fast(t *testing.T) { testSyncProgress(t, 63, FastSync) }
-
-// TestSyncProgress64Full tests sync progress 64 full.
-func TestSyncProgress64Full(t *testing.T) { testSyncProgress(t, 64, FullSync) }
-
-// TestSyncProgress64Fast tests sync progress 64 fast.
-func TestSyncProgress64Fast(t *testing.T) { testSyncProgress(t, 64, FastSync) }
-
-// TestSyncProgress64Light tests sync progress 64 light.
-func TestSyncProgress64Light(t *testing.T) { testSyncProgress(t, 64, LightSync) }
+func TestSyncProgress100Full(t *testing.T)  { testSyncProgress(t, xdc100, FullSync) }
+func TestSyncProgress100Fast(t *testing.T)  { testSyncProgress(t, xdc100, FastSync) }
+func TestSyncProgress164Full(t *testing.T)  { testSyncProgress(t, xdc164, FullSync) }
+func TestSyncProgress164Fast(t *testing.T)  { testSyncProgress(t, xdc164, FastSync) }
+func TestSyncProgress164Light(t *testing.T) { testSyncProgress(t, xdc164, LightSync) }
+func TestSyncProgress165Full(t *testing.T)  { testSyncProgress(t, xdc165, FullSync) }
+func TestSyncProgress165Fast(t *testing.T)  { testSyncProgress(t, xdc165, FastSync) }
+func TestSyncProgress165Light(t *testing.T) { testSyncProgress(t, xdc165, LightSync) }
 
 func testSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1403,21 +1333,14 @@ func checkProgress(t *testing.T, d *Downloader, stage string, want ethereum.Sync
 // Tests that synchronisation progress (origin block number and highest block
 // number) is tracked and updated correctly in case of a fork (or manual head
 // revertal).
-
-// TestForkedSyncProgress63Full tests forked sync progress 63 full.
-func TestForkedSyncProgress63Full(t *testing.T) { testForkedSyncProgress(t, 63, FullSync) }
-
-// TestForkedSyncProgress63Fast tests forked sync progress 63 fast.
-func TestForkedSyncProgress63Fast(t *testing.T) { testForkedSyncProgress(t, 63, FastSync) }
-
-// TestForkedSyncProgress64Full tests forked sync progress 64 full.
-func TestForkedSyncProgress64Full(t *testing.T) { testForkedSyncProgress(t, 64, FullSync) }
-
-// TestForkedSyncProgress64Fast tests forked sync progress 64 fast.
-func TestForkedSyncProgress64Fast(t *testing.T) { testForkedSyncProgress(t, 64, FastSync) }
-
-// TestForkedSyncProgress64Light tests forked sync progress 64 light.
-func TestForkedSyncProgress64Light(t *testing.T) { testForkedSyncProgress(t, 64, LightSync) }
+func TestForkedSyncProgress100Full(t *testing.T)  { testForkedSyncProgress(t, xdc100, FullSync) }
+func TestForkedSyncProgress100Fast(t *testing.T)  { testForkedSyncProgress(t, xdc100, FastSync) }
+func TestForkedSyncProgress164Full(t *testing.T)  { testForkedSyncProgress(t, xdc164, FullSync) }
+func TestForkedSyncProgress164Fast(t *testing.T)  { testForkedSyncProgress(t, xdc164, FastSync) }
+func TestForkedSyncProgress164Light(t *testing.T) { testForkedSyncProgress(t, xdc164, LightSync) }
+func TestForkedSyncProgress165Full(t *testing.T)  { testForkedSyncProgress(t, xdc165, FullSync) }
+func TestForkedSyncProgress165Fast(t *testing.T)  { testForkedSyncProgress(t, xdc165, FastSync) }
+func TestForkedSyncProgress165Light(t *testing.T) { testForkedSyncProgress(t, xdc165, LightSync) }
 
 func testForkedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1487,21 +1410,14 @@ func testForkedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 // Tests that if synchronisation is aborted due to some failure, then the progress
 // origin is not updated in the next sync cycle, as it should be considered the
 // continuation of the previous sync and not a new instance.
-
-// TestFailedSyncProgress63Full tests failed sync progress 63 full.
-func TestFailedSyncProgress63Full(t *testing.T) { testFailedSyncProgress(t, 63, FullSync) }
-
-// TestFailedSyncProgress63Fast tests failed sync progress 63 fast.
-func TestFailedSyncProgress63Fast(t *testing.T) { testFailedSyncProgress(t, 63, FastSync) }
-
-// TestFailedSyncProgress64Full tests failed sync progress 64 full.
-func TestFailedSyncProgress64Full(t *testing.T) { testFailedSyncProgress(t, 64, FullSync) }
-
-// TestFailedSyncProgress64Fast tests failed sync progress 64 fast.
-func TestFailedSyncProgress64Fast(t *testing.T) { testFailedSyncProgress(t, 64, FastSync) }
-
-// TestFailedSyncProgress64Light tests failed sync progress 64 light.
-func TestFailedSyncProgress64Light(t *testing.T) { testFailedSyncProgress(t, 64, LightSync) }
+func TestFailedSyncProgress100Full(t *testing.T)  { testFailedSyncProgress(t, xdc100, FullSync) }
+func TestFailedSyncProgress100Fast(t *testing.T)  { testFailedSyncProgress(t, xdc100, FastSync) }
+func TestFailedSyncProgress164Full(t *testing.T)  { testFailedSyncProgress(t, xdc164, FullSync) }
+func TestFailedSyncProgress164Fast(t *testing.T)  { testFailedSyncProgress(t, xdc164, FastSync) }
+func TestFailedSyncProgress164Light(t *testing.T) { testFailedSyncProgress(t, xdc164, LightSync) }
+func TestFailedSyncProgress165Full(t *testing.T)  { testFailedSyncProgress(t, xdc165, FullSync) }
+func TestFailedSyncProgress165Fast(t *testing.T)  { testFailedSyncProgress(t, xdc165, FastSync) }
+func TestFailedSyncProgress165Light(t *testing.T) { testFailedSyncProgress(t, xdc165, LightSync) }
 
 func testFailedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1568,21 +1484,14 @@ func testFailedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 
 // Tests that if an attacker fakes a chain height, after the attack is detected,
 // the progress height is successfully reduced at the next sync invocation.
-
-// TestFakedSyncProgress63Full tests faked sync progress 63 full.
-func TestFakedSyncProgress63Full(t *testing.T) { testFakedSyncProgress(t, 63, FullSync) }
-
-// TestFakedSyncProgress63Fast tests faked sync progress 63 fast.
-func TestFakedSyncProgress63Fast(t *testing.T) { testFakedSyncProgress(t, 63, FastSync) }
-
-// TestFakedSyncProgress64Full tests faked sync progress 64 full.
-func TestFakedSyncProgress64Full(t *testing.T) { testFakedSyncProgress(t, 64, FullSync) }
-
-// TestFakedSyncProgress64Fast tests faked sync progress 64 fast.
-func TestFakedSyncProgress64Fast(t *testing.T) { testFakedSyncProgress(t, 64, FastSync) }
-
-// TestFakedSyncProgress64Light tests faked sync progress 64 light.
-func TestFakedSyncProgress64Light(t *testing.T) { testFakedSyncProgress(t, 64, LightSync) }
+func TestFakedSyncProgress100Full(t *testing.T)  { testFakedSyncProgress(t, xdc100, FullSync) }
+func TestFakedSyncProgress100Fast(t *testing.T)  { testFakedSyncProgress(t, xdc100, FastSync) }
+func TestFakedSyncProgress164Full(t *testing.T)  { testFakedSyncProgress(t, xdc164, FullSync) }
+func TestFakedSyncProgress164Fast(t *testing.T)  { testFakedSyncProgress(t, xdc164, FastSync) }
+func TestFakedSyncProgress164Light(t *testing.T) { testFakedSyncProgress(t, xdc164, LightSync) }
+func TestFakedSyncProgress165Full(t *testing.T)  { testFakedSyncProgress(t, xdc165, FullSync) }
+func TestFakedSyncProgress165Fast(t *testing.T)  { testFakedSyncProgress(t, xdc165, FastSync) }
+func TestFakedSyncProgress165Light(t *testing.T) { testFakedSyncProgress(t, xdc165, LightSync) }
 
 func testFakedSyncProgress(t *testing.T, protocol int, mode SyncMode) {
 	t.Parallel()
@@ -1662,7 +1571,7 @@ func TestStateSyncSpindownCompletedDoesNotBlock(t *testing.T) {
 	tester := newTester()
 	defer tester.terminate()
 
-	if err := tester.newPeer("active", 63, testChainBase.shorten(8)); err != nil {
+	if err := tester.newPeer("active", xdc100, testChainBase.shorten(8)); err != nil {
 		t.Fatalf("failed to create peer: %v", err)
 	}
 	peer := tester.downloader.peers.Peer("active")
@@ -1711,11 +1620,14 @@ func TestDeliverHeadersHang(t *testing.T) {
 		protocol int
 		syncMode SyncMode
 	}{
-		{63, FullSync},
-		{63, FastSync},
-		{64, FullSync},
-		{64, FastSync},
-		{64, LightSync},
+		{xdc100, FullSync},
+		{xdc100, FastSync},
+		{xdc164, FullSync},
+		{xdc164, FastSync},
+		{xdc164, LightSync},
+		{xdc165, FullSync},
+		{xdc165, FastSync},
+		{xdc165, LightSync},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("protocol %d mode %v", tc.protocol, tc.syncMode), func(t *testing.T) {
@@ -1895,13 +1807,14 @@ func TestRemoteHeaderRequestSpan(t *testing.T) {
 //
 // Concretely: gap=51 matches the real-world scenario observed in production
 // (local=3,807,570, peer=3,807,621, localHead+48=3,807,618 < 3,807,621).
-func TestReorgProtectionDoesNotStallSync63Full(t *testing.T) {
-	testReorgProtectionDoesNotStallSync(t, 63, FullSync)
+func TestReorgProtectionDoesNotStallSync100Full(t *testing.T) {
+	testReorgProtectionDoesNotStallSync(t, xdc100, FullSync)
 }
-
-// TestReorgProtectionDoesNotStallSync64Full tests reorg protection does not stall sync 64 full.
-func TestReorgProtectionDoesNotStallSync64Full(t *testing.T) {
-	testReorgProtectionDoesNotStallSync(t, 64, FullSync)
+func TestReorgProtectionDoesNotStallSync164Full(t *testing.T) {
+	testReorgProtectionDoesNotStallSync(t, xdc164, FullSync)
+}
+func TestReorgProtectionDoesNotStallSync165Full(t *testing.T) {
+	testReorgProtectionDoesNotStallSync(t, xdc165, FullSync)
 }
 
 func testReorgProtectionDoesNotStallSync(t *testing.T, protocol int, mode SyncMode) {
@@ -2109,7 +2022,7 @@ func TestFastSyncPivotHashMismatch(t *testing.T) {
 	// Use a chain short enough to be fast but long enough to trigger state sync.
 	chainLen := 300
 	chain := testChainBase.shorten(chainLen)
-	tester.newPeer("peer", 63, chain)
+	tester.newPeer("peer", xdc100, chain)
 
 	// Identify the natural pivot block so we can supply the correct state root
 	// (so state sync succeeds) while feeding a wrong hash (so the check fires).
@@ -2142,7 +2055,7 @@ func TestFastSyncConfiguredPivotHashMatch(t *testing.T) {
 
 	chainLen := 300
 	chain := testChainBase.shorten(chainLen)
-	tester.newPeer("peer", 63, chain)
+	tester.newPeer("peer", xdc100, chain)
 
 	// Natural pivot = headBlock().Number - fsMinFullBlocks = (chainLen-1) - fsMinFullBlocks.
 	pivotNum := uint64(chainLen - 1 - fsMinFullBlocks) // = 235
@@ -2182,7 +2095,7 @@ func TestFastSyncGapPivotSync(t *testing.T) {
 	// 600 blocks: natural pivot = 600-1-64 = 535, gap pivot = 450.
 	chainLen := 600
 	chain := testChainBase.shorten(chainLen)
-	tester.newPeer("peer", 63, chain)
+	tester.newPeer("peer", xdc100, chain)
 
 	// Natural pivot = headBlock().Number - fsMinFullBlocks = (chainLen-1) - fsMinFullBlocks.
 	pivotNum := uint64(chainLen - 1 - fsMinFullBlocks) // = 535

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -37,7 +37,7 @@ const (
 	maxLackingHashes  = 4096 // Maximum number of entries allowed on the list or lacking items
 	measurementImpact = 0.1  // The impact a single measurement has on a peer's final throughput value.
 
-	minProtocolVer = 63  // eth63
+	minProtocolVer = 100 // xdc100
 	maxProtocolVer = 165 // xdc165
 )
 

--- a/eth/downloader/peer_test.go
+++ b/eth/downloader/peer_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 // TestIdlePeersProtocolVersions verifies that peers running every supported
-// protocol version (eth63, xdc100, xdc164) are eligible for concurrent
+// protocol version (xdc100, xdc164, xdc165) are eligible for concurrent
 // downloads. A regression here silently disables skeleton filling and body,
 // receipt and state fetches, stalling any node that falls behind.
 func TestIdlePeersProtocolVersions(t *testing.T) {
 	ps := newPeerSet()
-	for i, version := range []int{63, 100, 164} {
+	for i, version := range []int{xdc100, xdc164, xdc165} {
 		id := fmt.Sprintf("peer-%d", i)
 		if err := ps.Register(newPeerConnection(id, version, nil, log.New("id", id))); err != nil {
 			t.Fatalf("failed to register version %d peer: %v", version, err)

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -121,24 +121,24 @@ type queue struct {
 	mode SyncMode // Synchronisation mode to decide on the block parts to schedule for fetching
 
 	// Headers are "special", they download in batches, supported by a skeleton chain
-	headerHead      common.Hash                    // [eth/62] Hash of the last queued header to verify order
-	headerTaskPool  map[uint64]*types.Header       // [eth/62] Pending header retrieval tasks, mapping starting indexes to skeleton headers
-	headerTaskQueue *prque.Prque[int64, uint64]    // [eth/62] Priority queue of the skeleton indexes to fetch the filling headers for
-	headerPeerMiss  map[string]map[uint64]struct{} // [eth/62] Set of per-peer header batches known to be unavailable
-	headerPendPool  map[string]*fetchRequest       // [eth/62] Currently pending header retrieval operations
-	headerResults   []*types.Header                // [eth/62] Result cache accumulating the completed headers
-	headerProced    int                            // [eth/62] Number of headers already processed from the results
-	headerOffset    uint64                         // [eth/62] Number of the first header in the result cache
-	headerContCh    chan bool                      // [eth/62] Channel to notify when header download finishes
+	headerHead      common.Hash                    // Hash of the last queued header to verify order
+	headerTaskPool  map[uint64]*types.Header       // Pending header retrieval tasks, mapping starting indexes to skeleton headers
+	headerTaskQueue *prque.Prque[int64, uint64]    // Priority queue of the skeleton indexes to fetch the filling headers for
+	headerPeerMiss  map[string]map[uint64]struct{} // Set of per-peer header batches known to be unavailable
+	headerPendPool  map[string]*fetchRequest       // Currently pending header retrieval operations
+	headerResults   []*types.Header                // Result cache accumulating the completed headers
+	headerProced    int                            // Number of headers already processed from the results
+	headerOffset    uint64                         // Number of the first header in the result cache
+	headerContCh    chan bool                      // Channel to notify when header download finishes
 
 	// All data retrievals below are based on an already assembles header chain
-	blockTaskPool  map[common.Hash]*types.Header      // [eth/62] Pending block (body) retrieval tasks, mapping hashes to headers
-	blockTaskQueue *prque.Prque[int64, *types.Header] // [eth/62] Priority queue of the headers to fetch the blocks (bodies) for
-	blockPendPool  map[string]*fetchRequest           // [eth/62] Currently pending block (body) retrieval operations
+	blockTaskPool  map[common.Hash]*types.Header      // Pending block (body) retrieval tasks, mapping hashes to headers
+	blockTaskQueue *prque.Prque[int64, *types.Header] // Priority queue of the headers to fetch the blocks (bodies) for
+	blockPendPool  map[string]*fetchRequest           // Currently pending block (body) retrieval operations
 
-	receiptTaskPool  map[common.Hash]*types.Header      // [eth/63] Pending receipt retrieval tasks, mapping hashes to headers
-	receiptTaskQueue *prque.Prque[int64, *types.Header] // [eth/63] Priority queue of the headers to fetch the receipts for
-	receiptPendPool  map[string]*fetchRequest           // [eth/63] Currently pending receipt retrieval operations
+	receiptTaskPool  map[common.Hash]*types.Header      // Pending receipt retrieval tasks, mapping hashes to headers
+	receiptTaskQueue *prque.Prque[int64, *types.Header] // Priority queue of the headers to fetch the receipts for
+	receiptPendPool  map[string]*fetchRequest           // Currently pending receipt retrieval operations
 
 	resultCache *resultStore       // Downloaded but not yet delivered fetch results
 	resultSize  common.StorageSize // Approximate size of a block (exponential moving average)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -634,7 +634,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			}
 		}
 
-	case p.version >= eth63 && msg.Code == GetNodeDataMsg:
+	case p.version >= xdc100 && msg.Code == GetNodeDataMsg:
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
@@ -668,7 +668,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 		return p.SendNodeData(data)
 
-	case p.version >= eth63 && msg.Code == NodeDataMsg:
+	case p.version >= xdc100 && msg.Code == NodeDataMsg:
 		// A batch of node state data arrived to one of our previous requests
 		var data [][]byte
 		if err := msg.Decode(&data); err != nil {
@@ -679,7 +679,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			log.Debug("Failed to deliver node state data", "err", err)
 		}
 
-	case p.version >= eth63 && msg.Code == GetReceiptsMsg:
+	case p.version >= xdc100 && msg.Code == GetReceiptsMsg:
 		// Decode the retrieval message
 		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 		if _, err := msgStream.List(); err != nil {
@@ -715,7 +715,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 		return p.SendReceiptsRLP(receipts)
 
-	case p.version >= eth63 && msg.Code == ReceiptsMsg:
+	case p.version >= xdc100 && msg.Code == ReceiptsMsg:
 		// A batch of receipts arrived to one of our previous requests
 		var receipts [][]*types.Receipt
 		if err := msg.Decode(&receipts); err != nil {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -40,8 +40,9 @@ import (
 )
 
 // Tests that block headers can be retrieved from a remote chain based on user queries.
-func TestGetBlockHeaders63(t *testing.T)  { testGetBlockHeaders(t, 63) }
-func TestGetBlockHeaders164(t *testing.T) { testGetBlockHeaders(t, 164) }
+func TestGetBlockHeaders100(t *testing.T) { testGetBlockHeaders(t, xdc100) }
+func TestGetBlockHeaders164(t *testing.T) { testGetBlockHeaders(t, xdc164) }
+func TestGetBlockHeaders165(t *testing.T) { testGetBlockHeaders(t, xdc165) }
 
 func testGetBlockHeaders(t *testing.T, protocol int) {
 	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, downloader.MaxHashFetch+15, nil, nil)
@@ -199,8 +200,9 @@ func testGetBlockHeaders(t *testing.T, protocol int) {
 }
 
 // Tests that block contents can be retrieved from a remote chain based on their hashes.
-func TestGetBlockBodies63(t *testing.T)  { testGetBlockBodies(t, 63) }
-func TestGetBlockBodies164(t *testing.T) { testGetBlockBodies(t, 164) }
+func TestGetBlockBodies100(t *testing.T) { testGetBlockBodies(t, xdc100) }
+func TestGetBlockBodies164(t *testing.T) { testGetBlockBodies(t, xdc164) }
+func TestGetBlockBodies165(t *testing.T) { testGetBlockBodies(t, xdc165) }
 
 func testGetBlockBodies(t *testing.T, protocol int) {
 	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, downloader.MaxBlockFetch+15, nil, nil)
@@ -271,8 +273,9 @@ func testGetBlockBodies(t *testing.T, protocol int) {
 }
 
 // Tests that the node state database can be retrieved based on hashes.
-func TestGetNodeData63(t *testing.T)  { testGetNodeData(t, 63) }
-func TestGetNodeData164(t *testing.T) { testGetNodeData(t, 164) }
+func TestGetNodeData100(t *testing.T) { testGetNodeData(t, xdc100) }
+func TestGetNodeData164(t *testing.T) { testGetNodeData(t, xdc164) }
+func TestGetNodeData165(t *testing.T) { testGetNodeData(t, xdc165) }
 
 func testGetNodeData(t *testing.T, protocol int) {
 	// Define three accounts to simulate transactions with
@@ -370,8 +373,9 @@ func testGetNodeData(t *testing.T, protocol int) {
 }
 
 // Tests that the transaction receipts can be retrieved based on hashes.
-func TestGetReceipt63(t *testing.T)  { testGetReceipt(t, 63) }
-func TestGetReceipt164(t *testing.T) { testGetReceipt(t, 164) }
+func TestGetReceipt100(t *testing.T) { testGetReceipt(t, xdc100) }
+func TestGetReceipt164(t *testing.T) { testGetReceipt(t, xdc164) }
+func TestGetReceipt165(t *testing.T) { testGetReceipt(t, xdc165) }
 
 func testGetReceipt(t *testing.T, protocol int) {
 	// Define three accounts to simulate transactions with
@@ -474,8 +478,8 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 	pm.Start(1000)
 	defer pm.Stop()
 	var peers []*testPeer
-	for i := 0; i < totalPeers; i++ {
-		peer, _ := newTestPeer(fmt.Sprintf("peer %d", i), eth63, pm, true)
+	for i := range totalPeers {
+		peer, _ := newTestPeer(fmt.Sprintf("peer %d", i), xdc100, pm, true)
 		defer peer.close()
 		peers = append(peers, peer)
 	}
@@ -557,7 +561,12 @@ outer:
 
 // Tests that a propagated malformed block (uncles or transactions don't match
 // with the hashes in the header) gets discarded and not broadcast forward.
-func TestBroadcastMalformedBlock(t *testing.T) {
+func TestBroadcastMalformedBlock164(t *testing.T) { testBroadcastMalformedBlock(t, xdc164) }
+func TestBroadcastMalformedBlock165(t *testing.T) { testBroadcastMalformedBlock(t, xdc165) }
+
+func testBroadcastMalformedBlock(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a live node to test propagation with
 	var (
 		engine  = ethash.NewFaker()
@@ -579,10 +588,10 @@ func TestBroadcastMalformedBlock(t *testing.T) {
 
 	// Create two peers, one to send the malformed block with and one to check
 	// propagation
-	source, _ := newTestPeer("source", eth63, pm, true)
+	source, _ := newTestPeer("source", protocol, pm, true)
 	defer source.close()
 
-	sink, _ := newTestPeer("sink", eth63, pm, true)
+	sink, _ := newTestPeer("sink", protocol, pm, true)
 	defer sink.close()
 
 	// Create various combinations of malformed blocks
@@ -670,7 +679,7 @@ func testDAOChallenge(t *testing.T, localForked, remoteForked bool, timeout bool
 	defer pm.Stop()
 
 	// Connect a new peer and check that we receive the DAO challenge
-	peer, _ := newTestPeer("peer", eth63, pm, true)
+	peer, _ := newTestPeer("peer", xdc100, pm, true)
 	defer peer.close()
 
 	challenge := &getBlockHeadersData{

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -246,8 +246,8 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesi
 			Genesis:         genesis,
 			ForkID:          forkID,
 		}
-	case xdc100, eth63:
-		msg = &statusData63{
+	case xdc100:
+		msg = &statusData100{
 			ProtocolVersion: uint32(p.version),
 			NetworkId:       ethconfig.Defaults.NetworkId,
 			TD:              td,

--- a/eth/metrics.go
+++ b/eth/metrics.go
@@ -92,9 +92,9 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 	case msg.Code == BlockBodiesMsg:
 		packets, traffic = reqBodyInPacketsMeter, reqBodyInTrafficMeter
 
-	case rw.version >= eth63 && msg.Code == NodeDataMsg:
+	case rw.version >= xdc100 && msg.Code == NodeDataMsg:
 		packets, traffic = reqStateInPacketsMeter, reqStateInTrafficMeter
-	case rw.version >= eth63 && msg.Code == ReceiptsMsg:
+	case rw.version >= xdc100 && msg.Code == ReceiptsMsg:
 		packets, traffic = reqReceiptInPacketsMeter, reqReceiptInTrafficMeter
 
 	case msg.Code == NewBlockHashesMsg:
@@ -119,9 +119,9 @@ func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
 	case msg.Code == BlockBodiesMsg:
 		packets, traffic = reqBodyOutPacketsMeter, reqBodyOutTrafficMeter
 
-	case rw.version >= eth63 && msg.Code == NodeDataMsg:
+	case rw.version >= xdc100 && msg.Code == NodeDataMsg:
 		packets, traffic = reqStateOutPacketsMeter, reqStateOutTrafficMeter
-	case rw.version >= eth63 && msg.Code == ReceiptsMsg:
+	case rw.version >= xdc100 && msg.Code == ReceiptsMsg:
 		packets, traffic = reqReceiptOutPacketsMeter, reqReceiptOutTrafficMeter
 
 	case msg.Code == NewBlockHashesMsg:

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -695,8 +695,8 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 	errc := make(chan error, 2)
 
 	var (
-		status63 statusData63 // safe to read after two values have been received from errc
-		status   statusData   // safe to read after two values have been received from errc
+		status100 statusData100 // safe to read after two values have been received from errc
+		status    statusData    // safe to read after two values have been received from errc
 	)
 	go func() {
 		switch p.version {
@@ -709,8 +709,8 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 				Genesis:         genesis,
 				ForkID:          forkID,
 			})
-		case xdc100, eth63:
-			errc <- p2p.Send(p.rw, StatusMsg, &statusData63{
+		case xdc100:
+			errc <- p2p.Send(p.rw, StatusMsg, &statusData100{
 				ProtocolVersion: uint32(p.version),
 				NetworkId:       network,
 				TD:              td,
@@ -725,8 +725,8 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 		switch p.version {
 		case xdc165, xdc164:
 			errc <- p.readStatus(network, &status, genesis, forkFilter)
-		case xdc100, eth63:
-			errc <- p.readStatusLegacy(network, &status63, genesis)
+		case xdc100:
+			errc <- p.readStatus100(network, &status100, genesis)
 		default:
 			errc <- errResp(ErrProtocolVersionMismatch, "unsupported eth protocol version: %d", p.version)
 		}
@@ -746,15 +746,15 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 	switch p.version {
 	case xdc165, xdc164:
 		p.td, p.head = status.TD, status.Head
-	case xdc100, eth63:
-		p.td, p.head = status63.TD, status63.CurrentBlock
+	case xdc100:
+		p.td, p.head = status100.TD, status100.CurrentBlock
 	default:
 		return errResp(ErrProtocolVersionMismatch, "unsupported eth protocol version: %d", p.version)
 	}
 	return nil
 }
 
-func (p *peer) readStatusLegacy(network uint64, status *statusData63, genesis common.Hash) error {
+func (p *peer) readStatus100(network uint64, status *statusData100, genesis common.Hash) error {
 	msg, err := p.rw.ReadMsg()
 	if err != nil {
 		return err

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -32,7 +32,6 @@ import (
 
 // Constants to match up protocol versions and messages
 const (
-	eth63  = 63
 	xdc100 = 100
 	xdc164 = 164 // eth64
 	xdc165 = 165 // eth65
@@ -42,10 +41,10 @@ const (
 var protocolName = "eth"
 
 // ProtocolVersions are the supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{xdc165, xdc164, xdc100, eth63}
+var ProtocolVersions = []uint{xdc165, xdc164, xdc100}
 
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
-var protocolLengths = map[uint]uint64{xdc165: 230, xdc164: 227, xdc100: 227, eth63: 17}
+var protocolLengths = map[uint]uint64{xdc165: 230, xdc164: 227, xdc100: 227}
 
 const protocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
 
@@ -156,8 +155,8 @@ type lendingPool interface {
 	SubscribeTxPreEvent(chan<- core.LendingTxPreEvent) event.Subscription
 }
 
-// statusData63 is the network packet for the status message for eth/63 and xdc/100.
-type statusData63 struct {
+// statusData100 is the network packet for the status message for xdc/100.
+type statusData100 struct {
 	ProtocolVersion uint32
 	NetworkId       uint64
 	TD              *big.Int

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -49,7 +49,7 @@ func init() {
 var testAccount, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 
 // Tests that handshake failures are detected and reported correctly.
-func TestStatusMsgErrors63(t *testing.T) {
+func TestStatusMsgErrors100(t *testing.T) {
 	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
 	var (
 		genesis = pm.blockchain.Genesis()
@@ -68,20 +68,20 @@ func TestStatusMsgErrors63(t *testing.T) {
 			wantError: errResp(ErrNoStatusMsg, "first msg has code 2 (!= 0)"),
 		},
 		{
-			code: StatusMsg, data: statusData63{10, ethconfig.Defaults.NetworkId, td, head.Hash(), genesis.Hash()},
-			wantError: errResp(ErrProtocolVersionMismatch, "10 (!= %d)", 63),
+			code: StatusMsg, data: statusData100{10, ethconfig.Defaults.NetworkId, td, head.Hash(), genesis.Hash()},
+			wantError: errResp(ErrProtocolVersionMismatch, "10 (!= %d)", xdc100),
 		},
 		{
-			code: StatusMsg, data: statusData63{63, 999, td, head.Hash(), genesis.Hash()},
+			code: StatusMsg, data: statusData100{xdc100, 999, td, head.Hash(), genesis.Hash()},
 			wantError: errResp(ErrNetworkIDMismatch, "999 (!= %d)", ethconfig.Defaults.NetworkId),
 		},
 		{
-			code: StatusMsg, data: statusData63{63, ethconfig.Defaults.NetworkId, td, head.Hash(), common.Hash{3}},
+			code: StatusMsg, data: statusData100{xdc100, ethconfig.Defaults.NetworkId, td, head.Hash(), common.Hash{3}},
 			wantError: errResp(ErrGenesisMismatch, "0300000000000000 (!= %x)", genesis.Hash().Bytes()[:8]),
 		},
 	}
 	for i, test := range tests {
-		p, errc := newTestPeer("peer", 63, pm, false)
+		p, errc := newTestPeer("peer", xdc100, pm, false)
 		// The send call might hang until reset because
 		// the protocol might not read the payload.
 		go p2p.Send(p.app, test.code, test.data)
@@ -89,9 +89,9 @@ func TestStatusMsgErrors63(t *testing.T) {
 		select {
 		case err := <-errc:
 			if err == nil {
-				t.Errorf("test %d: protocol returned nil error, want %q", i, test.wantError)
+				t.Errorf("test %d: protocol returned nil error, want %v", i, test.wantError)
 			} else if err.Error() != test.wantError.Error() {
-				t.Errorf("test %d: wrong error: got %q, want %q", i, err, test.wantError)
+				t.Errorf("test %d: wrong error: got %v, want %v", i, err, test.wantError)
 			}
 		case <-time.After(2 * time.Second):
 			t.Errorf("protocol did not shut down within 2 seconds")
@@ -121,23 +121,23 @@ func TestStatusMsgErrors164(t *testing.T) {
 		},
 		{
 			code: StatusMsg, data: statusData{10, ethconfig.Defaults.NetworkId, td, head.Hash(), genesis.Hash(), forkID},
-			wantError: errResp(ErrProtocolVersionMismatch, "10 (!= %d)", 164),
+			wantError: errResp(ErrProtocolVersionMismatch, "10 (!= %d)", xdc164),
 		},
 		{
-			code: StatusMsg, data: statusData{164, 999, td, head.Hash(), genesis.Hash(), forkID},
+			code: StatusMsg, data: statusData{xdc164, 999, td, head.Hash(), genesis.Hash(), forkID},
 			wantError: errResp(ErrNetworkIDMismatch, "999 (!= %d)", ethconfig.Defaults.NetworkId),
 		},
 		{
-			code: StatusMsg, data: statusData{164, ethconfig.Defaults.NetworkId, td, head.Hash(), common.Hash{3}, forkID},
+			code: StatusMsg, data: statusData{xdc164, ethconfig.Defaults.NetworkId, td, head.Hash(), common.Hash{3}, forkID},
 			wantError: errResp(ErrGenesisMismatch, "0300000000000000000000000000000000000000000000000000000000000000 (!= %x)", genesis.Hash()),
 		},
 		{
-			code: StatusMsg, data: statusData{164, ethconfig.Defaults.NetworkId, td, head.Hash(), genesis.Hash(), forkid.ID{Hash: [4]byte{0x00, 0x01, 0x02, 0x03}}},
+			code: StatusMsg, data: statusData{xdc164, ethconfig.Defaults.NetworkId, td, head.Hash(), genesis.Hash(), forkid.ID{Hash: [4]byte{0x00, 0x01, 0x02, 0x03}}},
 			wantError: errResp(ErrForkIDRejected, "%s", forkid.ErrLocalIncompatibleOrStale.Error()),
 		},
 	}
 	for i, test := range tests {
-		p, errc := newTestPeer("peer", 164, pm, false)
+		p, errc := newTestPeer("peer", xdc164, pm, false)
 		// The send call might hang until reset because
 		// the protocol might not read the payload.
 		go p2p.Send(p.app, test.code, test.data)
@@ -145,60 +145,9 @@ func TestStatusMsgErrors164(t *testing.T) {
 		select {
 		case err := <-errc:
 			if err == nil {
-				t.Errorf("test %d: protocol returned nil error, want %q", i, test.wantError)
+				t.Errorf("test %d: protocol returned nil error, want %v", i, test.wantError)
 			} else if err.Error() != test.wantError.Error() {
-				t.Errorf("test %d: wrong error: got %q, want %q", i, err, test.wantError)
-			}
-		case <-time.After(2 * time.Second):
-			t.Errorf("protocol did not shut down within 2 seconds")
-		}
-		p.close()
-	}
-}
-
-func TestStatusMsgErrors100(t *testing.T) {
-	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
-	var (
-		genesis = pm.blockchain.Genesis()
-		head    = pm.blockchain.CurrentHeader()
-		td      = pm.blockchain.GetTd(head.Hash(), head.Number.Uint64())
-	)
-	defer pm.Stop()
-
-	tests := []struct {
-		code      uint64
-		data      interface{}
-		wantError error
-	}{
-		{
-			code: TransactionMsg, data: []interface{}{},
-			wantError: errResp(ErrNoStatusMsg, "first msg has code 2 (!= 0)"),
-		},
-		{
-			code: StatusMsg, data: statusData63{10, ethconfig.Defaults.NetworkId, td, head.Hash(), genesis.Hash()},
-			wantError: errResp(ErrProtocolVersionMismatch, "10 (!= %d)", 100),
-		},
-		{
-			code: StatusMsg, data: statusData63{100, 999, td, head.Hash(), genesis.Hash()},
-			wantError: errResp(ErrNetworkIDMismatch, "999 (!= %d)", ethconfig.Defaults.NetworkId),
-		},
-		{
-			code: StatusMsg, data: statusData63{100, ethconfig.Defaults.NetworkId, td, head.Hash(), common.Hash{3}},
-			wantError: errResp(ErrGenesisMismatch, "0300000000000000 (!= %x)", genesis.Hash().Bytes()[:8]),
-		},
-	}
-	for i, test := range tests {
-		p, errc := newTestPeer("peer", 100, pm, false)
-		// The send call might hang until reset because
-		// the protocol might not read the payload.
-		go p2p.Send(p.app, test.code, test.data)
-
-		select {
-		case err := <-errc:
-			if err == nil {
-				t.Errorf("test %d: protocol returned nil error, want %q", i, test.wantError)
-			} else if err.Error() != test.wantError.Error() {
-				t.Errorf("test %d: wrong error: got %q, want %q", i, err, test.wantError)
+				t.Errorf("test %d: wrong error: got %v, want %v", i, err, test.wantError)
 			}
 		case <-time.After(2 * time.Second):
 			t.Errorf("protocol did not shut down within 2 seconds")
@@ -252,8 +201,8 @@ func TestForkIDSplit(t *testing.T) {
 
 	// Both nodes should allow the other to connect (same genesis, next fork is the same)
 	p2pNoFork, p2pProFork := p2p.MsgPipe()
-	peerNoFork := newPeer(164, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
-	peerProFork := newPeer(164, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
+	peerNoFork := newPeer(xdc164, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
+	peerProFork := newPeer(xdc164, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
 	errc := make(chan error, 2)
 	go func() { errc <- ethNoFork.handle(peerProFork) }()
@@ -277,8 +226,8 @@ func TestForkIDSplit(t *testing.T) {
 	chainProFork.InsertChain(blocksProFork[:1])
 
 	p2pNoFork, p2pProFork = p2p.MsgPipe()
-	peerNoFork = newPeer(164, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
-	peerProFork = newPeer(164, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
+	peerNoFork = newPeer(xdc164, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
+	peerProFork = newPeer(xdc164, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
 	errc = make(chan error, 2)
 	go func() { errc <- ethNoFork.handle(peerProFork) }()
@@ -301,8 +250,8 @@ func TestForkIDSplit(t *testing.T) {
 	chainProFork.InsertChain(blocksProFork[1:2])
 
 	p2pNoFork, p2pProFork = p2p.MsgPipe()
-	peerNoFork = newPeer(164, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
-	peerProFork = newPeer(164, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
+	peerNoFork = newPeer(xdc164, p2p.NewPeer(enode.ID{1}, "", nil), p2pNoFork, nil)
+	peerProFork = newPeer(xdc164, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
 	errc = make(chan error, 2)
 	go func() { errc <- ethNoFork.handle(peerProFork) }()
@@ -339,10 +288,9 @@ func TestForkIDSplit(t *testing.T) {
 }
 
 // This test checks that received transactions are added to the local pool.
-func TestRecvTransactions63(t *testing.T)  { testRecvTransactions(t, 63) }
-func TestRecvTransactions100(t *testing.T) { testRecvTransactions(t, 100) }
-func TestRecvTransactions164(t *testing.T) { testRecvTransactions(t, 164) }
-func TestRecvTransactions165(t *testing.T) { testRecvTransactions(t, 165) }
+func TestRecvTransactions100(t *testing.T) { testRecvTransactions(t, xdc100) }
+func TestRecvTransactions164(t *testing.T) { testRecvTransactions(t, xdc164) }
+func TestRecvTransactions165(t *testing.T) { testRecvTransactions(t, xdc165) }
 
 func testRecvTransactions(t *testing.T, protocol int) {
 	txAdded := make(chan []*types.Transaction)
@@ -369,10 +317,9 @@ func testRecvTransactions(t *testing.T, protocol int) {
 }
 
 // This test checks that pending transactions are sent.
-func TestSendTransactions63(t *testing.T)  { testSendTransactions(t, 63) }
-func TestSendTransactions100(t *testing.T) { testSendTransactions(t, 100) }
-func TestSendTransactions164(t *testing.T) { testSendTransactions(t, 164) }
-func TestSendTransactions165(t *testing.T) { testSendTransactions(t, 165) }
+func TestSendTransactions100(t *testing.T) { testSendTransactions(t, xdc100) }
+func TestSendTransactions164(t *testing.T) { testSendTransactions(t, xdc164) }
+func TestSendTransactions165(t *testing.T) { testSendTransactions(t, xdc165) }
 
 func testSendTransactions(t *testing.T, protocol int) {
 	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 0, nil, nil)
@@ -401,11 +348,9 @@ func testSendTransactions(t *testing.T, protocol int) {
 		for n := 0; n < len(alltxs) && !t.Failed(); {
 			var forAllHashes func(callback func(hash common.Hash))
 			switch protocol {
-			case 63:
+			case xdc100:
 				fallthrough
-			case 100:
-				fallthrough
-			case 164:
+			case xdc164:
 				msg, err := p.app.ReadMsg()
 				if err != nil {
 					t.Errorf("%v: read error: %v", p.Peer, err)
@@ -424,7 +369,7 @@ func testSendTransactions(t *testing.T, protocol int) {
 						callback(tx.Hash())
 					}
 				}
-			case 165:
+			case xdc165:
 				msg, err := p.app.ReadMsg()
 				if err != nil {
 					t.Errorf("%v: read error: %v", p.Peer, err)
@@ -502,8 +447,8 @@ func testSyncTransaction(t *testing.T, propagation bool) {
 	// Sync up the two peers
 	io1, io2 := p2p.MsgPipe()
 
-	go pmSender.handle(pmSender.newPeer(165, p2p.NewPeer(enode.ID{}, "sender", nil), io2, pmSender.txpool.Get))
-	go pmFetcher.handle(pmFetcher.newPeer(165, p2p.NewPeer(enode.ID{}, "fetcher", nil), io1, pmFetcher.txpool.Get))
+	go pmSender.handle(pmSender.newPeer(xdc165, p2p.NewPeer(enode.ID{}, "sender", nil), io2, pmSender.txpool.Get))
+	go pmFetcher.handle(pmFetcher.newPeer(xdc165, p2p.NewPeer(enode.ID{}, "fetcher", nil), io1, pmFetcher.txpool.Get))
 
 	time.Sleep(250 * time.Millisecond)
 	pmFetcher.synchronise(pmFetcher.peers.BestPeer())

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -26,13 +26,16 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
 )
 
-func TestFastSyncDisabling63(t *testing.T)  { testFastSyncDisabling(t, 63) }
-func TestFastSyncDisabling164(t *testing.T) { testFastSyncDisabling(t, 164) }
-func TestFastSyncDisabling165(t *testing.T) { testFastSyncDisabling(t, 165) }
+// Tests that fast sync is disabled after a successful sync cycle.
+func TestFastSyncDisabling100(t *testing.T) { testFastSyncDisabling(t, xdc100) }
+func TestFastSyncDisabling164(t *testing.T) { testFastSyncDisabling(t, xdc164) }
+func TestFastSyncDisabling165(t *testing.T) { testFastSyncDisabling(t, xdc165) }
 
 // Tests that fast sync gets disabled as soon as a real block is successfully
 // imported into the blockchain.
 func testFastSyncDisabling(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a pristine protocol manager, check that fast sync is left enabled
 	pmEmpty, _ := newTestProtocolManagerMust(t, downloader.FastSync, 0, nil, nil)
 	defer pmEmpty.Stop()


### PR DESCRIPTION
# Proposed changes

eth/63 predates the XDC-specific protocols and is no longer spoken by any
supported client, so remove it from the advertised capabilities and from
every version-gated branch:

- drop eth63 from ProtocolVersions and protocolLengths, so the node no
  longer advertises the "eth/63" capability
- rename statusData63 to statusData100 and readStatusLegacy to
  readStatus100, xdc/100 now being the only legacy status format
- raise minProtocolVer to 100 and derive errTooOld and the syncWithPeer
  guard from it instead of hardcoding the number in three places
- replace the eth63 version gates in handleMsg and the metered read/write
  wrapper with xdc100
- drop the stale [eth/62] and [eth/63] tags from downloader and queue
  field comments
- stop advertising eth/63 in the devp2p ethtest suite

Tests are renamed to the xdc100/xdc164 constants instead of bare literals
and gain xdc165 coverage where it was missing.

This is a breaking p2p change: peers that only speak eth/63 can no longer
complete the handshake.
## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [X] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
