### PR TITLE
test(core/txpool/legacypool): drop shared config writes from parallel tests

### DIFF
--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -1936,10 +1936,10 @@ func TestQueueAccountLimiting(t *testing.T) {
 
 	account := crypto.PubkeyToAddress(key.PublicKey)
 	testAddBalance(pool, account, big.NewInt(300000000000000))
-	testTxPoolConfig.AccountQueue = 10
+	accountQueue := uint64(10)
 
 	// Keep queuing up transactions and make sure all above a limit are dropped
-	for i := uint64(1); i <= testTxPoolConfig.AccountQueue; i++ {
+	for i := uint64(1); i <= accountQueue; i++ {
 		if err := pool.addRemoteSync(pricedTransaction(i, 100000, big.NewInt(300000000), key)); err != nil {
 			t.Fatalf("tx %d: failed to add transaction: %v", i, err)
 		}
@@ -1947,18 +1947,18 @@ func TestQueueAccountLimiting(t *testing.T) {
 			t.Errorf("tx %d: pending pool size mismatch: have %d, want %d", i, len(pool.pending), 0)
 		}
 		list, _ := pool.queue.get(account)
-		if i <= testTxPoolConfig.AccountQueue {
+		if i <= accountQueue {
 			if list.Len() != int(i) {
 				t.Errorf("tx %d: queue size mismatch: have %d, want %d", i, list.Len(), i)
 			}
 		} else {
-			if list.Len() != int(testTxPoolConfig.AccountQueue) {
-				t.Errorf("tx %d: queue limit mismatch: have %d, want %d", i, list.Len(), testTxPoolConfig.AccountQueue)
+			if list.Len() != int(accountQueue) {
+				t.Errorf("tx %d: queue limit mismatch: have %d, want %d", i, list.Len(), accountQueue)
 			}
 		}
 	}
-	if pool.all.Count() != int(testTxPoolConfig.AccountQueue) {
-		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), testTxPoolConfig.AccountQueue)
+	if pool.all.Count() != int(accountQueue) {
+		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), accountQueue)
 	}
 }
 
@@ -2154,15 +2154,15 @@ func TestPendingLimiting(t *testing.T) {
 
 	account := crypto.PubkeyToAddress(key.PublicKey)
 	testAddBalance(pool, account, big.NewInt(400000000000000))
-	testTxPoolConfig.AccountQueue = 10
+	accountQueue := uint64(10)
 
 	// Keep track of transaction events to ensure all executables get announced
-	events := make(chan core.NewTxsEvent, testTxPoolConfig.AccountQueue)
+	events := make(chan core.NewTxsEvent, accountQueue)
 	sub := pool.txFeed.Subscribe(events)
 	defer sub.Unsubscribe()
 
 	// Keep queuing up transactions and make sure all above a limit are dropped
-	for i := uint64(0); i < testTxPoolConfig.AccountQueue; i++ {
+	for i := uint64(0); i < accountQueue; i++ {
 		if err := pool.addRemoteSync(pricedTransaction(i, 100000, big.NewInt(300000000), key)); err != nil {
 			t.Fatalf("tx %d: failed to add transaction: %v", i, err)
 		}
@@ -2173,10 +2173,10 @@ func TestPendingLimiting(t *testing.T) {
 			t.Errorf("tx %d: queue size mismatch: have %d, want %d", i, len(pool.queue.addresses()), 0)
 		}
 	}
-	if pool.all.Count() != int(testTxPoolConfig.AccountQueue) {
-		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), testTxPoolConfig.AccountQueue+5)
+	if pool.all.Count() != int(accountQueue) {
+		t.Errorf("total transaction mismatch: have %d, want %d", pool.all.Count(), accountQueue)
 	}
-	if err := validateEvents(events, int(testTxPoolConfig.AccountQueue)); err != nil {
+	if err := validateEvents(events, int(accountQueue)); err != nil {
 		t.Fatalf("event firing failed: %v", err)
 	}
 	if err := validatePoolInternals(pool); err != nil {


### PR DESCRIPTION
# Proposed changes

TestQueueAccountLimiting and TestPendingLimiting both run with t.Parallel() and both assigned testTxPoolConfig.AccountQueue, a package-level variable that every other test reads while building its pool. That is a data race, and it can also change the limits another test is asserting against.

Neither test needs the global: their pools are already constructed before the assignment, so the value only ever served as the loop bound. Use a local accountQueue instead. Also fix the mismatched want value in the pending count error message, which printed AccountQueue+5 for an equality check against AccountQueue.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [X] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
