### PR TITLE
feat(core): increase memory holding state trie

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -296,28 +296,28 @@ var (
 	CacheFlag = &cli.IntFlag{
 		Name:     "cache",
 		Usage:    "Megabytes of memory allocated to internal caching",
-		Value:    1024,
+		Value:    3072,
 		Category: flags.PerfCategory,
 	}
 	CacheDatabaseFlag = &cli.IntFlag{
 		Name:     "cache-database",
 		Aliases:  []string{"cache.database"},
 		Usage:    "Percentage of cache memory allowance to use for database io",
-		Value:    50,
+		Value:    17,
 		Category: flags.PerfCategory,
 	}
 	CacheTrieFlag = &cli.IntFlag{
 		Name:     "cache-trie",
 		Aliases:  []string{"cache.trie"},
 		Usage:    "Percentage of cache memory allowance to use for trie caching (default = 15% full mode, 30% archive mode)",
-		Value:    15,
+		Value:    5,
 		Category: flags.PerfCategory,
 	}
 	CacheGCFlag = &cli.IntFlag{
 		Name:     "cache-gc",
 		Aliases:  []string{"cache.gc"},
 		Usage:    "Percentage of cache memory allowance to use for trie pruning (default = 25% full mode, 0% archive mode)",
-		Value:    25,
+		Value:    34,
 		Category: flags.PerfCategory,
 	}
 	CachePrefetchFlag = &cli.BoolFlag{

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -102,7 +102,7 @@ const (
 	receiptsCacheLimit  = 32
 	maxFutureBlocks     = 256
 	maxTimeFutureBlocks = 30
-	TriesInMemory       = 128
+	TriesInMemory       = 1024
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//


### PR DESCRIPTION
# Proposed changes

increase memory holding state trie.

Memory increase from 1024MB to 3072MB.

As for purpose, only "cache memory allowance to use for trie pruning" is increased. Other purpose is kept the same memory.

Tested on a mainnet node with fast sync from scratch. Memory usage is only 10% of the server.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [x] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
