### PR TITLE
fix(cicd): derive network ID from genesis

### DIFF
--- a/cicd/devnet/start.sh
+++ b/cicd/devnet/start.sh
@@ -157,7 +157,7 @@ XDC ${config_arg} --ethstats ${netstats} \
 --gcmode ${gc_mode} --syncmode ${sync_mode} \
 --nat extip:${instance_ip} \
 --bootnodes ${bootnodes} \
---datadir /work/xdcchain --networkid 5551 \
+--datadir /work/xdcchain \
 --port $port --http --http-corsdomain "*" --http-addr 0.0.0.0 \
 --http-port $rpc_port \
 --http-api db,eth,net,txpool,web3,XDPoS \

--- a/cicd/mainnet/start.sh
+++ b/cicd/mainnet/start.sh
@@ -126,7 +126,7 @@ XDC --ethstats ${netstats} \
     --gcmode ${gc_mode} --syncmode ${sync_mode} \
     --nat extip:${INSTANCE_IP} \
     --bootnodes ${bootnodes} \
-    --datadir /work/xdcchain --networkid 50 \
+    --datadir /work/xdcchain \
     --port $port --http --http-corsdomain "*" --http-addr 0.0.0.0 \
     --http-port $rpc_port \
     --http-api db,eth,net,txpool,web3,XDPoS \

--- a/cicd/testnet/start.sh
+++ b/cicd/testnet/start.sh
@@ -140,7 +140,7 @@ XDC --ethstats ${netstats} \
 --gcmode ${gc_mode} --syncmode ${sync_mode} \
 --nat extip:${INSTANCE_IP} \
 --bootnodes ${bootnodes} \
---datadir /work/xdcchain --networkid 51 \
+--datadir /work/xdcchain \
 --port $port --http --http-corsdomain "*" --http-addr 0.0.0.0 \
 --http-port $rpc_port \
 --http-api db,eth,net,txpool,web3,XDPoS \


### PR DESCRIPTION
# Proposed changes

Remove the redundant `--networkid` arguments from the mainnet, testnet, and devnet container start scripts.

The scripts initialize their data directories from `genesis.json`, and the node already derives a zero-valued network ID from the stored chain ID. Keeping the values in the scripts duplicates the genesis configuration and allows them to drift apart.

Addresses #1887.

## Types of changes

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [ ] test: Adding missing tests or correcting existing tests

## Impacted Components

- [ ] Consensus
- [ ] Account
- [x] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Verification

- `bash -n cicd/mainnet/start.sh cicd/testnet/start.sh cicd/devnet/start.sh`
- `make all quick-test test tidy generate`
- Initialized three temporary data directories from `genesis/mainnet.json`, `genesis/testnet.json`, and `genesis/devnet.json`.
- Started each built node without `--networkid` and queried `net_version`: mainnet returned `50`, testnet `51`, and devnet `5551`.

`make lint` still reports the same 75 pre-existing findings as `main`; this shell-only change introduces no new lint findings.

## End-to-end test plan

1. Build the XDC container for each network.
2. Start it with a fresh volume and the corresponding `genesis.json`.
3. Query `net_version` and confirm it matches the genesis chain ID.
4. Restart the container with the initialized volume and confirm it reports the same network ID and resumes from the existing database.

## Checklist

- [x] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [x] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
