### PR TITLE
test(eth): fix flaky TestBroadcastBlock

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -483,6 +483,14 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 		defer peer.close()
 		peers = append(peers, peer)
 	}
+	// Peers are registered asynchronously once the handshake completes on the
+	// protocol manager side, wait for the peer set to catch up before broadcasting.
+	for deadline := time.Now().Add(10 * time.Second); pm.peers.Len() < totalPeers; {
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for peer registration: have %d, want %d", pm.peers.Len(), totalPeers)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	chain, _ := core.GenerateChain(gspec.Config, genesis, ethash.NewFaker(), db, 1, func(i int, gen *core.BlockGen) {})
 	expectedTD := new(big.Int).Add(chain[0].Difficulty(), pm.blockchain.GetTd(chain[0].ParentHash(), chain[0].NumberU64()-1))
 


### PR DESCRIPTION
# Proposed changes

Peers are registered into the peer set only after the protocol manager side of the handshake completes, so broadcasting right after newTestPeer returns could miss late peers and flake with fewer recipients than expected.

https://github.com/XinFinOrg/XDPoSChain/actions/runs/31360452080/job/93368159943

```text
2026-08-10T06:03:22.9951436Z --- FAIL: TestBroadcastBlock (2.03s)
2026-08-10T06:03:22.9951975Z     handler_test.go:554: block broadcast to 2 peers, expected 3
```

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [X] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [X] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
