### PR TITLE
fix(eth/downloader): reject empty gap-pivot masternode snapshots

### DIFF
--- a/consensus/XDPoS/engines/engine_v2/snapshot.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot.go
@@ -130,9 +130,10 @@ type GapStateReader interface {
 var ErrNoCandidates = errors.New("no masternode candidates in state")
 
 // BuildSnapshotFromState derives a gap block snapshot from the state committed
-// at that block. The ordering must stay identical to core.BlockChain.UpdateM1
-// and Downloader.generateSnapshot: a different equal-stake order yields a
-// different masternode set.
+// at that block. The ordering must stay identical to core.BlockChain.UpdateM1:
+// a different equal-stake order yields a different masternode set. Callers such
+// as Downloader.generateSnapshot must delegate here instead of reimplementing
+// the derivation.
 func BuildSnapshotFromState(statedb *state.StateDB, number uint64, hash common.Hash) (*SnapshotV2, error) {
 	var ms []utils.Masternode
 	for _, candidate := range statedb.GetCandidates() {

--- a/consensus/XDPoS/engines/engine_v2/snapshot_test.go
+++ b/consensus/XDPoS/engines/engine_v2/snapshot_test.go
@@ -206,7 +206,7 @@ func TestBuildSnapshotFromStateSortsByStakeDescending(t *testing.T) {
 // Equal stakes must keep the exact order xdc_sort produces, otherwise nodes
 // derive different masternode sets from the same state. A failure here means
 // the sort implementation drifted and the derivation no longer matches
-// core.BlockChain.UpdateM1 and Downloader.generateSnapshot.
+// core.BlockChain.UpdateM1.
 func TestBuildSnapshotFromStateEqualStakeOrder(t *testing.T) {
 	a, b, c := common.Address{0x1}, common.Address{0x2}, common.Address{0x3}
 	statedb := newCandidateState(t,

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -27,9 +27,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain"
 	"github.com/XinFinOrg/XDPoSChain/common"
-	xdc_sort "github.com/XinFinOrg/XDPoSChain/common/sort"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2"
-	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
@@ -1780,10 +1778,19 @@ func (d *Downloader) processFastSyncContent(latest *types.Header) error {
 								log.Error("Failed to create state for gap pivot snapshot", "number", gapNum, "root", root, "err", err)
 								return err
 							}
-							if err := d.generateSnapshot(statedb, gapNum, gapHash); err != nil {
+							snap, err := d.generateSnapshot(statedb, gapNum, gapHash)
+							if err != nil {
+								// Abort fast sync instead of persisting an empty or partial
+								// snapshot that would permanently mask the gap. A normal chain
+								// always has masternode candidates at a gap block, so this
+								// failure means the gap block state itself is abnormal: retrying
+								// fast sync hits the same block again. The operator must resync
+								// with a clean data directory or restore valid gap block state
+								// before fast sync can complete.
 								log.Error("Failed to generate snapshot for gap pivot", "number", gapNum, "hash", gapHash, "err", err)
 								return err
 							}
+							log.Info("Gap pivot snapshot generated", "number", gapNum, "hash", gapHash.Hex(), "candidates", len(snap.NextEpochCandidates))
 							syncedGaps[gapNum] = true
 						}
 						log.Info("All gap pivot state syncs complete", "count", len(gapNumbers))
@@ -1998,36 +2005,15 @@ func (d *Downloader) requestTTL() time.Duration {
 	return ttl
 }
 
-// generateSnapshot creates and stores a snapshot from the given state and block hash.
-// It retrieves candidates from state, sorts them by stake in descending order,
-// and stores the snapshot for future use.
-func (d *Downloader) generateSnapshot(statedb *state.StateDB, number uint64, hash common.Hash) error {
-	candidates := statedb.GetCandidates()
-	var ms []utils.Masternode
-	for _, candidate := range candidates {
-		v := statedb.GetCandidateCap(candidate)
-		// Skip zero address candidates
-		if !candidate.IsZero() {
-			ms = append(ms, utils.Masternode{Address: candidate, Stake: v})
-		}
-	}
-	xdc_sort.Slice(ms, func(i, j int) bool {
-		return ms[i].Stake.Cmp(ms[j].Stake) >= 0
-	})
-
-	masterNodes := []common.Address{}
-	for _, m := range ms {
-		masterNodes = append(masterNodes, m.Address)
-	}
-
-	snap := engine_v2.NewSnapshot(number, hash, masterNodes)
-	log.Info("[generateSnapshot] created snapshot", "number", number, "hash", hash.Hex(), "candidates", len(masterNodes))
-
-	err := engine_v2.StoreSnapshot(snap, d.stateDB)
+// generateSnapshot derives the masternode snapshot of a gap block from the
+// given state, stores it and returns it.
+func (d *Downloader) generateSnapshot(statedb *state.StateDB, number uint64, hash common.Hash) (*engine_v2.SnapshotV2, error) {
+	snap, err := engine_v2.BuildSnapshotFromState(statedb, number, hash)
 	if err != nil {
-		log.Error("[generateSnapshot] error while storing snapshot", "hash", hash, "error", err)
-		return err
+		return nil, err
 	}
-
-	return nil
+	if err := engine_v2.StoreSnapshot(snap, d.stateDB); err != nil {
+		return nil, err
+	}
+	return snap, nil
 }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -30,6 +31,7 @@ import (
 	ethereum "github.com/XinFinOrg/XDPoSChain"
 	"github.com/XinFinOrg/XDPoSChain/common"
 	engine_v2 "github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2"
+	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
@@ -82,19 +84,26 @@ type downloadTester struct {
 
 // newTester creates a new downloader test mocker.
 func newTester() *downloadTester {
+	return newTesterWithGenesis(testGenesis, testDB)
+}
+
+// newTesterWithGenesis creates a new downloader test mocker backed by a custom
+// genesis and peer database, for tests whose chain state differs from the
+// shared test genesis.
+func newTesterWithGenesis(genesis *types.Block, peerDb ethdb.Database) *downloadTester {
 	tester := &downloadTester{
-		genesis:     testGenesis,
-		peerDb:      testDB,
+		genesis:     genesis,
+		peerDb:      peerDb,
 		peers:       make(map[string]*downloadTesterPeer),
-		ownHashes:   []common.Hash{testGenesis.Hash()},
-		ownHeaders:  map[common.Hash]*types.Header{testGenesis.Hash(): testGenesis.Header()},
-		ownBlocks:   map[common.Hash]*types.Block{testGenesis.Hash(): testGenesis},
-		ownReceipts: map[common.Hash]types.Receipts{testGenesis.Hash(): nil},
-		ownChainTd:  map[common.Hash]*big.Int{testGenesis.Hash(): testGenesis.Difficulty()},
+		ownHashes:   []common.Hash{genesis.Hash()},
+		ownHeaders:  map[common.Hash]*types.Header{genesis.Hash(): genesis.Header()},
+		ownBlocks:   map[common.Hash]*types.Block{genesis.Hash(): genesis},
+		ownReceipts: map[common.Hash]types.Receipts{genesis.Hash(): nil},
+		ownChainTd:  map[common.Hash]*big.Int{genesis.Hash(): genesis.Difficulty()},
 	}
 	tester.stateDb = rawdb.NewMemoryDatabase()
 	tester.triedb = trie.NewDatabase(tester.stateDb)
-	tester.stateDb.Put(testGenesis.Root().Bytes(), []byte{0x00})
+	tester.stateDb.Put(genesis.Root().Bytes(), []byte{0x00})
 	tester.downloader = New(tester.stateDb, new(event.TypeMux), tester, nil, tester.dropPeer, tester.handleProposedBlock)
 	return tester
 }
@@ -2147,6 +2156,72 @@ func TestFastSyncGapPivotSync(t *testing.T) {
 	}
 	if snap.Hash != gapBlockHash {
 		t.Errorf("snapshot hash mismatch: have %v, want %v", snap.Hash, gapBlockHash)
+	}
+	if !slices.Equal(snap.NextEpochCandidates, testMasternodes) {
+		t.Errorf("snapshot candidates mismatch: have %v, want %v", snap.NextEpochCandidates, testMasternodes)
+	}
+}
+
+// TestFastSyncGapPivotEmptyCandidatesAborts verifies the downloader-boundary
+// behavior of the gap-pivot snapshot derivation: when the voting-contract
+// storage holds no candidates, fast sync must abort with
+// engine_v2.ErrNoCandidates and must not persist any snapshot, proving the
+// failure propagates before the pivot is committed.
+func TestFastSyncGapPivotEmptyCandidatesAborts(t *testing.T) {
+	// Genesis without any voting-contract storage: the gap block state holds
+	// no masternode candidates.
+	gspec := &core.Genesis{
+		Alloc:   types.GenesisAlloc{testAddress: {Balance: big.NewInt(1000000000000000000)}},
+		BaseFee: big.NewInt(params.InitialBaseFee),
+		Config:  testChainConfig,
+	}
+	peerDb := rawdb.NewMemoryDatabase()
+	genesis := gspec.MustCommit(peerDb)
+
+	tester := newTesterWithGenesis(genesis, peerDb)
+	// XDPoS config is required so SetPivotBlock can compute gap numbers.
+	// TestXDPoSMockChainConfig has Epoch=900, Gap=450.
+	tester.configOverride = params.TestXDPoSMockChainConfig
+	defer tester.terminate()
+
+	// 600 blocks: natural pivot = 600-1-64 = 535, gap pivot = 450.
+	chainLen := 600
+	chain := newTestChainWithDB(chainLen, genesis, peerDb)
+	tester.newPeer("peer", xdc100, chain)
+
+	pivotNum := uint64(chainLen - 1 - fsMinFullBlocks) // = 535
+	pivotHash := chain.headerm[chain.chain[pivotNum]].Hash()
+	pivotRoot := chain.headerm[chain.chain[pivotNum]].Root
+	tester.downloader.SetPivotBlock(pivotNum, pivotHash, pivotRoot)
+
+	// Same layout as TestFastSyncGapPivotSync: the fixed pivot derives exactly
+	// one gap pivot, block 450, so the abort is exercised on the intended block
+	// instead of passing because no gap pivot was scheduled at all.
+	tester.downloader.pivotGapLock.RLock()
+	gaps := make([]uint64, len(tester.downloader.pivotGapNumbers))
+	copy(gaps, tester.downloader.pivotGapNumbers)
+	tester.downloader.pivotGapLock.RUnlock()
+	if len(gaps) != 1 || gaps[0] != 450 {
+		t.Fatalf("expected gap pivots [450], got %v", gaps)
+	}
+
+	if err := tester.sync("peer", nil, FastSync); !errors.Is(err, engine_v2.ErrNoCandidates) {
+		t.Fatalf("fast sync with empty gap-pivot candidates error = %v, want %v", err, engine_v2.ErrNoCandidates)
+	}
+
+	// The abort happens before commitPivotBlock, so the pivot block must not
+	// be in the local chain.
+	if _, ok := tester.ownBlocks[pivotHash]; ok {
+		t.Errorf("pivot block %d committed despite ErrNoCandidates", pivotNum)
+	}
+	// No snapshot may have been persisted for the gap pivot block.
+	gapBlockHash := chain.headerm[chain.chain[450]].Hash()
+	has, hasErr := rawdb.HasXdposV2Snapshot(tester.downloader.stateDB, gapBlockHash)
+	if hasErr != nil {
+		t.Fatalf("failed to probe gap pivot snapshot %s: %v", gapBlockHash, hasErr)
+	}
+	if has {
+		t.Errorf("snapshot persisted for gap pivot block 450 despite ErrNoCandidates")
 	}
 }
 

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/state"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/params"
 )
 
@@ -36,6 +38,11 @@ var (
 	testKey, _      = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	testAddress     = crypto.PubkeyToAddress(testKey.PublicKey)
 	testDB          = rawdb.NewMemoryDatabase()
+	testMasternodes = []common.Address{
+		common.HexToAddress("0x0000000000000000000000000000000000000101"),
+		common.HexToAddress("0x0000000000000000000000000000000000000102"),
+		common.HexToAddress("0x0000000000000000000000000000000000000103"),
+	}
 	testChainConfig = func() *params.ChainConfig {
 		cfg := *params.TestChainConfig
 		cfg.CancunBlock = nil
@@ -45,12 +52,37 @@ var (
 	}()
 
 	testGspec = &core.Genesis{
-		Alloc:   types.GenesisAlloc{testAddress: {Balance: big.NewInt(1000000000000000000)}},
+		Alloc: types.GenesisAlloc{
+			testAddress:                      {Balance: big.NewInt(1000000000000000000)},
+			common.MasternodeVotingSMCBinary: {Balance: new(big.Int), Storage: masternodeVotingStorage(testMasternodes)},
+		},
 		BaseFee: big.NewInt(params.InitialBaseFee),
 		Config:  testChainConfig,
 	}
 	testGenesis = testGspec.MustCommit(testDB)
 )
+
+// masternodeVotingStorage lays out the candidate array of the masternode voting
+// contract so StateDB.GetCandidates works without deploying the contract.
+func masternodeVotingStorage(candidates []common.Address) map[common.Hash]common.Hash {
+	// Slot numbers must stay in sync with slotValidatorMapping in
+	// core/state/statedb_utils.go: "candidates" = 8, "validatorsState" = 1.
+	const candidatesSlot, validatorsStateSlot = 8, 1
+
+	slotHash := common.BigToHash(new(big.Int).SetUint64(candidatesSlot))
+	storage := map[common.Hash]common.Hash{
+		slotHash: common.BigToHash(new(big.Int).SetUint64(uint64(len(candidates)))),
+	}
+	for i, candidate := range candidates {
+		storage[state.GetLocDynamicArrAtElement(slotHash, uint64(i), 1)] = candidate.Hash()
+		// validatorsState[candidate].cap sits one word past the struct base.
+		// Stakes strictly decrease with the index, so the descending stake sort
+		// preserves the genesis order and callers can assert it exactly.
+		capLoc := new(big.Int).Add(state.GetLocMappingAtKey(candidate.Hash(), validatorsStateSlot), common.Big1)
+		storage[common.BigToHash(capLoc)] = common.BigToHash(big.NewInt(int64(len(candidates)-i) * 1000))
+	}
+	return storage
+}
 
 // The common prefix of all test chains:
 var testChainBase *testChain
@@ -83,11 +115,21 @@ type testChain struct {
 	blockm   map[common.Hash]*types.Block
 	receiptm map[common.Hash][]*types.Receipt
 	tdm      map[common.Hash]*big.Int
+	db       ethdb.Database // Database the block states are committed to
 }
 
-// newTestChain creates a blockchain of the given length.
+// newTestChain creates a blockchain of the given length, committing the block
+// states to the shared testDB.
 func newTestChain(length int, genesis *types.Block) *testChain {
+	return newTestChainWithDB(length, genesis, testDB)
+}
+
+// newTestChainWithDB creates a blockchain of the given length, committing the
+// block states to db. It is used for chains whose genesis state differs from
+// the shared test genesis (e.g. no voting-contract storage).
+func newTestChainWithDB(length int, genesis *types.Block, db ethdb.Database) *testChain {
 	tc := new(testChain).copy(length)
+	tc.db = db
 	tc.genesis = genesis
 	tc.chain = append(tc.chain, genesis.Hash())
 	tc.headerm[tc.genesis.Hash()] = tc.genesis.Header()
@@ -120,6 +162,7 @@ func (tc *testChain) copy(newlen int) *testChain {
 		blockm:   make(map[common.Hash]*types.Block, newlen),
 		receiptm: make(map[common.Hash][]*types.Receipt, newlen),
 		tdm:      make(map[common.Hash]*big.Int, newlen),
+		db:       tc.db,
 	}
 	for i := 0; i < len(tc.chain) && i < newlen; i++ {
 		hash := tc.chain[i]
@@ -137,7 +180,7 @@ func (tc *testChain) copy(newlen int) *testChain {
 // contains a transaction and every 5th an uncle to allow testing correct block
 // reassembly.
 func (tc *testChain) generate(n int, seed byte, parent *types.Block, heavy bool) {
-	blocks, receipts := core.GenerateChain(testGspec.Config, parent, ethash.NewFaker(), testDB, n, func(i int, block *core.BlockGen) {
+	blocks, receipts := core.GenerateChain(testGspec.Config, parent, ethash.NewFaker(), tc.db, n, func(i int, block *core.BlockGen) {
 		block.SetCoinbase(common.Address{seed})
 		// If a heavy chain is requested, delay blocks to raise difficulty
 		if heavy {


### PR DESCRIPTION
# Proposed changes

A gap-pivot fast sync persisted a gap-block snapshot with an empty masternode list when the gap block's state held no candidates. The placeholder loads back without complaint and permanently masks the hole: signatures and epoch switch blocks are rejected for the whole epoch with no recovery path.

## Change

`Downloader.generateSnapshot` no longer carries its own copy of the gap-block masternode derivation. It delegates to `engine_v2.BuildSnapshotFromState`, which errors with `ErrNoCandidates` instead of returning an empty set, so a gap-pivot fast sync aborts instead of completing with an unusable snapshot. The downloader test genesis now seeds the masternode voting contract storage so `TestFastSyncGapPivotSync` can assert the derived candidate set.

## Compatibility impact

Behavior change: a gap-pivot fast sync now fails instead of completing when the gap block has no masternode candidates. Networks whose voting contract is seeded in genesis cannot hit this path, but a release note for node operators is recommended.


## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
