### PR TITLE
fix(core/txpool/locals): close journal under lock in Stop to fix data race #35096

### DIFF
--- a/core/txpool/locals/tx_tracker.go
+++ b/core/txpool/locals/tx_tracker.go
@@ -180,7 +180,6 @@ func (tracker *TxTracker) Start() error {
 		}); err != nil {
 			log.Warn("Failed to load transaction journal", "err", err)
 		}
-
 		// Ensure the writer is ready before Start returns so Track/TrackAll can
 		// persist transactions immediately.
 		if err := tracker.journal.setupWriter(); err != nil {
@@ -197,13 +196,17 @@ func (tracker *TxTracker) Start() error {
 func (tracker *TxTracker) Stop() error {
 	close(tracker.shutdownCh)
 	tracker.wg.Wait()
-	return nil
+
+	tracker.mu.Lock()
+	var err error
+	if tracker.journal != nil {
+		err = tracker.journal.close()
+	}
+	tracker.mu.Unlock()
+	return err
 }
 
 func (tracker *TxTracker) loop() {
-	if tracker.journal != nil {
-		defer tracker.journal.close()
-	}
 	var (
 		lastJournal = time.Now()
 		timer       = time.NewTimer(10 * time.Second) // Do initial check after 10 seconds, do rechecks more seldom.


### PR DESCRIPTION
## Description

The local tx tracker's journal was previously closed inside the `loop()` goroutine via a `defer`. Because the journal can still be accessed concurrently by `Track`/`TrackAll` during shutdown, this created a data race on the underlying journal writer.

This change moves `journal.close()` out of the goroutine and into `Stop()`, where it runs deterministically after `tracker.wg.Wait()` and is guarded by `tracker.mu`.

Note: on `dev-upgrade` the load/setupWriter half of upstream PR #35096 was already present in `Start()` (journal is loaded and the writer is set up before the goroutine starts), so only the close-relocation half is ported here.

Ref: #35096
