### PR TITLE
test(consensus): fix flaky TestIsYourTurnConsensusV2CrossConfig 

### DIFF
--- a/consensus/tests/engine_v2_tests/authorised_masternode_test.go
+++ b/consensus/tests/engine_v2_tests/authorised_masternode_test.go
@@ -101,19 +101,33 @@ func TestIsYourTurnConsensusV2CrossConfig(t *testing.T) {
 	err := blockchain.InsertBlock(currentBlock)
 	adaptor.EngineV2.SetNewRoundFaker(blockchain, types.Round(10), false)
 	assert.Nil(t, err)
-	// after first mine period
-	time.Sleep(time.Duration(firstMinePeriod) * time.Second)
+
+	// YourTurn derives the mine period from the config for the current round
+	// (round 10 -> MinePeriod 3s) via Config(currentRound). Note that
+	// UpdateParams only repoints the engine's CurrentConfig, so the
+	// blockchain-level CurrentConfig stays at the pre-switch value (2s); look
+	// up the switched-to config by round instead.
+	newMinePeriod := blockchain.Config().XDPoS.V2.Config(uint64(10)).MinePeriod
+	if newMinePeriod <= firstMinePeriod {
+		t.Fatalf("test setup requires a larger mine period after the config switch, got first=%d new=%d", firstMinePeriod, newMinePeriod)
+	}
+
+	// Wait just past the previous mine period but keep waitedTime strictly
+	// below the switched-to config's mine period so YourTurn reports false.
+	// Sleeping the full firstMinePeriod is unsafe: YourTurn compares against
+	// Unix-second granularity, and rounding can push waitedTime up to
+	// newMinePeriod and flip the result to true.
+	time.Sleep(time.Duration(firstMinePeriod-1) * time.Second)
 	isYourTurn, err := adaptor.YourTurn(blockchain, currentBlockHeader, common.HexToAddress("xdc703c4b2bD70c169f5717101CaeE543299Fc946C7"))
 	assert.Nil(t, err)
 	assert.False(t, isYourTurn)
 
 	adaptor.UpdateParams(currentBlockHeader) // it will be triggered automatically on the real code by other process
 
-	// after new mine period
-	secondMinePeriod := blockchain.Config().XDPoS.V2.CurrentConfig.MinePeriod
-
-	// YourTurn uses Unix-second granularity; add a small buffer to avoid edge-time flakiness.
-	time.Sleep(time.Duration(secondMinePeriod-firstMinePeriod+1) * time.Second)
+	// Wait until waitedTime is comfortably past the switched-to config's mine
+	// period (Unix-second granularity, so add a buffer) so YourTurn reports
+	// true.
+	time.Sleep(time.Duration(newMinePeriod) * time.Second)
 	isYourTurn, err = adaptor.YourTurn(blockchain, currentBlockHeader, common.HexToAddress("xdc703c4b2bD70c169f5717101CaeE543299Fc946C7"))
 	assert.Nil(t, err)
 	assert.True(t, isYourTurn)


### PR DESCRIPTION
# Proposed changes

`TestIsYourTurnConsensusV2CrossConfig` was flaky in CI, intermittently failing on the first `assert.False` with "Should be false". The failure is a timing/rounding bug in the test, not a consensus-logic bug.

https://github.com/XinFinOrg/XDPoSChain/actions/runs/32529339583/job/96918041990?pr=2520

```text
2026-08-21T21:44:49.8937306Z --- FAIL: TestIsYourTurnConsensusV2CrossConfig (3.33s)
2026-08-21T21:44:49.8937658Z     authorised_masternode_test.go:108: 
2026-08-21T21:44:49.8939392Z         	Error Trace:	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/consensus/tests/engine_v2_tests/authorised_masternode_test.go:108
2026-08-21T21:44:49.8939702Z         	Error:      	Should be false
2026-08-21T21:44:49.8940350Z         	Test:       	TestIsYourTurnConsensusV2CrossConfig
```

## Root cause

`YourTurn` derives the mine period via `Config(currentRound)`. Once the test advances the round to 10, that resolves to the switched-to config (`UnitTestV2Configs[10]`, MinePeriod = 3s) even before `UpdateParams` runs. The check compares `now.Unix() - parent.Time` against that period using Unix-second granularity, and `parent.Time` is floor-rounded. On slower CI machines `InsertBlock(910)` can straddle a second boundary, pushing the first `waitedTime` up to 3 (>= MinePeriod), so `YourTurn` returns true and the `assert.False` fails — matching the CI log `[yourturn] Yes ... round=10`. Separately, `UpdateParams` only repoints the engine's `CurrentConfig`, so reading `MinePeriod` from `blockchain.Config()` stays at the pre-switch value (2s), making the second sleep under-computed.

## Fix

Look up the switched-to mine period by round (`Config(10)` -> 3s) and sanity-check it is larger than the previous one. Sleep `firstMinePeriod - 1` before the first `YourTurn` so `waitedTime` stays strictly below the new period (reports false), and sleep `newMinePeriod` before the second `YourTurn` so `waitedTime` is comfortably past it (reports true).

## Verification

The patched test passes consistently (ran multiple times), sibling tests `TestIsAuthorisedMNForConsensusV2` and `TestIsYourTurnConsensusV2` pass, and `gofmt`, `goimports`, `go vet`, `make tidy`, and `make quick-test` are all clean. The original CI failure was reproduced on unpatched `dev-upgrade` by simulating the same second-boundary timing, confirming the fix addresses the real root cause.

## Compatibility

Test-only change; no consensus, RPC, or network-format impact.

## Types of changes

What types of changes does your code introduce to XDC network?
_Put an `✅` in the boxes that apply_

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to CI configuration files and scripts
- [ ] chore: Changes that don't change source code or tests
- [ ] docs: Documentation only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] revert: Revert something
- [ ] style: Changes that do not affect the meaning of the code
- [X] test: Adding missing tests or correcting existing tests

## Impacted Components

Which parts of the codebase does this PR touch?
_Put an `✅` in the boxes that apply_

- [ ] Consensus
- [ ] Account
- [ ] Network
- [ ] Geth
- [ ] Smart Contract
- [ ] External components
- [ ] Not sure (Please specify below)

## Checklist

_Put an `✅` in the boxes once you have confirmed below actions (or provide reasons on not doing so) that_

- [ ] This PR has sufficient test coverage (unit/integration test) OR I have provided reason in the PR description for not having test coverage
- [ ] Tested on a private network from the genesis block and monitored the chain operating correctly for multiple epochs.
- [ ] Provide an end-to-end test plan in the PR description on how to manually test it on the devnet/testnet.
- [ ] Tested the backwards compatibility.
- [ ] Tested with XDC nodes running this version co-exist with those running the previous version.
- [ ] Relevant documentation has been updated as part of this PR
- [ ] N/A
