### PR TITLE
fix(consensus/XDPoS,core): repair missing V2 gap snapshots at startup

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -198,9 +198,22 @@ func (x *XDPoS_v2) Initial(chain consensus.ChainReader, header *types.Header) er
 	x.lock.Lock()
 	defer x.lock.Unlock()
 
-	return x.initial(chain, header)
+	if err := x.initial(chain, header); err != nil {
+		return err
+	}
+	// Startup-only repair, skipped for chain readers that cannot open state.
+	// Runs under x.lock, which is safe here: Initial is only reached from the
+	// startup path before the protocol starts, and the historical state reads
+	// do not take any chain locks.
+	if gapChain, ok := chain.(GapStateReader); ok {
+		x.RepairGapSnapshots(gapChain)
+	}
+	return nil
 }
 
+// initial sets the v2 parameters from the chain. It must only be called while
+// holding x.lock, from either the startup path (Initial) or header verification.
+// The startup-only gap snapshot repair is deliberately kept in Initial, not here.
 func (x *XDPoS_v2) initial(chain consensus.ChainReader, header *types.Header) error {
 	log.Warn("[initial] initial v2 related parameters")
 

--- a/consensus/XDPoS/engines/engine_v2/snapshot.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot.go
@@ -2,11 +2,15 @@ package engine_v2
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	xdc_sort "github.com/XinFinOrg/XDPoSChain/common/sort"
 	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
 )
@@ -110,4 +114,128 @@ func (x *XDPoS_v2) getSnapshot(chain consensus.ChainReader, number uint64, isGap
 	log.Trace("Loaded snapshot from disk", "number", gapBlockNum, "hash", gapBlockHash)
 	x.snapshots.Add(snap.Hash, snap)
 	return snap, nil
+}
+
+// GapStateReader is a chain reader that can also open historical state and
+// expose its database, which the startup repair needs to rebuild a snapshot
+// from its gap block.
+type GapStateReader interface {
+	consensus.ChainReader
+	ChainDb() ethdb.Database
+	StateAt(root common.Hash) (*state.StateDB, error)
+}
+
+// ErrNoCandidates is returned by BuildSnapshotFromState when the gap block
+// state yields no masternode candidates.
+var ErrNoCandidates = errors.New("no masternode candidates in state")
+
+// BuildSnapshotFromState derives a gap block snapshot from the state committed
+// at that block. The ordering must stay identical to core.BlockChain.UpdateM1
+// and Downloader.generateSnapshot: a different equal-stake order yields a
+// different masternode set.
+func BuildSnapshotFromState(statedb *state.StateDB, number uint64, hash common.Hash) (*SnapshotV2, error) {
+	var ms []utils.Masternode
+	for _, candidate := range statedb.GetCandidates() {
+		if candidate.IsZero() {
+			continue
+		}
+		ms = append(ms, utils.Masternode{Address: candidate, Stake: statedb.GetCandidateCap(candidate)})
+	}
+	// GetCandidates and GetCandidateCap return zero values when the voting
+	// contract storage cannot be read, memoizing the failure in StateDB.Error().
+	// Persisting a snapshot derived from such reads would store an empty or
+	// partial masternode set that permanently masks the hole, so surface the
+	// read error instead.
+	if err := statedb.Error(); err != nil {
+		return nil, fmt.Errorf("reading masternode candidates from state: %w", err)
+	}
+	if len(ms) == 0 {
+		// An empty snapshot loads back fine and would permanently mask the hole.
+		return nil, ErrNoCandidates
+	}
+	xdc_sort.Slice(ms, func(i, j int) bool {
+		return ms[i].Stake.Cmp(ms[j].Stake) >= 0
+	})
+
+	candidates := make([]common.Address, len(ms))
+	for i, m := range ms {
+		candidates[i] = m.Address
+	}
+	return NewSnapshot(number, hash, candidates), nil
+}
+
+// repairGapCandidates returns the gap block numbers at or below head whose
+// snapshot can still matter to the running chain. getSnapshot maps head to the
+// gap block between Gap and Gap+Epoch blocks back, which is always one of these.
+func (x *XDPoS_v2) repairGapCandidates(head uint64) []uint64 {
+	epoch, gap := x.config.Epoch, x.config.Gap
+	if epoch == 0 || gap == 0 || gap >= epoch {
+		return nil
+	}
+	offset := epoch - gap
+	if head < offset {
+		return nil
+	}
+	latest := head - (head-offset)%epoch
+	if latest < epoch {
+		return []uint64{latest}
+	}
+	return []uint64{latest - epoch, latest}
+}
+
+// RepairGapSnapshots restores gap block snapshots missing from the database,
+// which happens when the process exits between writeHeadBlock and UpdateM1.
+// Meant to run once at startup. Failures are only logged: a node that is still
+// syncing legitimately has no state to rebuild from.
+func (x *XDPoS_v2) RepairGapSnapshots(chain GapStateReader) {
+	head := chain.CurrentHeader()
+	if head == nil {
+		return
+	}
+	// Probe and store through the chain's own database rather than x.db, so a
+	// mismatched engine database cannot cause silent wrong-database writes.
+	db := chain.ChainDb()
+	for _, gapNum := range x.repairGapCandidates(head.Number.Uint64()) {
+		// The snapshot at V2 SwitchBlock-Gap is owned by initial(), and gap
+		// blocks below the switch belong to the v1 engine. Config validation
+		// forces SwitchBlock to align with an epoch switch (SwitchBlock % Epoch
+		// == 0), so <= never skips a v2 gap block.
+		if gapNum <= x.config.V2.SwitchBlock.Uint64() {
+			continue
+		}
+		gapHeader := chain.GetHeaderByNumber(gapNum)
+		if gapHeader == nil {
+			// gapNum is at or below the current head, so the canonical header must exist.
+			log.Warn("[RepairGapSnapshots] missing canonical gap header", "number", gapNum, "head", head.Number)
+			continue
+		}
+		gapHash := gapHeader.Hash()
+		// Only a genuinely absent key is repaired. If we cannot reliably determine
+		// whether a snapshot is present (e.g. I/O error), skip repair to avoid
+		// overwriting a snapshot that may have been persisted through a reorg.
+		has, err := rawdb.HasXdposV2Snapshot(db, gapHash)
+		if err != nil {
+			log.Debug("[RepairGapSnapshots] cannot probe stored snapshot", "number", gapNum, "hash", gapHash, "err", err)
+			continue
+		}
+		if has {
+			continue
+		}
+		statedb, err := chain.StateAt(gapHeader.Root)
+		if err != nil {
+			log.Warn("[RepairGapSnapshots] gap block state unavailable", "number", gapNum, "hash", gapHash, "root", gapHeader.Root, "err", err)
+			continue
+		}
+		snap, err := BuildSnapshotFromState(statedb, gapNum, gapHash)
+		if err != nil {
+			log.Warn("[RepairGapSnapshots] cannot derive snapshot", "number", gapNum, "hash", gapHash, "err", err)
+			continue
+		}
+		if err := StoreSnapshot(snap, db); err != nil {
+			log.Warn("[RepairGapSnapshots] cannot store snapshot", "number", gapNum, "hash", gapHash, "err", err)
+			continue
+		}
+		x.snapshots.Add(snap.Hash, snap)
+		log.Warn("[RepairGapSnapshots] repaired missing snapshot", "number", gapNum, "hash", gapHash, "candidates", len(snap.NextEpochCandidates))
+	}
 }

--- a/consensus/XDPoS/engines/engine_v2/snapshot_test.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot_test.go
@@ -1,12 +1,22 @@
 package engine_v2
 
 import (
+	"errors"
 	"fmt"
+	"math/big"
+	"sync/atomic"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/common/lru"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/state"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/ethdb/leveldb"
+	"github.com/XinFinOrg/XDPoSChain/params"
 )
 
 func TestGetMasterNodes(t *testing.T) {
@@ -38,5 +48,507 @@ func TestStoreLoadSnapshot(t *testing.T) {
 	restoredSnapshot, err := loadSnapshot(lddb, snap.Hash)
 	if err != nil || restoredSnapshot.Hash != snap.Hash {
 		t.Error("load snapshot failed", err)
+	}
+}
+
+const (
+	testRepairEpoch = uint64(900)
+	testRepairGap   = uint64(450)
+	// testRepairSwitchBlock is aligned to the epoch (SwitchBlock % Epoch == 0),
+	// matching the alignment that production chain config validation enforces.
+	testRepairSwitchBlock = uint64(900)
+)
+
+// newCandidateState returns a state holding the masternode voting contract
+// storage that BuildSnapshotFromState reads, with candidates in the given order.
+func newCandidateState(t *testing.T, candidates []common.Address, caps []*big.Int) *state.StateDB {
+	t.Helper()
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()))
+	if err != nil {
+		t.Fatalf("create state: %v", err)
+	}
+	slotHash := common.BigToHash(new(big.Int).SetUint64(8)) // slotValidatorMapping["candidates"]
+	statedb.SetState(common.MasternodeVotingSMCBinary, slotHash, common.BigToHash(new(big.Int).SetUint64(uint64(len(candidates)))))
+	for i, candidate := range candidates {
+		statedb.SetState(common.MasternodeVotingSMCBinary, state.GetLocDynamicArrAtElement(slotHash, uint64(i), 1), candidate.Hash())
+		if candidate.IsZero() {
+			continue
+		}
+		locCap := new(big.Int).Add(state.GetLocMappingAtKey(candidate.Hash(), 1), big.NewInt(1))
+		statedb.SetState(common.MasternodeVotingSMCBinary, common.BigToHash(locCap), common.BigToHash(caps[i]))
+	}
+	return statedb
+}
+
+// repairTestChain is a minimal GapStateReader over a handful of headers.
+type repairTestChain struct {
+	headers    map[uint64]*types.Header
+	head       *types.Header
+	db         ethdb.Database
+	stateErr   error
+	stateCalls int
+	statedb    *state.StateDB
+}
+
+func (c *repairTestChain) addHeader(header *types.Header) {
+	if c.headers == nil {
+		c.headers = make(map[uint64]*types.Header)
+	}
+	c.headers[header.Number.Uint64()] = header
+	if c.head == nil || header.Number.Uint64() > c.head.Number.Uint64() {
+		c.head = header
+	}
+}
+
+func (c *repairTestChain) Config() *params.ChainConfig  { return nil }
+func (c *repairTestChain) ChainDb() ethdb.Database      { return c.db }
+func (c *repairTestChain) CurrentHeader() *types.Header { return c.head }
+func (c *repairTestChain) GetHeaderByNumber(number uint64) *types.Header {
+	return c.headers[number]
+}
+func (c *repairTestChain) GetHeader(common.Hash, uint64) *types.Header { return nil }
+func (c *repairTestChain) GetHeaderByHash(common.Hash) *types.Header   { return nil }
+func (c *repairTestChain) GetBlock(common.Hash, uint64) *types.Block   { return nil }
+
+func (c *repairTestChain) StateAt(common.Hash) (*state.StateDB, error) {
+	c.stateCalls++
+	if c.stateErr != nil {
+		return nil, c.stateErr
+	}
+	return c.statedb, nil
+}
+
+// failingHasDB wraps a database and fails every Has probe, simulating an I/O
+// error while checking whether a snapshot exists.
+type failingHasDB struct {
+	ethdb.Database
+}
+
+func (db *failingHasDB) Has([]byte) (bool, error) {
+	return false, errors.New("simulated Has probe failure")
+}
+
+func newRepairEngine(db ethdb.Database) *XDPoS_v2 {
+	return &XDPoS_v2{
+		config: &params.XDPoSConfig{
+			Epoch: testRepairEpoch,
+			Gap:   testRepairGap,
+			V2: &params.V2{
+				SwitchBlock: new(big.Int).SetUint64(testRepairSwitchBlock),
+			},
+		},
+		db:        db,
+		snapshots: lru.NewCache[common.Hash, *SnapshotV2](utils.InMemorySnapshots),
+	}
+}
+
+// newRepairFixture wires an engine and a chain whose head is at headNumber, with
+// gap block headers present for every gap number at or below it.
+func newRepairFixture(t *testing.T, headNumber uint64, candidates []common.Address, caps []*big.Int) (*XDPoS_v2, *repairTestChain, ethdb.Database) {
+	t.Helper()
+	db := rawdb.NewMemoryDatabase()
+	x := newRepairEngine(db)
+	chain := &repairTestChain{db: db, statedb: newCandidateState(t, candidates, caps)}
+	for num := testRepairEpoch - testRepairGap; num <= headNumber; num += testRepairEpoch {
+		chain.addHeader(&types.Header{Number: new(big.Int).SetUint64(num), Extra: []byte{byte(num), byte(num >> 8)}})
+	}
+	chain.addHeader(&types.Header{Number: new(big.Int).SetUint64(headNumber), Extra: []byte("head")})
+	return x, chain, db
+}
+
+func gapHash(t *testing.T, chain *repairTestChain, number uint64) common.Hash {
+	t.Helper()
+	header := chain.GetHeaderByNumber(number)
+	if header == nil {
+		t.Fatalf("no header at %d", number)
+	}
+	return header.Hash()
+}
+
+func assertSnapshotStored(t *testing.T, db ethdb.Database, hash common.Hash, want []common.Address) {
+	t.Helper()
+	snap, err := loadSnapshot(db, hash)
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	if len(snap.NextEpochCandidates) != len(want) {
+		t.Fatalf("candidates = %v, want %v", snap.NextEpochCandidates, want)
+	}
+	for i, addr := range want {
+		if snap.NextEpochCandidates[i] != addr {
+			t.Fatalf("candidates = %v, want %v", snap.NextEpochCandidates, want)
+		}
+	}
+}
+
+func TestBuildSnapshotFromStateSortsByStakeDescending(t *testing.T) {
+	low, mid, high := common.Address{0x1}, common.Address{0x2}, common.Address{0x3}
+	statedb := newCandidateState(t,
+		[]common.Address{low, mid, high},
+		[]*big.Int{big.NewInt(10), big.NewInt(20), big.NewInt(30)},
+	)
+
+	snap, err := BuildSnapshotFromState(statedb, 1350, common.Hash{0xaa})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	want := []common.Address{high, mid, low}
+	for i, addr := range want {
+		if snap.NextEpochCandidates[i] != addr {
+			t.Fatalf("candidates = %v, want %v", snap.NextEpochCandidates, want)
+		}
+	}
+	if snap.Number != 1350 || snap.Hash != (common.Hash{0xaa}) {
+		t.Fatalf("snapshot = (%d, %s), want (1350, 0xaa..)", snap.Number, snap.Hash.Hex())
+	}
+}
+
+// Equal stakes must keep the exact order xdc_sort produces, otherwise nodes
+// derive different masternode sets from the same state. A failure here means
+// the sort implementation drifted and the derivation no longer matches
+// core.BlockChain.UpdateM1 and Downloader.generateSnapshot.
+func TestBuildSnapshotFromStateEqualStakeOrder(t *testing.T) {
+	a, b, c := common.Address{0x1}, common.Address{0x2}, common.Address{0x3}
+	statedb := newCandidateState(t,
+		[]common.Address{a, b, c},
+		[]*big.Int{big.NewInt(10), big.NewInt(10), big.NewInt(10)},
+	)
+
+	snap, err := BuildSnapshotFromState(statedb, 1350, common.Hash{0xaa})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	want := []common.Address{c, b, a}
+	for i, addr := range want {
+		if snap.NextEpochCandidates[i] != addr {
+			t.Fatalf("candidates = %v, want %v", snap.NextEpochCandidates, want)
+		}
+	}
+}
+
+// The quicksort path of the vendored xdc_sort (more than 12 elements) yields a
+// different equal-stake order than the insertion path pinned above; pin that
+// artifact too, so a drift in the sort implementation is caught for large
+// candidate sets as well.
+func TestBuildSnapshotFromStateEqualStakeOrderLarge(t *testing.T) {
+	const n = 15
+	candidates := make([]common.Address, n)
+	caps := make([]*big.Int, n)
+	for i := range n {
+		candidates[i] = common.Address{byte(i + 1)}
+		caps[i] = big.NewInt(10)
+	}
+	statedb := newCandidateState(t, candidates, caps)
+
+	snap, err := BuildSnapshotFromState(statedb, 1350, common.Hash{0xaa})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	want := []common.Address{
+		{5}, {4}, {3}, {2}, {12}, {6}, {11}, {10}, {9}, {15}, {13}, {14}, {7}, {1}, {8},
+	}
+	if len(snap.NextEpochCandidates) != len(want) {
+		t.Fatalf("candidates = %v, want %v", snap.NextEpochCandidates, want)
+	}
+	for i, addr := range want {
+		if snap.NextEpochCandidates[i] != addr {
+			t.Fatalf("candidates = %v, want %v", snap.NextEpochCandidates, want)
+		}
+	}
+}
+
+func TestBuildSnapshotFromStateSkipsZeroCandidates(t *testing.T) {
+	real := common.Address{0x1}
+	statedb := newCandidateState(t,
+		[]common.Address{{}, real},
+		[]*big.Int{big.NewInt(0), big.NewInt(10)},
+	)
+
+	snap, err := BuildSnapshotFromState(statedb, 1350, common.Hash{0xaa})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	if len(snap.NextEpochCandidates) != 1 || snap.NextEpochCandidates[0] != real {
+		t.Fatalf("candidates = %v, want [%s]", snap.NextEpochCandidates, real.Hex())
+	}
+}
+
+func TestBuildSnapshotFromStateRejectsEmptyCandidates(t *testing.T) {
+	statedb := newCandidateState(t, nil, nil)
+
+	if _, err := BuildSnapshotFromState(statedb, 1350, common.Hash{0xaa}); !errors.Is(err, ErrNoCandidates) {
+		t.Fatalf("err = %v, want ErrNoCandidates", err)
+	}
+}
+
+// failingReadDB fails every read once armed, simulating a database whose trie
+// nodes are unreadable (partially pruned or corrupt voting contract storage).
+type failingReadDB struct {
+	ethdb.Database
+	fail atomic.Bool
+}
+
+func (db *failingReadDB) Get(key []byte) ([]byte, error) {
+	if db.fail.Load() {
+		return nil, errors.New("simulated trie read failure")
+	}
+	return db.Database.Get(key)
+}
+
+func (db *failingReadDB) Has(key []byte) (bool, error) {
+	if db.fail.Load() {
+		return false, errors.New("simulated trie read failure")
+	}
+	return db.Database.Has(key)
+}
+
+// TestBuildSnapshotFromStateReturnsStateReadError proves that a state whose
+// voting contract storage cannot be read yields the recorded StateDB error
+// instead of a candidate set that is empty (or worse, non-empty but partial),
+// which would be persisted as a valid snapshot and permanently mask the hole.
+func TestBuildSnapshotFromStateReturnsStateReadError(t *testing.T) {
+	disk := rawdb.NewMemoryDatabase()
+	statedb, err := state.New(types.EmptyRootHash, state.NewDatabase(disk))
+	if err != nil {
+		t.Fatalf("create state: %v", err)
+	}
+	candidates := []common.Address{{0x4}, {0x3}}
+	caps := []*big.Int{big.NewInt(5), big.NewInt(3)}
+	slotHash := common.BigToHash(new(big.Int).SetUint64(8)) // slotValidatorMapping["candidates"]
+	statedb.SetState(common.MasternodeVotingSMCBinary, slotHash, common.BigToHash(new(big.Int).SetUint64(uint64(len(candidates)))))
+	for i, candidate := range candidates {
+		statedb.SetState(common.MasternodeVotingSMCBinary, state.GetLocDynamicArrAtElement(slotHash, uint64(i), 1), candidate.Hash())
+		locCap := new(big.Int).Add(state.GetLocMappingAtKey(candidate.Hash(), 1), big.NewInt(1))
+		statedb.SetState(common.MasternodeVotingSMCBinary, common.BigToHash(locCap), common.BigToHash(caps[i]))
+	}
+	root, err := statedb.Commit(0, false)
+	if err != nil {
+		t.Fatalf("commit state: %v", err)
+	}
+	if err := statedb.Database().TrieDB().Commit(root, false); err != nil {
+		t.Fatalf("persist state: %v", err)
+	}
+
+	// Reopen the committed state over a database whose reads will fail.
+	db := &failingReadDB{Database: disk}
+	statedb, err = state.New(root, state.NewDatabase(db))
+	if err != nil {
+		t.Fatalf("reopen state: %v", err)
+	}
+	db.fail.Store(true)
+
+	snap, err := BuildSnapshotFromState(statedb, 1350, common.Hash{0xaa})
+	if err == nil {
+		t.Fatal("err = nil, want the recorded state read error")
+	}
+	if errors.Is(err, ErrNoCandidates) {
+		t.Fatalf("state read error was masked as empty candidates: %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("snapshot = %+v, want nil", snap)
+	}
+}
+
+func TestRepairGapCandidates(t *testing.T) {
+	x := newRepairEngine(rawdb.NewMemoryDatabase())
+	// Gap block G=1350 backs heads in [1800, 2700); it must stay a candidate
+	// across that whole span plus the margin on either side.
+	tests := []struct {
+		head uint64
+		want []uint64
+	}{
+		{head: 0, want: nil},
+		{head: 449, want: nil},
+		{head: 450, want: []uint64{450}},
+		{head: 1350, want: []uint64{450, 1350}},
+		{head: 1799, want: []uint64{450, 1350}},
+		{head: 1800, want: []uint64{450, 1350}},
+		{head: 2250, want: []uint64{1350, 2250}},
+		{head: 2699, want: []uint64{1350, 2250}},
+		{head: 3150, want: []uint64{2250, 3150}},
+	}
+	for _, tt := range tests {
+		got := x.repairGapCandidates(tt.head)
+		if len(got) != len(tt.want) {
+			t.Fatalf("head %d: got %v, want %v", tt.head, got, tt.want)
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Fatalf("head %d: got %v, want %v", tt.head, got, tt.want)
+			}
+		}
+	}
+}
+
+// Invalid schedules must yield no candidates. In particular, with gap == 0 the
+// offset math would target epoch-switch blocks, whose snapshots are owned by
+// the epoch transition, not by this repair.
+func TestRepairGapCandidatesInvalidSchedule(t *testing.T) {
+	tests := []struct {
+		name  string
+		epoch uint64
+		gap   uint64
+		head  uint64
+	}{
+		{name: "zero epoch", epoch: 0, gap: 0, head: 1800},
+		{name: "zero gap", epoch: 900, gap: 0, head: 1800},
+		{name: "gap equals epoch", epoch: 900, gap: 900, head: 1800},
+		{name: "gap exceeds epoch", epoch: 900, gap: 1200, head: 1800},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x := newRepairEngine(rawdb.NewMemoryDatabase())
+			x.config.Epoch = tt.epoch
+			x.config.Gap = tt.gap
+			if got := x.repairGapCandidates(tt.head); got != nil {
+				t.Fatalf("repairGapCandidates(%d) = %v, want nil", tt.head, got)
+			}
+		})
+	}
+}
+
+func TestRepairGapSnapshotsHeadIsGapBlock(t *testing.T) {
+	candidate := common.Address{0x1}
+	x, chain, db := newRepairFixture(t, 1350, []common.Address{candidate}, []*big.Int{big.NewInt(10)})
+
+	x.RepairGapSnapshots(chain)
+
+	assertSnapshotStored(t, db, gapHash(t, chain, 1350), []common.Address{candidate})
+}
+
+// A node that kept importing past the gap block and only restarted later must
+// still have its missing snapshot repaired.
+func TestRepairGapSnapshotsHeadPastGapBlock(t *testing.T) {
+	candidate := common.Address{0x1}
+	x, chain, db := newRepairFixture(t, 1799, []common.Address{candidate}, []*big.Int{big.NewInt(10)})
+
+	x.RepairGapSnapshots(chain)
+
+	assertSnapshotStored(t, db, gapHash(t, chain, 1350), []common.Address{candidate})
+}
+
+func TestRepairGapSnapshotsChecksBothCandidates(t *testing.T) {
+	candidate := common.Address{0x1}
+	x, chain, db := newRepairFixture(t, 2400, []common.Address{candidate}, []*big.Int{big.NewInt(10)})
+
+	x.RepairGapSnapshots(chain)
+
+	for _, gapNum := range []uint64{1350, 2250} {
+		assertSnapshotStored(t, db, gapHash(t, chain, gapNum), []common.Address{candidate})
+	}
+}
+
+// A stored snapshot may come from the reorg path and disagree with the state
+// derived one, so it must never be overwritten.
+func TestRepairGapSnapshotsKeepsStoredSnapshot(t *testing.T) {
+	stored := common.Address{0x9}
+	x, chain, db := newRepairFixture(t, 1350, []common.Address{{0x1}}, []*big.Int{big.NewInt(10)})
+	if err := StoreSnapshot(NewSnapshot(1350, gapHash(t, chain, 1350), []common.Address{stored}), db); err != nil {
+		t.Fatalf("store snapshot: %v", err)
+	}
+
+	x.RepairGapSnapshots(chain)
+
+	assertSnapshotStored(t, db, gapHash(t, chain, 1350), []common.Address{stored})
+	if chain.stateCalls != 0 {
+		t.Fatalf("stateCalls = %d, want 0", chain.stateCalls)
+	}
+}
+
+func TestRepairGapSnapshotsSkipsMissingState(t *testing.T) {
+	x, chain, db := newRepairFixture(t, 1350, []common.Address{{0x1}}, []*big.Int{big.NewInt(10)})
+	chain.stateErr = errors.New("missing trie node")
+
+	x.RepairGapSnapshots(chain)
+
+	if _, err := loadSnapshot(db, gapHash(t, chain, 1350)); err == nil {
+		t.Fatal("snapshot was stored despite unavailable state")
+	}
+}
+
+func TestRepairGapSnapshotsSkipsSwitchBlockGap(t *testing.T) {
+	x, chain, db := newRepairFixture(t, 450, []common.Address{{0x1}}, []*big.Int{big.NewInt(10)})
+
+	x.RepairGapSnapshots(chain)
+
+	if _, err := loadSnapshot(db, gapHash(t, chain, 450)); err == nil {
+		t.Fatal("snapshot at V2 switch block gap should be left to initial()")
+	}
+	if chain.stateCalls != 0 {
+		t.Fatalf("stateCalls = %d, want 0", chain.stateCalls)
+	}
+}
+
+func TestRepairGapSnapshotsBeforeFirstGap(t *testing.T) {
+	x := newRepairEngine(rawdb.NewMemoryDatabase())
+	chain := &repairTestChain{}
+	chain.addHeader(&types.Header{Number: big.NewInt(100)})
+
+	x.RepairGapSnapshots(chain)
+
+	if chain.stateCalls != 0 {
+		t.Fatalf("stateCalls = %d, want 0", chain.stateCalls)
+	}
+}
+
+// Initial runs the repair through the GapStateReader assertion, without
+// requiring a fully initialized engine or a decodable v2 header.
+func TestInitialRunsRepair(t *testing.T) {
+	candidate := common.Address{0x1}
+	x, chain, db := newRepairFixture(t, 1350, []common.Address{candidate}, []*big.Int{big.NewInt(10)})
+	// Pretend the engine is already initialized so initial() returns early
+	// instead of decoding a real v2 header.
+	x.highestQuorumCert = &types.QuorumCert{ProposedBlockInfo: &types.BlockInfo{Hash: common.Hash{0x1}}}
+
+	if err := x.Initial(chain, chain.head); err != nil {
+		t.Fatalf("Initial() = %v, want nil", err)
+	}
+	assertSnapshotStored(t, db, gapHash(t, chain, 1350), []common.Address{candidate})
+}
+
+// Initial must skip the repair for chain readers that cannot open historical
+// state; only *core.BlockChain implements GapStateReader.
+func TestInitialSkipsRepairWithoutStateReader(t *testing.T) {
+	x, chain, _ := newRepairFixture(t, 1350, []common.Address{{0x1}}, []*big.Int{big.NewInt(10)})
+	x.highestQuorumCert = &types.QuorumCert{ProposedBlockInfo: &types.BlockInfo{Hash: common.Hash{0x1}}}
+	plain := struct{ consensus.ChainReader }{chain}
+
+	if err := x.Initial(plain, chain.head); err != nil {
+		t.Fatalf("Initial() = %v, want nil", err)
+	}
+	if chain.stateCalls != 0 {
+		t.Fatalf("stateCalls = %d, want 0", chain.stateCalls)
+	}
+}
+
+// A Has probe that cannot determine whether a snapshot exists must skip the
+// repair: an I/O error must never overwrite a masternode set persisted through
+// a reorg.
+func TestRepairGapSnapshotsSkipsHasProbeError(t *testing.T) {
+	x, chain, db := newRepairFixture(t, 1350, []common.Address{{0x1}}, []*big.Int{big.NewInt(10)})
+	chain.db = &failingHasDB{Database: db}
+
+	x.RepairGapSnapshots(chain)
+
+	if _, err := loadSnapshot(db, gapHash(t, chain, 1350)); err == nil {
+		t.Fatal("snapshot was stored despite a failed Has probe")
+	}
+	if chain.stateCalls != 0 {
+		t.Fatalf("stateCalls = %d, want 0", chain.stateCalls)
+	}
+}
+
+// An empty derived snapshot must not be stored: it would load back fine and
+// permanently mask the missing masternode list.
+func TestRepairGapSnapshotsSkipsEmptyCandidates(t *testing.T) {
+	x, chain, db := newRepairFixture(t, 1350, nil, nil)
+
+	x.RepairGapSnapshots(chain)
+
+	if _, err := loadSnapshot(db, gapHash(t, chain, 1350)); err == nil {
+		t.Fatal("snapshot was stored despite no candidates in state")
+	}
+	if chain.stateCalls != 1 {
+		t.Fatalf("stateCalls = %d, want 1", chain.stateCalls)
 	}
 }

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -25,6 +25,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/rlp"
@@ -294,6 +295,11 @@ func (bc *BlockChain) StateAt(root common.Hash) (*state.StateDB, error) {
 		return nil, err
 	}
 	return statedb, nil
+}
+
+// ChainDb returns the underlying database of the blockchain.
+func (bc *BlockChain) ChainDb() ethdb.Database {
+	return bc.db
 }
 
 // Config retrieves the chain's fork configuration.

--- a/core/blockchain_reader_test.go
+++ b/core/blockchain_reader_test.go
@@ -1,0 +1,29 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2"
+)
+
+// BlockChain must keep satisfying the v2 engine's GapStateReader, otherwise
+// Initial's startup repair silently skips a missing gap snapshot on
+// production nodes. The check lives in a test file so that production core
+// does not depend on a consensus engine implementation; engine_v2 must
+// therefore never import core itself (only its subpackages), or an import
+// cycle would result.
+var _ engine_v2.GapStateReader = (*BlockChain)(nil)

--- a/core/rawdb/accessors_xdc.go
+++ b/core/rawdb/accessors_xdc.go
@@ -50,6 +50,11 @@ func ReadXdposV2Snapshot(db ethdb.KeyValueReader, hash common.Hash) ([]byte, err
 	return data, nil
 }
 
+// HasXdposV2Snapshot reports whether a snapshot is stored for the given hash.
+func HasXdposV2Snapshot(db ethdb.KeyValueReader, hash common.Hash) (bool, error) {
+	return db.Has(xdposV2Key(hash))
+}
+
 // WriteXdposV2Snapshot writes the SnapshotV2 into the database.
 func WriteXdposV2Snapshot(db ethdb.KeyValueWriter, hash common.Hash, blob []byte) error {
 	if err := db.Put(xdposV2Key(hash), blob); err != nil {


### PR DESCRIPTION
# Proposed changes

A node can lose its persisted V2 gap snapshot when the process exits between writeHeadBlock and UpdateM1 in writeBlockWithState: the head markers are already on disk, the snapshot is not, and nothing recreates it. Every consumer of that snapshot then fails for a whole epoch. A node that keeps up with the chain head still imports blocks, because the fetcher path verifies headers with fullVerify disabled and trusts header.Validators, but it can no longer mine or vote. A node that falls behind takes the downloader path, where fullVerify is enabled, and stalls on the epoch switch block while reporting it as a bad block.

This change repairs the hole once at startup, before the chain is used: for each gap block whose snapshot is missing, rebuild it from the state committed at that block and store it. Only the last two gap blocks at or below the head are considered: a gap block G is among them exactly while the head is in [G, G+2*Epoch), and G's snapshot is consulted exactly while the head is in [G+Gap, G+Gap+Epoch), so every hole that can still affect the running chain is covered. The derivation is shared with core.BlockChain.UpdateM1 and the downloader through the unstable xdc_sort ordering, which must not drift, since a different equal-stake order yields a different masternode set. The rebuild is skipped when a snapshot is already stored, so a decode or I/O error never overwrites a masternode set persisted through a reorg, and at or below the V2 switch block, where the snapshot still comes from Initial(). Every failure is only logged and startup continues, so nodes that legitimately cannot rebuild (offline pruning, fast sync pivot) are unaffected.

Tests: adds 21 unit tests covering stake ordering (including pinned equal-stake artifacts for both sort paths), repair candidate boundaries, skip conditions, error paths, reorg preservation, and a compile-time GapStateReader assertion on core.BlockChain. Relevant CI checks are enabled.

Compatibility impact: startup-only repair; no consensus, wire, or RPC changes. No database schema change or migration required.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
