### PR TITLE
fix: split blocks at gap in import

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1596,17 +1596,27 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	for i, result := range results {
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.body())
 	}
-	if index, err := d.blockchain.InsertChain(blocks); err != nil {
-		if index < len(results) {
-			log.Debug("Downloaded item processing failed", "number", results[index].Header.Number, "hash", results[index].Header.Hash(), "err", err)
-		} else {
-			// The InsertChain method in blockchain.go will sometimes return an out-of-bounds index,
-			// when it needs to preprocess blocks to import a sidechain.
-			// The importer will put together a new list of blocks to import, which is a superset
-			// of the blocks delivered from the downloader, and the indexing will be off.
-			log.Debug("Downloaded item processing failed on sidechain import", "index", index, "err", err)
+	// For XDPoS, the header verification of an epoch-switch block reads the
+	// snapshot stored at its gap block, and that snapshot is only written while
+	// the gap block itself is being executed (UpdateMasternodes). VerifyHeaders
+	// verifies the whole batch up-front (its results channel is fully buffered),
+	// so it would race ahead and try to verify the epoch-switch block before the
+	// gap block in the same batch has been executed, failing to find the snapshot.
+	// Split the batch right after each gap block so the gap block is executed -
+	// and its snapshot stored - before the following blocks are verified.
+	for _, segment := range d.splitBlocksAtGap(blocks) {
+		if index, err := d.blockchain.InsertChain(segment); err != nil {
+			if index < len(segment) {
+				log.Debug("Downloaded item processing failed", "number", segment[index].Number(), "hash", segment[index].Hash(), "err", err)
+			} else {
+				// The InsertChain method in blockchain.go will sometimes return an out-of-bounds index,
+				// when it needs to preprocess blocks to import a sidechain.
+				// The importer will put together a new list of blocks to import, which is a superset
+				// of the blocks delivered from the downloader, and the indexing will be off.
+				log.Debug("Downloaded item processing failed on sidechain import", "index", index, "err", err)
+			}
+			return fmt.Errorf("%w: %v", errInvalidChain, err)
 		}
-		return fmt.Errorf("%w: %v", errInvalidChain, err)
 	}
 	if d.handleProposedBlock != nil {
 		header := blocks[len(blocks)-1].Header()
@@ -1616,6 +1626,36 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 		}
 	}
 	return nil
+}
+
+// splitBlocksAtGap splits a contiguous batch of blocks into segments that each
+// end on a gap block (a block at offset Epoch-Gap within its epoch). The
+// snapshot used to verify the following epoch-switch block is stored when the
+// gap block is executed, so inserting one segment at a time guarantees the gap
+// block's snapshot exists before the next segment's headers are verified. For
+// non-XDPoS chains (or when there is nothing to split) the whole batch is
+// returned as a single segment.
+func (d *Downloader) splitBlocksAtGap(blocks []*types.Block) [][]*types.Block {
+	cfg := d.blockchain.Config()
+	if cfg == nil || cfg.XDPoS == nil || len(blocks) <= 1 {
+		return [][]*types.Block{blocks}
+	}
+	epoch, gap := cfg.XDPoS.Epoch, cfg.XDPoS.Gap
+	if epoch == 0 || gap == 0 || gap >= epoch {
+		return [][]*types.Block{blocks}
+	}
+
+	var segments [][]*types.Block
+	start := 0
+	for i, block := range blocks {
+		// Cut the batch right after each gap block, but never after the very last
+		// block (that would just create an empty trailing segment).
+		if block.NumberU64()%epoch == epoch-gap && i < len(blocks)-1 {
+			segments = append(segments, blocks[start:i+1])
+			start = i + 1
+		}
+	}
+	return append(segments, blocks[start:])
 }
 
 // processFastSyncContent takes fetch results from the queue and writes them to the


### PR DESCRIPTION

# Proposed changes

in order to fix fastsync snapshot err, when inserting a batch of blocks, it split the batch into multiple batches that do not contain gap block inside (except for boarder).

tested on a mainnet fast sync new node

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [x] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
