### PR TITLE
feat(core/txpool,eth): track already-known local transactions on resubmit

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -364,13 +364,16 @@ func (p *TxPool) SetLocalTracker(tracker LocalTracker) {
 }
 
 // AddLocal enqueues a single local transaction into the pool and return the
-// original error. The transaction will be tracked if it was accepted or
-// rejected for a temporary reason, allowing the local tracker to implement
-// re-journal and re-submit flows.
+// original error. The transaction will be tracked if it was accepted, already
+// known to the pool, or rejected for a temporary reason, allowing the local
+// tracker to implement re-journal and re-submit flows.
 func (p *TxPool) AddLocal(tx *types.Transaction, sync bool) error {
 	err := p.Add([]*types.Transaction{tx}, sync)[0]
 	if p.localTracker != nil {
-		if err == nil || p.localTracker.IsRetryableReject(err) {
+		// An already-known transaction is in the desired state: it lost a race
+		// to a concurrent submission of the same transaction, so track it to
+		// keep the local resubmit protection, but still surface the error.
+		if err == nil || p.localTracker.IsRetryableReject(err) || errors.Is(err, ErrAlreadyKnown) {
 			p.localTracker.Track(tx)
 		}
 	}

--- a/core/txpool/txpool_local_test.go
+++ b/core/txpool/txpool_local_test.go
@@ -283,6 +283,38 @@ func TestAddLocalTracksTemporaryRejectedTransaction(t *testing.T) {
 	}
 }
 
+func TestAddLocalTracksAlreadyKnownTransaction(t *testing.T) {
+	events := []string{}
+	tracker := &testLocalTracker{events: &events}
+	subpool := &testSubPool{
+		events:  &events,
+		addErrs: []error{ErrAlreadyKnown},
+	}
+
+	pool, err := New(0, testChain{}, []SubPool{subpool})
+	if err != nil {
+		t.Fatalf("failed to create txpool: %v", err)
+	}
+	defer pool.Close()
+
+	pool.SetLocalTracker(tracker)
+
+	tx := types.NewTransaction(0, common.Address{0x1}, big.NewInt(1), 21000, big.NewInt(1), nil)
+	err = pool.AddLocal(tx, true)
+	if !errors.Is(err, ErrAlreadyKnown) {
+		t.Fatalf("unexpected error: have %v, want %v", err, ErrAlreadyKnown)
+	}
+
+	// The transaction is in the desired state (already in the pool), so it
+	// must still be tracked for the local resubmit flow.
+	if !reflect.DeepEqual(tracker.tracked, []common.Hash{tx.Hash()}) {
+		t.Fatalf("tracker should receive already-known local tx")
+	}
+	if !reflect.DeepEqual(events, []string{"add", "track"}) {
+		t.Fatalf("unexpected call order: have %v", events)
+	}
+}
+
 func TestAddLocalTemporaryRejectWithoutTrackerReturnsError(t *testing.T) {
 	events := []string{}
 	subpool := &testSubPool{

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -318,16 +318,17 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	if b.eth.localTxTracker == nil {
 		return err
 	}
-	// If the transaction fails with an error indicating it is invalid, or if there is
-	// very little chance it will be accepted later (e.g., the gas price is below the
-	// configured minimum, or the sender has insufficient funds to cover the cost),
-	// propagate the error to the user.
+	// Track the transaction unless it was permanently rejected. A transaction
+	// is tracked when it is accepted, temporarily rejected, or already known
+	// to the pool. An already-known transaction is in the desired state (it
+	// lost a race to a concurrent submission), so we still track it, but the
+	// error is surfaced to the caller to match upstream go-ethereum semantics.
 	if err != nil && !locals.IsTemporaryReject(err) {
+		if errors.Is(err, txpool.ErrAlreadyKnown) {
+			b.eth.localTxTracker.Track(signedTx)
+		}
 		return err
 	}
-	// No error will be returned to user if the transaction fails with a temporary
-	// error and might be accepted later (e.g., the transaction pool is full).
-	// Locally submitted transactions will be resubmitted later via the local tracker.
 	b.eth.localTxTracker.Track(signedTx)
 	return nil
 }

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -230,3 +230,28 @@ func TestSendTxWithLocalPermanentErrorNotTracked(t *testing.T) {
 		t.Fatalf("unexpected tracked tx count: have %d, want 0", tracked)
 	}
 }
+
+func TestSendTxTracksAlreadyKnown(t *testing.T) {
+	b := initBackend(t, true)
+	if b.eth.localTxTracker == nil {
+		t.Fatal("expected local tx tracker to be configured")
+	}
+	tx := makeTx(0, nil, nil, key)
+	// Simulate the transaction reaching the pool via gossip: a plain pool add
+	// does not involve the local tracker.
+	if err := b.eth.txPool.Add([]*types.Transaction{tx}, true)[0]; err != nil {
+		t.Fatalf("failed to seed the pool with the transaction: %v", err)
+	}
+	if tracked := reflect.ValueOf(b.eth.localTxTracker).Elem().FieldByName("all").Len(); tracked != 0 {
+		t.Fatalf("unexpected tracked tx count before resubmission: have %d, want 0", tracked)
+	}
+	// Submitting the same transaction locally must report ErrAlreadyKnown to
+	// the submitter while still tracking it for the local resubmit flow.
+	err := b.SendTx(context.Background(), tx)
+	if !errors.Is(err, txpool.ErrAlreadyKnown) {
+		t.Fatalf("unexpected error, want: %v, got: %v", txpool.ErrAlreadyKnown, err)
+	}
+	if tracked := reflect.ValueOf(b.eth.localTxTracker).Elem().FieldByName("all").Len(); tracked != 1 {
+		t.Fatalf("unexpected tracked tx count: have %d, want 1", tracked)
+	}
+}


### PR DESCRIPTION
## Summary

A local transaction that reaches the pool through a concurrent submission
(peer gossip, wallet retry, or a parallel RPC endpoint) returns
`txpool.ErrAlreadyKnown` from `TxPool.Add`, but is not placed in the desired
local-tracking state: the local tracker only starts on a successful admission.
If that transaction is later evicted, it loses its local resubmit and journal
protection and silently disappears.

This PR treats `ErrAlreadyKnown` as the desired state on the initial admission
path. `AddLocal` and `EthAPIBackend.SendTx` still surface the error to the
caller (matching upstream go-ethereum semantics) but now also register the
transaction with the local tracker so it keeps the resubmit and journal
guarantees.

## Background

The resubmit loop (`TxTracker.loop` -> `TxTracker.recheck`) already retains
already-known transactions in the tracked set, because `recheck` skips
transactions still present in the pool (`pool.Has`). The only gap was on the
initial admission path, which this PR closes.

## Changes

- `core/txpool/txpool.go`: `AddLocal` tracks the transaction when it is
  accepted, temporarily rejected, or already known to the pool.
- `eth/api_backend.go`: `SendTx` tracks the transaction unless it is
  permanently rejected; an already-known transaction is still tracked while
  the error is surfaced to the caller.
- Tests: `TestAddLocalTracksAlreadyKnownTransaction`,
  `TestSendTxTracksAlreadyKnown`.

## Test plan

- `go test ./core/txpool/ -run TestAddLocal`
- `go test ./eth/ -run TestSendTx`

## Risk

Low. The change only adds tracking for an already-known transaction and
preserves the original error returned to the caller; the resubmit path was
already consistent.
