### PR TITLE
fix(core/txpool): stop delivering special tx events under the pool lock

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -986,7 +986,7 @@ func (pool *LegacyPool) promoteSpecialTx(addr common.Address, tx *types.Transact
 	// Set the potentially new pending nonce and notify any subsystems of the new tx
 	pool.queue.bump(addr)
 	pool.pendingNonces.set(addr, tx.Nonce()+1)
-	pool.txFeed.Send(core.NewTxsEvent{Txs: []*types.Transaction{tx}})
+	pool.queueTxEvent(tx)
 	return true, nil
 }
 

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -4029,3 +4029,123 @@ func TestSetGasPrice(t *testing.T) {
 		})
 	}
 }
+
+// TestSpecialTxPromotionDoesNotBlockOnTxFeed reproduces the mainnet freeze: promoting a
+// special transaction delivered its NewTxsEvent while holding the pool write lock, so a
+// subscriber that stopped draining wedged the pool itself and, through it, every peer
+// goroutine that wanted to add or read transactions.
+func TestSpecialTxPromotionDoesNotBlockOnTxFeed(t *testing.T) {
+	pool, key := setupPool()
+	defer pool.Close()
+
+	pool.SetSigner(func(common.Address) bool { return true })
+	testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1_000_000_000_000_000_000))
+
+	// Subscriber that never reads, modelling a stalled txBroadcastLoop.
+	sink := make(chan core.NewTxsEvent)
+	sub := pool.SubscribeTransactions(sink, false)
+	defer sub.Unsubscribe()
+
+	gasPrice := new(big.Int).SetUint64(common.DefaultMinGasPrice + 1)
+	specialTx, err := types.SignTx(types.NewTransaction(0, common.BlockSignersBinary, big.NewInt(1), 100000, gasPrice, nil), types.HomesteadSigner{}, key)
+	if err != nil {
+		t.Fatalf("failed to sign special tx: %v", err)
+	}
+	if !specialTx.IsSpecialTransaction() {
+		t.Fatal("test setup: transaction is not special")
+	}
+
+	added := make(chan error, 1)
+	go func() {
+		added <- pool.Add([]*types.Transaction{specialTx}, false)[0]
+	}()
+	select {
+	case err := <-added:
+		if err != nil {
+			t.Fatalf("failed to add special tx: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Add blocked: the special tx event is delivered while holding the pool lock")
+	}
+
+	// Rigidity check: the special tx must actually be promoted to pending, not just
+	// accepted into the queue. A regression that skipped promotion would let this test
+	// pass trivially (Add returns, the lock is free) while the tx never reached pending.
+	promoted := false
+	deadline := time.Now().Add(2 * time.Second)
+	for !promoted && time.Now().Before(deadline) {
+		pending, _ := pool.Content()
+		for _, txs := range pending {
+			for _, ptx := range txs {
+				if ptx.Hash() == specialTx.Hash() {
+					promoted = true
+					break
+				}
+			}
+			if promoted {
+				break
+			}
+		}
+		if !promoted {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if !promoted {
+		t.Fatal("special tx was accepted but never promoted to pending")
+	}
+
+	usable := make(chan struct{})
+	go func() {
+		defer close(usable)
+		pool.Stats()
+	}()
+	select {
+	case <-usable:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pool lock still held after promoting a special tx")
+	}
+}
+
+// TestSpecialTxEventDeliveredInSingleReorg locks in the enqueue-before-request
+// ordering: queueTxEvent rendezvouses with scheduleReorgLoop while the pool lock
+// is held, so the event is already batched when Add requests the promotion and a
+// single reorg run announces it. A regression that decoupled the two would split
+// this into an event-only run plus a second maintenance run.
+func TestSpecialTxEventDeliveredInSingleReorg(t *testing.T) {
+	pool, key := setupPool()
+	defer pool.Close()
+
+	pool.SetSigner(func(common.Address) bool { return true })
+	testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1_000_000_000_000_000_000))
+
+	// Draining subscriber, buffered so runReorg never blocks on the send.
+	events := make(chan core.NewTxsEvent, 4)
+	sub := pool.SubscribeTransactions(events, false)
+	defer sub.Unsubscribe()
+
+	gasPrice := new(big.Int).SetUint64(common.DefaultMinGasPrice + 1)
+	tx, err := types.SignTx(types.NewTransaction(0, common.BlockSignersBinary, big.NewInt(1), 100000, gasPrice, nil), types.HomesteadSigner{}, key)
+	if err != nil {
+		t.Fatalf("failed to sign special tx: %v", err)
+	}
+	if !tx.IsSpecialTransaction() {
+		t.Fatal("test setup: transaction is not special")
+	}
+
+	// Sync add: runReorg sends the announcement before closing its done channel.
+	if err := pool.Add([]*types.Transaction{tx}, true)[0]; err != nil {
+		t.Fatalf("failed to add special tx: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if len(ev.Txs) != 1 || ev.Txs[0].Hash() != tx.Hash() {
+			t.Fatalf("unexpected event: got %d txs, first hash %v want %v", len(ev.Txs), ev.Txs[0].Hash(), tx.Hash())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("special tx event was not delivered by the requested reorg run")
+	}
+	if err := validateEvents(events, 0); err != nil {
+		t.Fatalf("special tx announced by more than one reorg run: %v", err)
+	}
+}


### PR DESCRIPTION
# Proposed changes

## Summary

`promoteSpecialTx` called `txFeed.Send` while holding `pool.mu`. `event.Feed.Send` is a synchronous rendezvous: it blocks until every subscriber accepts the event, so a subscriber that stopped draining (e.g. the transaction broadcast loop wedged behind a stalled peer) pinned the pool write lock indefinitely and froze the whole node — `Add`/`Pending` pile up, `runReorg` never runs, block import stops while RPC stays responsive.

This commit routes the special transaction event through `queueTxEvent` like every other path in `add()`, so `runReorg` delivers it after releasing the lock.

## Why only special transactions were affected

Normal transactions never send events while holding the pool lock: they are enqueued (`enqueueTx`) or announced via `queueTxEvent`, promoted to pending by the background `runReorg`, and only then announced through `txFeed.Send` after `pool.mu.Unlock()`. Only the special-transaction fast path in `add()` promoted synchronously and sent on the feed under the lock, which is why the freeze only manifested on special (block-signing/randomize) transactions.

## Why the change is safe

The event is enqueued on an unbuffered channel while the lock is held, but the rendezvous is with `scheduleReorgLoop` (fast, independent of subscribers); the event is batched before the promote request arrives, so a single reorg run carries both — no extra event-only run. Promotion semantics, error returns (`ErrDuplicateSpecialTransaction`, `ErrSpecialTxCostOverflow`), totalcost accounting, and pending visibility are unchanged.

## Compatibility

No consensus, RPC, or wire-protocol impact and no migration needed. The only observable change is *when* a promoted special transaction's `NewTxsEvent` is emitted: same reorg run, but after the lock is released — identical to the regular transaction path, so tx event subscribers see the same ordering.

## Tests

- `TestSpecialTxPromotionDoesNotBlockOnTxFeed`: a stalled subscriber no longer blocks `Add`; the transaction is still promoted to pending and the pool lock stays usable.
- `TestSpecialTxEventDeliveredInSingleReorg`: the special transaction event is announced exactly once, by the requested reorg run.

## Scope

This PR fixes the pool-side amplifier of the mainnet freeze only. The upstream causes (peer broadcast stall and shutdown hang on a wedged subscriber) are intentionally excluded and tracked separately.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [X] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
