### PR TITLE
test(common/countdown,p2p/discover): skip long tests in `make quick-test`

### DIFF
--- a/common/countdown/countdown_test.go
+++ b/common/countdown/countdown_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func skipLongInShortMode(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping long-running test in -short mode")
+	}
+}
+
 func TestCountdownWillCallback(t *testing.T) {
 	var fakeI interface{}
 	called := make(chan int)
@@ -25,6 +32,8 @@ func TestCountdownWillCallback(t *testing.T) {
 }
 
 func TestCountdownShouldReset(t *testing.T) {
+	skipLongInShortMode(t)
+
 	var fakeI interface{}
 	called := make(chan int)
 	OnTimeoutFn := func(time.Time, interface{}) error {
@@ -76,6 +85,8 @@ firstReset:
 }
 
 func TestCountdownShouldResetEvenIfErrored(t *testing.T) {
+	skipLongInShortMode(t)
+
 	var fakeI interface{}
 	called := make(chan int)
 	OnTimeoutFn := func(time.Time, interface{}) error {
@@ -127,6 +138,8 @@ firstReset:
 }
 
 func TestCountdownShouldBeAbleToStop(t *testing.T) {
+	skipLongInShortMode(t)
+
 	var fakeI interface{}
 	called := make(chan int)
 	OnTimeoutFn := func(time.Time, interface{}) error {
@@ -150,6 +163,8 @@ func TestCountdownShouldBeAbleToStop(t *testing.T) {
 }
 
 func TestCountdownShouldAvoidDeadlock(t *testing.T) {
+	skipLongInShortMode(t)
+
 	var fakeI interface{}
 	called := make(chan int)
 	countdown, err := NewExpCountDown(5000*time.Millisecond, 0, 0)

--- a/p2p/discover/short_mode_test.go
+++ b/p2p/discover/short_mode_test.go
@@ -1,0 +1,10 @@
+package discover
+
+import "testing"
+
+func skipLongInShortMode(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping long-running test in -short mode")
+	}
+}

--- a/p2p/discover/v4_lookup_test.go
+++ b/p2p/discover/v4_lookup_test.go
@@ -30,7 +30,9 @@ import (
 )
 
 func TestUDPv4_Lookup(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPTest(t)
 
 	// Lookup on empty table returns no nodes.
@@ -65,7 +67,9 @@ func TestUDPv4_Lookup(t *testing.T) {
 }
 
 func TestUDPv4_LookupIterator(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPTest(t)
 	defer test.close()
 

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -172,7 +172,9 @@ func TestUDP_pingPacketRejected(t *testing.T) {
 }
 
 func TestUDPv4_pingTimeout(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -185,6 +187,8 @@ func TestUDPv4_pingTimeout(t *testing.T) {
 }
 
 func TestUDPv4_resolveReturnsNilWhenUnresolved(t *testing.T) {
+	skipLongInShortMode(t)
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -204,6 +208,8 @@ func TestUDPv4_resolveReturnsNilWhenUnresolved(t *testing.T) {
 }
 
 func TestUDPv4_resolveReturnsNilWhenLookupMisses(t *testing.T) {
+	skipLongInShortMode(t)
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -225,7 +231,9 @@ func (req testPacket) Kind() byte   { return byte(req) }
 func (req testPacket) Name() string { return "" }
 
 func TestUDPv4_responseTimeouts(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -297,7 +305,9 @@ func TestUDPv4_responseTimeouts(t *testing.T) {
 }
 
 func TestUDPv4_findnodeTimeout(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -369,6 +379,8 @@ func TestUDPv4_findnode(t *testing.T) {
 }
 
 func TestUDPv4_findnodeMultiReply(t *testing.T) {
+	skipLongInShortMode(t)
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -522,6 +534,8 @@ func TestUDPv4_successfulPing(t *testing.T) {
 
 // This test checks that EIP-868 requests work.
 func TestUDPv4_EIP868(t *testing.T) {
+	skipLongInShortMode(t)
+
 	test := newUDPTest(t)
 	defer test.close()
 
@@ -560,6 +574,7 @@ func TestUDPv4_EIP868(t *testing.T) {
 
 // This test verifies that a small network of nodes can boot up into a healthy state.
 func TestUDPv4_smallNetConvergence(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
 
 	// Start the network.

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -109,7 +109,9 @@ func startLocalhostV5(t *testing.T, cfg Config) *UDPv5 {
 
 // This test checks that incoming PING calls are handled correctly.
 func TestUDPv5_pingHandling(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -126,7 +128,9 @@ func TestUDPv5_pingHandling(t *testing.T) {
 
 // This test checks that incoming 'unknown' packets trigger the handshake.
 func TestUDPv5_unknownPacket(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -162,7 +166,9 @@ func TestUDPv5_unknownPacket(t *testing.T) {
 
 // This test checks that incoming FINDNODE calls are handled correctly.
 func TestUDPv5_findnodeHandling(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -240,7 +246,9 @@ func (test *udpV5Test) expectNodes(wantReqID []byte, wantTotal uint8, wantNodes 
 
 // This test checks that outgoing PING calls work.
 func TestUDPv5_pingCall(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -372,7 +380,9 @@ func TestUDPv5_callResend(t *testing.T) {
 
 // This test ensures we don't allow multiple rounds of WHOAREYOU for a single call.
 func TestUDPv5_multipleHandshakeRounds(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -398,7 +408,9 @@ func TestUDPv5_multipleHandshakeRounds(t *testing.T) {
 
 // This test checks that calls with n replies may take up to n * respTimeout.
 func TestUDPv5_callTimeoutReset(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -487,7 +499,9 @@ func TestUDPv5_talkHandling(t *testing.T) {
 
 // This test checks that outgoing TALKREQ calls work.
 func TestUDPv5_talkRequest(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 
@@ -528,7 +542,9 @@ func TestUDPv5_talkRequest(t *testing.T) {
 
 // This test checks that lookup works.
 func TestUDPv5_lookup(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 
 	// Lookup on empty table returns no nodes.
@@ -605,7 +621,9 @@ func TestUDPv5_LocalNode(t *testing.T) {
 }
 
 func TestUDPv5_PingWithIPV4MappedAddress(t *testing.T) {
+	skipLongInShortMode(t)
 	t.Parallel()
+
 	test := newUDPV5Test(t)
 	defer test.close()
 


### PR DESCRIPTION
# Proposed changes

Add skipLongInShortMode helpers and call them in tests that take longer than 4.0s so they are skipped when running with -short.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [X] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
