### PR TITLE
fix(cmd/XDC): fix staking lost for an epoch when a checkpoint lands during sync

### DIFF
--- a/cmd/XDC/main.go
+++ b/cmd/XDC/main.go
@@ -385,17 +385,17 @@ func startNode(ctx *cli.Context, stack *node.Node, backend ethapi.Backend, cfg X
 				chain := ethBackend.BlockChain()
 				engine.UpdateParams(chain.CurrentHeader())
 
-				ok = false
 				// While syncing, skip masternode validation (IsAuthorisedAddress ->
 				// GetSnapshot on the just-imported head). The CheckpointCh send in
 				// insertChain/insertBlock is unbuffered, so we still receive here to
-				// avoid blocking block import; staking resumes on the first checkpoint
-				// after sync completes.
-				if !ethBackend.Downloader().Synchronising() {
-					ok, err = ethBackend.ValidateMasternode()
-					if err != nil {
-						utils.Fatalf("Can't verify masternode permission: %v", err)
-					}
+				// avoid blocking block import, but the staking state is left alone:
+				// an unknown result must not be read as "not a masternode".
+				if ethBackend.Downloader().Synchronising() {
+					continue
+				}
+				ok, err = ethBackend.ValidateMasternode()
+				if err != nil {
+					utils.Fatalf("Can't verify masternode permission: %v", err)
 				}
 
 				if !ok {


### PR DESCRIPTION
# Proposed changes

**Symptom.** On a freshly started network, masternodes silently stop producing blocks and never recover within the same epoch. Block production collapses from one block per mine period (2 s) to one block per two timeout periods (20 s), because every round led by an affected node times out instead of proposing.

**Where.** main.go, inside the `for range core.CheckpointCh` loop that re-evaluates staking permission at each epoch switch block.

**The bug.** The loop skipped masternode validation while the downloader was running — `IsAuthorisedAddress` would otherwise query a snapshot for a head that is not settled yet. But the skip left the result variable at `false`:

```go
ok = false
if !ethBackend.Downloader().Synchronising() {
    ok, err = ethBackend.ValidateMasternode()
    ...
}

if !ok {
    if started {
        log.Info("Only masternode can propose and verify blocks. Cancelling staking on this node...")
        ethBackend.StopStaking()
```

So "we did not check" was indistinguishable from "this node is not a masternode", and the node actively **stopped** staking. Recovery was only possible at the next checkpoint, which is the next epoch switch block — a full epoch (900 blocks) later.

**Why it fired reliably.** At node startup, `Block synchronisation started` and the import of the first epoch switch block land in the same millisecond, so the checkpoint is always processed while `Synchronising()` is true:

```
19:23:08.072  Block synchronisation started
19:23:08.072  Mining aborted due to sync
19:23:08.074  Imported new chain segment  number=1
19:23:08.074  Checkpoint!!! It's time to reconcile node's state...
19:23:08.074  Only masternode can propose and verify blocks. Cancelling staking on this node...
19:23:08.074  Cancelled mining mode!!!
```

On the local devnet two of three masternodes hit this, leaving a single proposer. With `leaderIndex = round % 3`, two out of every three rounds hit the 10 s `timeoutPeriod`, giving exactly the observed 20 s block interval.

**The fix.** Skip the entire checkpoint while syncing instead of falling through with a default-`false` result, so an unknown validation outcome leaves the staking state untouched:

```go
if ethBackend.Downloader().Synchronising() {
    continue
}
ok, err = ethBackend.ValidateMasternode()
```

**Impact.** Any staking node whose downloader happens to be active when an epoch switch block is imported — most commonly right after a restart, but also after any catch-up sync — loses block production for the remainder of that epoch. The regression was introduced in `b1e23b109f` (2026-08-06).

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [X] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
