### PR TITLE
fix(core/txpool/locals): nil journal writer before checking close error #35300

### DIFF
--- a/core/txpool/locals/journal.go
+++ b/core/txpool/locals/journal.go
@@ -117,10 +117,11 @@ func (journal *journal) load(add func([]*types.Transaction) []error) error {
 
 func (journal *journal) setupWriter() error {
 	if journal.writer != nil {
-		if err := journal.writer.Close(); err != nil {
+		err := journal.writer.Close()
+		journal.writer = nil
+		if err != nil {
 			return err
 		}
-		journal.writer = nil
 	}
 
 	// Re-open the journal file for appending
@@ -150,10 +151,11 @@ func (journal *journal) insert(tx *types.Transaction) error {
 func (journal *journal) rotate(all map[common.Address]types.Transactions) error {
 	// Close the current journal (if any is open)
 	if journal.writer != nil {
-		if err := journal.writer.Close(); err != nil {
+		err := journal.writer.Close()
+		journal.writer = nil
+		if err != nil {
 			return err
 		}
-		journal.writer = nil
 	}
 	// Generate a new journal with the contents of the current pool
 	replacement, err := os.OpenFile(journal.path+".new", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)


### PR DESCRIPTION
## Summary

- Clear `journal.writer` immediately after `Close()` in `setupWriter` and `rotate`, before checking the returned error.
- Prevents leaving a stale file handle that could be reused if `Close()` fails.

Ref: #35300
