### PR TITLE
refactor(eth): move initial transaction sync off the peer handshake path

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -105,6 +105,11 @@ type ProtocolManager struct {
 	// and processing
 	wg sync.WaitGroup
 
+	// stopMu guards stopping, which gates goroutines started off the peer
+	// handler path so none is added to wg once Stop began waiting on it
+	stopMu   sync.RWMutex
+	stopping bool
+
 	// Test fields or hooks
 	broadcastTxAnnouncesOnly bool // Testing field, disable transaction propagation
 
@@ -256,7 +261,9 @@ func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 			peer := pm.newPeer(int(version), p, rw, pm.txpool.Get)
 			select {
 			case pm.newPeerCh <- peer:
-				pm.wg.Add(1)
+				if !pm.enterTracked() {
+					return p2p.DiscQuitting
+				}
 				defer pm.wg.Done()
 				return pm.handle(peer)
 			case <-pm.quitSync:
@@ -371,9 +378,42 @@ func (pm *ProtocolManager) Stop() {
 	pm.peers.Close()
 
 	// Wait for all peer handler goroutines and the loops to come down.
+	// Flip the gate first: a peer handshake racing with the shutdown must not
+	// add to the wait group once it is being waited on.
+	pm.stopMu.Lock()
+	pm.stopping = true
+	pm.stopMu.Unlock()
 	pm.wg.Wait()
 
 	log.Info("Ethereum protocol stopped")
+}
+
+// goTracked runs fn in a goroutine tracked by pm.wg, reporting whether it was
+// started. Work requested after Stop began waiting is dropped instead, since
+// growing the wait group at that point races with the wait itself.
+func (pm *ProtocolManager) goTracked(fn func()) bool {
+	if !pm.enterTracked() {
+		return false
+	}
+	go func() {
+		defer pm.wg.Done()
+		fn()
+	}()
+	return true
+}
+
+// enterTracked adds the caller to pm.wg, reporting whether it was admitted. A
+// caller that was not must return without calling pm.wg.Done, since Stop is
+// already waiting on the group and growing it now races with that wait.
+func (pm *ProtocolManager) enterTracked() bool {
+	pm.stopMu.RLock()
+	defer pm.stopMu.RUnlock()
+
+	if pm.stopping {
+		return false
+	}
+	pm.wg.Add(1)
+	return true
 }
 
 func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter, getPooledTx func(hash common.Hash) *types.Transaction) *peer {
@@ -418,8 +458,11 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	}
 	p.Log().Info("Register peer", "nodeid", p.ID().String(), "version", p.version, "addr", p.RemoteAddr())
 	// Propagate existing transactions. new transactions appearing
-	// after this will be sent via broadcasts.
-	pm.syncTransactions(p)
+	// after this will be sent via broadcasts. Kept off the handshake path so a
+	// contended txpool cannot keep the peer out of its message loop.
+	pm.goTracked(func() {
+		pm.syncTransactions(p)
+	})
 
 	// If we're DAO hard-fork aware, validate any remote peer with regard to the hard-fork
 	if daoBlock := pm.blockchain.Config().DAOForkBlock; daoBlock != nil {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -925,3 +925,287 @@ func TestRegisterDownloaderPeerUndoesRacedRemoval(t *testing.T) {
 	}
 	pm.downloader.UnregisterPeer(p.id)
 }
+
+// TestPeerServesRequestsWhileTxPoolIsBlocked ensures a contended transaction pool cannot
+// keep a freshly registered peer out of its message loop. When the initial transaction
+// sync ran on the handshake path, a stalled Pending call left every peer unable to answer
+// requests, which timed out the downloader and froze the node. Both the legacy (xdc/100)
+// txsync path and the xdc/165+ announcement path are exercised.
+func TestPeerServesRequestsWhileTxPoolIsBlocked(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		version int
+		seed    types.Transactions // txs pre-loaded into the pool before pm startup
+	}{
+		{
+			name:    "legacy-xdc100",
+			version: xdc100,
+			seed: types.Transactions{
+				newTestTransaction(testBankKey, 0, 100),
+				newTestTransaction(testBankKey, 1, 100),
+			},
+		},
+		{
+			name:    "announce-xdc165",
+			version: xdc165,
+			seed: types.Transactions{
+				newTestTransaction(testBankKey, 0, 100),
+				newTestTransaction(testBankKey, 1, 100),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			base := newTestTxPool()
+			if len(tt.seed) > 0 {
+				base.Add(tt.seed, false)
+			}
+			pool := &blockingTxPool{testTxPool: base, release: make(chan struct{})}
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(pool.release) }) }
+
+			pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+			if err != nil {
+				t.Fatalf("failed to create protocol manager: %v", err)
+			}
+			defer pm.Stop()
+			defer release()
+
+			peer, _ := newTestPeer("peer", tt.version, pm, true)
+			defer peer.close()
+
+			header := pm.blockchain.GetBlockByNumber(1).Header()
+
+			// MsgPipe is unbuffered, so the send blocks too until the peer reads it.
+			errc := make(chan error, 1)
+			go func() {
+				if err := p2p.Send(peer.app, GetBlockHeadersMsg, &getBlockHeadersData{Origin: hashOrNumber{Number: 1}, Amount: 1}); err != nil {
+					errc <- err
+					return
+				}
+				errc <- p2p.ExpectMsg(peer.app, BlockHeadersMsg, []*types.Header{header})
+			}()
+			select {
+			case err := <-errc:
+				if err != nil {
+					t.Fatalf("header request failed: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("peer never answered while the txpool was blocked")
+			}
+			// The deferred initial sync must still run to completion once the pool
+			// unblocks: xdc/165+ announces the pending hashes, the legacy path
+			// delivers the transactions themselves through the txsync loop.
+			release()
+
+			want, msg := any(types.Transactions(tt.seed)), uint64(TransactionMsg)
+			if tt.version >= xdc165 {
+				want, msg = []common.Hash{tt.seed[0].Hash(), tt.seed[1].Hash()}, NewPooledTransactionHashesMsg
+			}
+			delivered := make(chan error, 1)
+			go func() {
+				delivered <- p2p.ExpectMsg(peer.app, msg, want)
+			}()
+			select {
+			case err := <-delivered:
+				if err != nil {
+					t.Fatalf("initial sync delivery failed: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("initial sync never delivered the pending transactions")
+			}
+		})
+	}
+}
+
+// TestSyncTransactionsSkipsKnownTxs ensures the initial transaction sync does not echo a
+// transaction back to the peer it was received from. Because the sync now runs concurrently
+// with the peer message loop, a transaction sent by the peer can be picked up by the pending
+// snapshot; it must be filtered against the peer's known transaction set before sending.
+func TestSyncTransactionsSkipsKnownTxs(t *testing.T) {
+	pool := newTestTxPool()
+	tx := newTestTransaction(testBankKey, 0, 100)
+	pool.Add([]*types.Transaction{tx}, false)
+
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	defer pm.Stop()
+
+	// A peer that already sent us the pooled transaction must not get it back. The
+	// announce loop is intentionally not running, so an attempted echo would block
+	// on the unbuffered p.txAnnounce handoff in syncTransactions until the timeout
+	// below trips.
+	//
+	// Note this guard relies on p.txAnnounce being unbuffered (see newPeer): a
+	// buffered channel would swallow the echo and the timeout would never fire.
+	// The capacity is pinned here so buffering it later fails this test loudly
+	// instead of silently voiding the echo detection.
+	_, net := p2p.MsgPipe()
+	id := randomPeerID(t)
+	known := pm.newPeer(xdc165, p2p.NewPeer(id, "known", nil), net, pm.txpool.Get)
+	if cap(known.txAnnounce) != 0 {
+		t.Fatalf("txAnnounce must stay unbuffered for the echo guard, capacity %d", cap(known.txAnnounce))
+	}
+	known.MarkTransaction(tx.Hash())
+	defer known.close()
+
+	done := make(chan struct{})
+	go func() {
+		pm.syncTransactions(known)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial transaction sync echoed a transaction the peer already has")
+	}
+
+	// Control: a peer without prior knowledge of the transaction must still receive
+	// its announcement.
+	app, net := p2p.MsgPipe()
+	id2 := randomPeerID(t)
+	fresh := pm.newPeer(xdc165, p2p.NewPeer(id2, "fresh", nil), net, pm.txpool.Get)
+	go fresh.announceTransactions()
+	defer fresh.close()
+
+	go pm.syncTransactions(fresh)
+	errc := make(chan error, 1)
+	go func() {
+		errc <- p2p.ExpectMsg(app, NewPooledTransactionHashesMsg, []common.Hash{tx.Hash()})
+	}()
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("initial sync announcement failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial sync never announced the pending transaction")
+	}
+}
+
+// TestTrackedGateClosesOnShutdown covers the gate that keeps pm.wg.Add out of the
+// window in which Stop waits on the group. Without it, a peer handshake racing
+// with the shutdown panics with "WaitGroup misuse: Add called concurrently with
+// Wait".
+func TestTrackedGateClosesOnShutdown(t *testing.T) {
+	pm := &ProtocolManager{}
+
+	if !pm.enterTracked() {
+		t.Fatal("enterTracked refused entry before shutdown")
+	}
+	pm.wg.Done()
+
+	ran := make(chan struct{})
+	if !pm.goTracked(func() { close(ran) }) {
+		t.Fatal("goTracked refused to start work before shutdown")
+	}
+	select {
+	case <-ran:
+	case <-time.After(time.Second):
+		t.Fatal("goTracked did not run the work it accepted")
+	}
+	pm.wg.Wait()
+
+	pm.stopMu.Lock()
+	pm.stopping = true
+	pm.stopMu.Unlock()
+
+	if pm.enterTracked() {
+		pm.wg.Done()
+		t.Fatal("enterTracked admitted a caller after shutdown began")
+	}
+	started := make(chan struct{})
+	if pm.goTracked(func() { close(started) }) {
+		t.Fatal("goTracked started work after shutdown began")
+	}
+	// The work must not be running in the background either: nothing was added
+	// to the wait group, so Stop would not wait for it.
+	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-started:
+		t.Fatal("goTracked ran the work it reported as rejected")
+	default:
+	}
+	// The gate must leave the group balanced, otherwise Stop blocks forever.
+	pm.wg.Wait()
+}
+
+// TestProtocolManagerStopWaitsForInitialTxScan pins the shutdown contract of
+// the asynchronous initial transaction sync: once a sync has entered the
+// pool's Pending scan, Stop must stay blocked until the scan returns, and the
+// sync must then abandon delivery instead of resolving or sending
+// transactions after the protocol manager has stopped. On the handshake-path
+// sync this test fails from the other side: a wedged pool stalled the peer
+// handler, Stop did not wait for the scan, and the snapshot was delivered
+// regardless of the shutdown.
+func TestProtocolManagerStopWaitsForInitialTxScan(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		version int
+	}{
+		{name: "legacy-xdc100", version: xdc100},
+		{name: "announce-xdc165", version: xdc165},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := &stalledTxPool{
+				testTxPool: newTestTxPool(),
+				blocked:    make(chan struct{}),
+				entered:    make(chan struct{}),
+				resolver:   &resolveCountingResolver{},
+			}
+			pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+			if err != nil {
+				t.Fatalf("failed to create protocol manager: %v", err)
+			}
+
+			peer, _ := newTestPeer("stopping", tt.version, pm, true)
+			defer peer.close()
+			// Close the pipe on cleanup so the lingering reader of the silence
+			// check below and the peer's message loop are released.
+			defer peer.app.Close()
+			// A failing case must not leave the Stop goroutine and the sync
+			// parked inside the pool scan behind.
+			var releaseOnce sync.Once
+			defer releaseOnce.Do(func() { close(pool.blocked) })
+
+			// Wait until the initial sync is parked inside the pool's Pending
+			// scan before initiating shutdown.
+			select {
+			case <-pool.entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("initial transaction sync never entered Pending")
+			}
+
+			stopped := make(chan struct{})
+			go func() {
+				defer close(stopped)
+				pm.Stop()
+			}()
+
+			// The sync is tracked by the protocol wait group and Pending cannot
+			// be cancelled, so Stop must stay blocked while the scan is in
+			// flight instead of declaring the protocol stopped with a live
+			// transaction-pool reader.
+			select {
+			case <-stopped:
+				t.Fatal("Stop returned while the initial sync was blocked in Pending")
+			case <-time.After(500 * time.Millisecond):
+			}
+
+			// Release the scan. The sync must observe the shutdown and abandon
+			// delivery: nothing may be resolved for the legacy path, and no
+			// announcement may reach the wire for xdc/165+.
+			releaseOnce.Do(func() { close(pool.blocked) })
+			select {
+			case <-stopped:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Stop did not complete after the pending scan was released")
+			}
+			if calls := pool.resolver.calls.Load(); calls != 0 {
+				t.Fatalf("post-scan sync resolved %d transactions after shutdown", calls)
+			}
+			expectNoMsg(t, peer.app, 500*time.Millisecond)
+		})
+	}
+}

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -52,10 +52,25 @@ var (
 	testBank       = crypto.PubkeyToAddress(testBankKey.PublicKey)
 )
 
+func randomPeerID(t *testing.T) enode.ID {
+	t.Helper()
+	var id enode.ID
+	if _, err := rand.Read(id[:]); err != nil {
+		t.Fatalf("failed to generate peer ID: %v", err)
+	}
+	return id
+}
+
 // newTestProtocolManager creates a new protocol manager for testing purposes,
 // with the given number of blocks already known, and potential notification
 // channels for different events.
 func newTestProtocolManager(mode downloader.SyncMode, blocks int, generator func(int, *core.BlockGen), newtx chan<- []*types.Transaction) (*ProtocolManager, ethdb.Database, error) {
+	return newTestProtocolManagerWithTxPool(mode, blocks, generator, &testTxPool{added: newtx, pool: make(map[common.Hash]*types.Transaction)})
+}
+
+// newTestProtocolManagerWithTxPool is newTestProtocolManager with a caller supplied
+// transaction pool.
+func newTestProtocolManagerWithTxPool(mode downloader.SyncMode, blocks int, generator func(int, *core.BlockGen), pool txPool) (*ProtocolManager, ethdb.Database, error) {
 	var (
 		evmux  = new(event.TypeMux)
 		engine = ethash.NewFaker()
@@ -72,9 +87,7 @@ func newTestProtocolManager(mode downloader.SyncMode, blocks int, generator func
 		panic(err)
 	}
 
-	txpool := newTestTxPool()
-	txpool.added = newtx
-	pm, err := NewProtocolManager(gspec.Config, mode, ethconfig.Defaults.NetworkId, evmux, &testTxPool{added: newtx, pool: make(map[common.Hash]*types.Transaction)}, engine, blockchain, db)
+	pm, err := NewProtocolManager(gspec.Config, mode, ethconfig.Defaults.NetworkId, evmux, pool, engine, blockchain, db)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -182,6 +195,17 @@ func (p *testTxPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bo
 // send events to the given channel.
 func (p *testTxPool) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Subscription {
 	return p.SubscribeTransactions(ch, false)
+}
+
+// blockingTxPool stalls Pending until release is closed, modelling a contended pool.
+type blockingTxPool struct {
+	*testTxPool
+	release chan struct{}
+}
+
+func (p *blockingTxPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+	<-p.release
+	return p.testTxPool.Pending(filter)
 }
 
 // newTestTransaction create a new dummy transaction.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -50,16 +50,87 @@ type txsync struct {
 
 // syncTransactions starts sending all currently pending transactions to the given peer.
 func (pm *ProtocolManager) syncTransactions(p *peer) {
+	abandoned := func() bool {
+		select {
+		case <-p.term:
+			return true
+		case <-pm.quitSync:
+			return true
+		default:
+			return false
+		}
+	}
+	// Bail out if the peer was already dropped or the node began shutting down,
+	// so neither a removed peer nor a stopping node triggers a full, potentially
+	// expensive pool scan. The sync now runs concurrently with the message
+	// loop, so both can happen at any point.
+	if abandoned() {
+		return
+	}
+
 	// Assemble the set of transaction to broadcast or announce to the remote
 	// peer. Fun fact, this is quite an expensive operation as it needs to sort
 	// the transactions if the sorting is not cached yet. However, with a random
 	// order, insertions could overflow the non-executable queues and get dropped.
 	//
 	// TODO(karalabe): Figure out if we could get away with random order somehow
-	var txs types.Transactions
 	pending := pm.txpool.Pending(txpool.PendingFilter{})
+
+	// Abandon the sync if shutdown started or the peer was dropped while the
+	// pool was being scanned, so no useless resolve and send work is done.
+	if abandoned() {
+		return
+	}
+
+	// Skip transactions the peer already has. The sync now runs concurrently
+	// with the message loop, so transactions received from this peer since
+	// registration are marked known and must not be echoed back to it. The
+	// known set is shared with the message loop, so a single cardinality read
+	// replaces one lock acquisition per pending transaction; a freshly
+	// registered peer knows nothing, which is the common case.
+	//
+	// The read happens after the scan, so anything marked while the pool was
+	// being scanned is still filtered. Only a transaction marked during the
+	// filtering itself, on a peer that knew nothing when the loop started, can
+	// slip through and be echoed back once.
+	filter := p.knownTxs.Cardinality() > 0
+
+	// The xdc/165 protocol introduces proper transaction announcements, so instead
+	// of dripping transactions across multiple peers, just send the entire list as
+	// an announcement and let the remote side decide what they need (likely nothing).
+	// Only the hashes are needed, so the pending snapshot is filtered once and
+	// the full transactions are never sent. Each hash is checked against the
+	// live pool first: queueing marks hashes as known before the announcer
+	// drops the vanished ones, so announcing a transaction removed after the
+	// snapshot would leave a ghost entry suppressing later announcements of
+	// the same transaction.
+	if p.version >= xdc165 {
+		var hashes []common.Hash
+		for _, batch := range pending {
+			for _, lazy := range batch {
+				if filter && p.knownTxs.Contains(lazy.Hash) {
+					continue
+				}
+				if p.getPooledTx(lazy.Hash) == nil {
+					continue
+				}
+				hashes = append(hashes, lazy.Hash)
+			}
+		}
+		if len(hashes) > 0 {
+			p.AsyncSendPooledTransactionHashes(hashes)
+		}
+		return
+	}
+	// Out of luck, peer is running legacy protocols, drop the txs over. The
+	// full transactions are needed here, so resolve them, skipping the ones
+	// the peer already has.
+	var txs types.Transactions
 	for _, batch := range pending {
 		for _, lazy := range batch {
+			if filter && p.knownTxs.Contains(lazy.Hash) {
+				continue
+			}
 			if tx := lazy.Resolve(); tx != nil {
 				txs = append(txs, tx)
 			}
@@ -68,21 +139,13 @@ func (pm *ProtocolManager) syncTransactions(p *peer) {
 	if len(txs) == 0 {
 		return
 	}
-	// The xdc/165 protocol introduces proper transaction announcements, so instead
-	// of dripping transactions across multiple peers, just send the entire list as
-	// an announcement and let the remote side decide what they need (likely nothing).
-	if p.version >= xdc165 {
-		hashes := make([]common.Hash, len(txs))
-		for i, tx := range txs {
-			hashes[i] = tx.Hash()
-		}
-		p.AsyncSendPooledTransactionHashes(hashes)
-		return
-	}
-	// Out of luck, peer is running legacy protocols, drop the txs over
+	// The peer might have been dropped while the pool was being scanned, in
+	// which case the sync must not wait for the txsync loop to pick up the
+	// batch.
 	select {
 	case pm.txsyncCh <- &txsync{p, txs}:
 	case <-pm.quitSync:
+	case <-p.term:
 	}
 }
 
@@ -97,28 +160,45 @@ func (pm *ProtocolManager) txsyncLoop64() {
 		pack    = new(txsync)         // the pack that is being sent
 		done    = make(chan error, 1) // result of the send
 	)
-	// send starts a sending a pack of transactions from the sync.
-	send := func(s *txsync) {
+	// send packs the unknown transactions of the sync and starts delivering
+	// the pack in the background, reporting whether a pack was scheduled. A
+	// sync whose transactions all became known while it sat in the queue
+	// drains to an empty pack; reporting false lets the caller move on to the
+	// next peer instead of waiting for a completion event that never arrives.
+	send := func(s *txsync) bool {
 		if s.p.version >= xdc165 {
 			panic("initial transaction syncer running on xdc/165+")
 		}
-		// Fill pack with transactions up to the target size.
+		// Fill pack with transactions up to the target size, skipping the ones
+		// the peer came to know about while the sync was queued. The empty-pack
+		// clause keeps a single oversized transaction eligible.
 		size := common.StorageSize(0)
-		pack.p = s.p
+		filter := s.p.knownTxs.Cardinality() > 0
 		pack.txs = pack.txs[:0]
-		for i := 0; i < len(s.txs) && size < txsyncPackSize; i++ {
-			pack.txs = append(pack.txs, s.txs[i])
-			size += common.StorageSize(s.txs[i].Size())
+		for len(s.txs) > 0 && (len(pack.txs) == 0 || size < txsyncPackSize) {
+			tx := s.txs[0]
+			s.txs = s.txs[1:]
+			if filter && s.p.knownTxs.Contains(tx.Hash()) {
+				continue
+			}
+			pack.txs = append(pack.txs, tx)
+			size += common.StorageSize(tx.Size())
 		}
-		// Remove the transactions that will be sent.
-		s.txs = s.txs[:copy(s.txs, s.txs[len(pack.txs):])]
+		// Drop the sync once drained, whether anything was packed or not.
 		if len(s.txs) == 0 {
 			delete(pending, s.p.ID())
 		}
+		if len(pack.txs) == 0 {
+			return false
+		}
+		// pack.p is only set for a real send, so the done branch never observes
+		// the peer of a sync that filtered down to nothing.
+		pack.p = s.p
 		// Send the pack in the background.
 		s.p.Log().Trace("Sending batch of transactions", "count", len(pack.txs), "bytes", size)
 		sending = true
 		go func() { done <- pack.p.SendTransactions64(pack.txs) }()
+		return true
 	}
 
 	// pick chooses the next pending sync.
@@ -135,12 +215,24 @@ func (pm *ProtocolManager) txsyncLoop64() {
 		return nil
 	}
 
+	// schedule keeps picking pending syncs until one produces a real pack or
+	// the queue is exhausted, so syncs that filtered down to nothing cannot
+	// starve the peers parked behind them.
+	schedule := func() {
+		for {
+			s := pick()
+			if s == nil || send(s) {
+				return
+			}
+		}
+	}
+
 	for {
 		select {
 		case s := <-pm.txsyncCh:
 			pending[s.p.ID()] = s
 			if !sending {
-				send(s)
+				schedule()
 			}
 		case err := <-done:
 			sending = false
@@ -150,9 +242,7 @@ func (pm *ProtocolManager) txsyncLoop64() {
 				delete(pending, pack.p.ID())
 			}
 			// Schedule the next send.
-			if s := pick(); s != nil {
-				send(s)
-			}
+			schedule()
 		case <-pm.quitSync:
 			return
 		}

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/txpool"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
 	"github.com/XinFinOrg/XDPoSChain/eth/downloader"
 	"github.com/XinFinOrg/XDPoSChain/log"
@@ -470,5 +471,458 @@ func testFastSyncDisabling(t *testing.T, protocol int) {
 		case <-ticker.C:
 			pmEmpty.synchronise(pmEmpty.peers.BestPeer())
 		}
+	}
+}
+
+// pendingCountingPool wraps testTxPool and records Pending invocations, so tests
+// can assert that a sync abandoned before the scan never touches the pool.
+type pendingCountingPool struct {
+	*testTxPool
+	calls atomic.Int32
+}
+
+func (p *pendingCountingPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+	p.calls.Add(1)
+	return p.testTxPool.Pending(filter)
+}
+
+// resolveCountingResolver counts lazy resolve lookups, to observe whether a sync
+// given up on still resolves transactions. When serve is set, Get returns it,
+// so live syncs can be observed resolving a real transaction.
+type resolveCountingResolver struct {
+	calls atomic.Int32
+	serve *types.Transaction
+}
+
+func (r *resolveCountingResolver) Get(hash common.Hash) *types.Transaction {
+	r.calls.Add(1)
+	return r.serve
+}
+
+// stalledTxPool blocks Pending until released and then serves a single lazy
+// transaction whose resolution is observed via the counting resolver.
+type stalledTxPool struct {
+	*testTxPool
+	blocked  chan struct{}
+	entered  chan struct{}
+	resolver *resolveCountingResolver
+}
+
+func (p *stalledTxPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+	close(p.entered)
+	<-p.blocked
+	return map[common.Address][]*txpool.LazyTransaction{
+		common.HexToAddress("0xdead"): {
+			{Hash: common.HexToHash("0xfeed"), Pool: p.resolver},
+		},
+	}
+}
+
+// lazyTxPool serves a single lazy transaction whose Tx field is nil, so
+// LazyTransaction.Resolve has to go through the counting resolver. Get is
+// overridden to report the same transaction, so the peer's announcement loop
+// accepts the announced hash instead of dropping it as unknown. testTxPool
+// always attaches Tx to its lazy transactions, which short-circuits Resolve
+// and would make the resolver counter unreachable.
+type lazyTxPool struct {
+	*testTxPool
+	resolver *resolveCountingResolver // must have serve set
+}
+
+func (p *lazyTxPool) Get(hash common.Hash) *types.Transaction {
+	return p.resolver.serve
+}
+
+func (p *lazyTxPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+	return map[common.Address][]*txpool.LazyTransaction{
+		common.HexToAddress("0xdead"): {
+			{Hash: p.resolver.serve.Hash(), Pool: p.resolver},
+		},
+	}
+}
+
+// ghostTxPool serves a pending snapshot entry for a transaction that is no
+// longer in the pool: Pending reports its hash while Get (inherited from
+// testTxPool) returns nil, matching a transaction removed between the pool
+// scan and the announcement assembly.
+type ghostTxPool struct {
+	*testTxPool
+	hash common.Hash
+}
+
+func (p *ghostTxPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+	return map[common.Address][]*txpool.LazyTransaction{
+		common.HexToAddress("0xdead"): {
+			{Hash: p.hash, Pool: p},
+		},
+	}
+}
+
+// TestSyncTransactionsAbortsForStoppedNodeBeforeScan ensures a sync that starts
+// after the protocol manager began shutting down does not run a full pending
+// scan. quitSync is closed early in Stop, so a sync goroutine scheduled after
+// that point must bail out before touching the pool.
+func TestSyncTransactionsAbortsForStoppedNodeBeforeScan(t *testing.T) {
+	pool := &pendingCountingPool{testTxPool: newTestTxPool()}
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	pm.Stop()
+
+	_, net := p2p.MsgPipe()
+	peer := pm.newPeer(xdc165, p2p.NewPeer(enode.ID{}, "late", nil), net, pm.txpool.Get)
+	defer peer.close()
+
+	pm.syncTransactions(peer)
+
+	if calls := pool.calls.Load(); calls != 0 {
+		t.Fatalf("Pending called %d times for a sync started after shutdown", calls)
+	}
+}
+
+// TestSyncTransactionsAbortsForDroppedPeerBeforeScan ensures a peer dropped
+// before the initial transaction sync runs does not trigger a full pending
+// scan. The scan is expensive when the pool is contended, so it must not run
+// for a peer that is already gone.
+func TestSyncTransactionsAbortsForDroppedPeerBeforeScan(t *testing.T) {
+	pool := &pendingCountingPool{testTxPool: newTestTxPool()}
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	defer pm.Stop()
+
+	_, net := p2p.MsgPipe()
+	peer := pm.newPeer(xdc165, p2p.NewPeer(enode.ID{}, "dropped", nil), net, pm.txpool.Get)
+	peer.close()
+
+	pm.syncTransactions(peer)
+
+	if calls := pool.calls.Load(); calls != 0 {
+		t.Fatalf("Pending called %d times for a peer dropped before the scan", calls)
+	}
+}
+
+// TestSyncTransactionsFiltersTxsMarkedDuringScan ensures the known-transaction
+// filter is decided after the pending scan, not before it: a transaction the
+// peer sends us while the pool is being scanned must not be echoed back. This
+// pins the ordering the cardinality short-circuit depends on, since a filter
+// evaluated before the scan would skip the check for a peer that knew nothing
+// when the sync started.
+func TestSyncTransactionsFiltersTxsMarkedDuringScan(t *testing.T) {
+	pool := &stalledTxPool{
+		testTxPool: newTestTxPool(),
+		blocked:    make(chan struct{}),
+		entered:    make(chan struct{}),
+		resolver:   &resolveCountingResolver{},
+	}
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	defer pm.Stop()
+
+	// The announce loop is intentionally not running, so an attempted echo would
+	// block in AsyncSendPooledTransactionHashes until the timeout below trips.
+	_, net := p2p.MsgPipe()
+	peer := pm.newPeer(xdc165, p2p.NewPeer(enode.ID{}, "marker", nil), net, pm.txpool.Get)
+	defer peer.close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pm.syncTransactions(peer)
+	}()
+
+	select {
+	case <-pool.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial transaction sync never entered Pending")
+	}
+	peer.MarkTransaction(common.HexToHash("0xfeed"))
+	close(pool.blocked)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial transaction sync echoed a transaction marked during the scan")
+	}
+}
+
+// TestSyncTransactionsAbortsForPeerDroppedDuringScan ensures a peer dropped
+// while the pending scan is in flight does not get its transactions resolved
+// and sent. Dropping the peer closes p.term, which the sync must observe right
+// after Pending returns, skipping the useless resolve and send work.
+func TestSyncTransactionsAbortsForPeerDroppedDuringScan(t *testing.T) {
+	pool := &stalledTxPool{
+		testTxPool: newTestTxPool(),
+		blocked:    make(chan struct{}),
+		entered:    make(chan struct{}),
+		resolver:   &resolveCountingResolver{},
+	}
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	defer pm.Stop()
+
+	_, net := p2p.MsgPipe()
+	peer := pm.newPeer(xdc165, p2p.NewPeer(enode.ID{}, "dropped", nil), net, pm.txpool.Get)
+
+	done := make(chan struct{})
+	go func() {
+		pm.syncTransactions(peer)
+		close(done)
+	}()
+
+	// Wait until the sync goroutine is inside Pending, then drop the peer and
+	// unblock the pool. The sync must return without resolving the transaction.
+	// Close the peer before unblocking the pool so syncTransactions observes the
+	// closed term channel as soon as Pending returns.
+	select {
+	case <-pool.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial transaction sync never entered Pending")
+	}
+	peer.close()
+	close(pool.blocked)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial transaction sync did not return after the peer was dropped")
+	}
+	if calls := pool.resolver.calls.Load(); calls != 0 {
+		t.Fatalf("transaction resolved %d times for a peer dropped during the scan", calls)
+	}
+}
+
+// txsyncPeer is an unregistered peer wired to a message pipe, used to drive
+// txsyncLoop64 directly. The app side of the pipe is closed on test cleanup,
+// releasing any pack writer still blocked on delivery.
+type txsyncPeer struct {
+	p   *peer
+	app *p2p.MsgPipeRW
+}
+
+func newTxsyncPeer(t *testing.T, pm *ProtocolManager, version int, name string) *txsyncPeer {
+	t.Helper()
+	app, net := p2p.MsgPipe()
+	id := randomPeerID(t)
+	p := pm.newPeer(version, p2p.NewPeer(id, name, nil), net, pm.txpool.Get)
+	t.Cleanup(func() {
+		p.close()
+		app.Close()
+	})
+	return &txsyncPeer{p: p, app: app}
+}
+
+// submitTxsync queues an initial sync carrying the given transactions, failing
+// the test if the sync loop does not take it.
+func submitTxsync(t *testing.T, pm *ProtocolManager, p *peer, txs types.Transactions) {
+	t.Helper()
+	select {
+	case pm.txsyncCh <- &txsync{p: p, txs: txs}:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("initial sync for peer %v was never accepted", p.ID())
+	}
+}
+
+// expectTransactionMsg reads one TransactionMsg from the app side of a test
+// peer's pipe and fails the test unless it carries exactly the wanted
+// transactions.
+func expectTransactionMsg(t *testing.T, app *p2p.MsgPipeRW, want types.Transactions) {
+	t.Helper()
+	errc := make(chan error, 1)
+	go func() { errc <- p2p.ExpectMsg(app, TransactionMsg, want) }()
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("transaction delivery mismatch: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the transaction delivery")
+	}
+}
+
+// expectNoMsg fails the test if any message arrives on the app side of a test
+// peer's pipe within the grace window. The lingering read is released by the
+// pipe close registered at peer creation.
+func expectNoMsg(t *testing.T, app *p2p.MsgPipeRW, grace time.Duration) {
+	t.Helper()
+	errc := make(chan error, 1)
+	go func() {
+		_, err := app.ReadMsg()
+		errc <- err
+	}()
+	select {
+	case err := <-errc:
+		t.Fatalf("unexpected message delivered: %v", err)
+	case <-time.After(grace):
+	}
+}
+
+// TestSyncTransactionsAnnouncesWithoutResolving ensures the xdc/165 initial
+// sync announces the lazy hashes straight from the pending snapshot without
+// resolving a single transaction from the pool, while the legacy path still
+// resolves. The positive control proves the resolver counter actually fires,
+// so the zero on the announcement path is meaningful rather than a broken
+// counter passing vacuously.
+func TestSyncTransactionsAnnouncesWithoutResolving(t *testing.T) {
+	tx := newTestTransaction(testBankKey, 0, 100)
+	resolver := &resolveCountingResolver{serve: tx}
+	pool := &lazyTxPool{testTxPool: newTestTxPool(), resolver: resolver}
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	defer pm.Stop()
+
+	// xdc/165 announces the pending hash without touching the pool. The
+	// announcement reader is required, because txAnnounce is unbuffered and
+	// the sync would block on queueing otherwise.
+	app, net := p2p.MsgPipe()
+	id := randomPeerID(t)
+	announce := pm.newPeer(xdc165, p2p.NewPeer(id, "announce", nil), net, pm.txpool.Get)
+	go announce.announceTransactions()
+	defer announce.close()
+	defer app.Close()
+
+	pm.syncTransactions(announce)
+
+	errc := make(chan error, 1)
+	go func() { errc <- p2p.ExpectMsg(app, NewPooledTransactionHashesMsg, []common.Hash{tx.Hash()}) }()
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("initial sync announcement failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("initial sync never announced the pending transaction")
+	}
+	if calls := resolver.calls.Load(); calls != 0 {
+		t.Fatalf("announcement path resolved %d transactions, want 0", calls)
+	}
+
+	// Control: the legacy path must resolve, proving the counter is wired to
+	// LazyTransaction.Resolve and the zero above is not a dead counter.
+	app100, net100 := p2p.MsgPipe()
+	id100 := randomPeerID(t)
+	legacy := pm.newPeer(xdc100, p2p.NewPeer(id100, "legacy", nil), net100, pm.txpool.Get)
+	defer legacy.close()
+	defer app100.Close()
+
+	pm.syncTransactions(legacy)
+	if calls := resolver.calls.Load(); calls == 0 {
+		t.Fatal("legacy sync never resolved the pending transaction")
+	}
+	// Drain the pack the legacy syncer delivers, so its writer is not left
+	// blocked on the pipe until cleanup.
+	errc = make(chan error, 1)
+	go func() { errc <- p2p.ExpectMsg(app100, TransactionMsg, types.Transactions{tx}) }()
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("legacy initial sync delivery failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("legacy sync never delivered the pending transaction")
+	}
+}
+
+// TestSyncTransactionsSkipsTxsVanishedFromPool ensures the xdc/165 initial
+// sync neither announces nor marks known a transaction that was removed from
+// the pool between the pending snapshot and the announcement assembly. The
+// async announcer drops vanished hashes without sending them, but the queueing
+// handoff marks them known first, leaving a ghost entry that would suppress
+// later announcements if the transaction re-entered the pool.
+func TestSyncTransactionsSkipsTxsVanishedFromPool(t *testing.T) {
+	hash := common.HexToHash("0xdeadbeef")
+	pool := &ghostTxPool{testTxPool: newTestTxPool(), hash: hash}
+	pm, _, err := newTestProtocolManagerWithTxPool(downloader.FullSync, 4, nil, pool)
+	if err != nil {
+		t.Fatalf("failed to create protocol manager: %v", err)
+	}
+	defer pm.Stop()
+
+	// The announce loop must run for the guard to be observable: txAnnounce is
+	// unbuffered, so only a completed handoff can pollute knownTxs. The
+	// announcer drops the hash on its existence check, so nothing may reach
+	// the wire either way.
+	app, net := p2p.MsgPipe()
+	id := randomPeerID(t)
+	peer := pm.newPeer(xdc165, p2p.NewPeer(id, "ghost", nil), net, pm.txpool.Get)
+	go peer.announceTransactions()
+	defer peer.close()
+	defer app.Close()
+
+	pm.syncTransactions(peer)
+
+	if peer.knownTxs.Contains(hash) {
+		t.Fatal("transaction removed from the pool was marked known")
+	}
+	expectNoMsg(t, app, time.Second)
+}
+
+// TestTxsyncSkipsKnownTxsAtPackTime ensures the legacy syncer filters a peer's
+// known transactions when it finally packs the queued sync. The peer can learn
+// a transaction while its initial sync waits behind another peer's in-flight
+// pack, and the packer must then drop it instead of echoing it back.
+func TestTxsyncSkipsKnownTxsAtPackTime(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 4, nil, nil)
+	defer pm.Stop()
+
+	// The blocker occupies the single in-flight pack; its delivery blocks on
+	// the unread pipe until the test drains it below.
+	blocker := newTxsyncPeer(t, pm, xdc100, "blocker")
+	blockerTxs := types.Transactions{newTestTransaction(testBankKey, 0, 100)}
+	submitTxsync(t, pm, blocker.p, blockerTxs)
+
+	// The target's sync is queued behind the blocker with the transaction
+	// still unknown, and the peer learns it while parked.
+	target := newTxsyncPeer(t, pm, xdc100, "target")
+	targetTxs := types.Transactions{newTestTransaction(testBankKey, 1, 100)}
+	submitTxsync(t, pm, target.p, targetTxs)
+	target.p.MarkTransaction(targetTxs[0].Hash())
+
+	// Draining the blocker's pack is the only way to release the loop, which
+	// must then skip the target's now fully known sync.
+	expectTransactionMsg(t, blocker.app, blockerTxs)
+	expectNoMsg(t, target.app, time.Second)
+}
+
+// TestTxsyncEmptyPackDoesNotStarveOthers ensures syncs that drained to nothing
+// while queued are skipped without stalling the loop: the peers parked behind
+// them must still be served even though an empty pack never produces the
+// completion event a busy loop would wait for.
+func TestTxsyncEmptyPackDoesNotStarveOthers(t *testing.T) {
+	pm, _ := newTestProtocolManagerMust(t, downloader.FullSync, 4, nil, nil)
+	defer pm.Stop()
+
+	blocker := newTxsyncPeer(t, pm, xdc100, "blocker")
+	blockerTxs := types.Transactions{newTestTransaction(testBankKey, 0, 100)}
+	submitTxsync(t, pm, blocker.p, blockerTxs)
+
+	// Two syncs whose whole payload becomes known while parked, plus one that
+	// still has something to deliver.
+	var drained []*txsyncPeer
+	for i := 0; i < 2; i++ {
+		p := newTxsyncPeer(t, pm, xdc100, fmt.Sprintf("drained-%d", i))
+		txs := types.Transactions{newTestTransaction(testBankKey, uint64(i+1), 100)}
+		submitTxsync(t, pm, p.p, txs)
+		p.p.MarkTransaction(txs[0].Hash())
+		drained = append(drained, p)
+	}
+	lucky := newTxsyncPeer(t, pm, xdc100, "lucky")
+	luckyTxs := types.Transactions{newTestTransaction(testBankKey, 9, 100)}
+	submitTxsync(t, pm, lucky.p, luckyTxs)
+
+	// Release the blocker's pack by draining it; the loop must skip the two
+	// drained syncs and deliver the lucky peer's transaction.
+	expectTransactionMsg(t, blocker.app, blockerTxs)
+	expectTransactionMsg(t, lucky.app, luckyTxs)
+	for _, p := range drained {
+		expectNoMsg(t, p.app, time.Second)
 	}
 }


### PR DESCRIPTION
## Problem

handle() called syncTransactions between registering a peer and entering its message loop, so a peer could not read a single message until txpool.Pending() returned. While the pool lock was held the peer answered nothing and the downloader eventually dropped it with err=timeout. A stack dump from a frozen mainnet node showed 20 peer registrations parked in makeProtocol -> handle -> syncTransactions -> Pending.

## Root Cause Context

The freeze itself is fixed elsewhere: the pool lock was pinned by promoteSpecialTx delivering an event while holding it, and by a peer broadcaster that stopped draining its queue after a send error. This PR only removes the coupling, so peer registration no longer depends on the transaction pool being responsive, and a full Pending scan stays off the handshake path even when the pool is healthy.

## Change

The initial transaction sync now runs in a goroutine tracked by pm.wg, started through a new admission gate (goTracked/enterTracked) that drops work if Stop already began waiting on the wait group — a handshake completing at that moment would otherwise grow the wait group concurrently with the wait, which is a data race. The protocol Run callback enters the same gate instead of calling wg.Add directly, so admission to the wait group has a single rule.

Because the sync now runs concurrently with the peer message loop, three compensations were required: the pending snapshot is filtered against the peer's known transactions so transactions received from the peer after registration are not echoed back to it; the sync abandons itself if shutdown started or the peer was dropped while the pool was being scanned; and the legacy txsync packer re-filters against known transactions at pack time, since a peer can learn a transaction while its initial sync waits behind another peer's in-flight pack.

## Shutdown Contract

Stop() waits for the sync goroutine via pm.wg, so a pinned pool lock can still delay shutdown. That wait is part of the contract, not an accident: while a scan is in flight Stop stays blocked (the scan is not cancellable), and once the scan returns the sync observes the shutdown and abandons delivery, leaving no transaction resolution or hash announcement behind. No timeout escape is added; a permanently wedged pool is a transaction-pool correctness issue outside this change.

## Concurrency Note

p.knownTxs is a mapset.NewSet from golang-set/v2 v2.7.0 whose operations are individually locked, so the concurrent reader added here is safe. Compound sequences such as Cardinality check then Pop then Add remain non-atomic across calls, which can only cause benign over/under-marking, not a crash. The filter is skipped entirely when the set is empty (a freshly registered peer), so the common path pays a single lock acquisition instead of one per pending transaction and adds no O(pool) contention on the lock the message loop takes in MarkTransaction.

## Compatibility

No wire-protocol, message-format, or consensus changes. xdc/100 legacy delivery and xdc/165+ hash announcements behave exactly as before, both exercised through the real handshake path. No migration guide or node-operator coordination is required; the change is a strict availability improvement and nodes can upgrade independently.

## Tests

- TestPeerServesRequestsWhileTxPoolIsBlocked — a header request is served while Pending is blocked, and initial delivery completes after release, for both xdc/100 and xdc/165
- TestSyncTransactionsSkipsKnownTxs — a transaction the peer already sent is not echoed back
- TestSyncTransactionsFiltersTxsMarkedDuringScan — the filter is decided after the scan, not before
- TestSyncTransactionsAbortsForStoppedNodeBeforeScan / TestSyncTransactionsAbortsForDroppedPeerBeforeScan / TestSyncTransactionsAbortsForPeerDroppedDuringScan — no scan or post-scan work for a stopped node or dropped peer
- TestTxsyncSkipsKnownTxsAtPackTime — the legacy packer drops transactions learned while queued
- TestSyncTransactionsAnnouncesWithoutResolving — xdc/165 announces lazy hashes without resolving; legacy still resolves (positive control)
- TestTrackedGateClosesOnShutdown — the wait-group admission gate, preventing Add/Wait misuse panic
- TestProtocolManagerStopWaitsForInitialTxScan — Stop waits for an entered scan and no delivery follows shutdown, for both protocol versions
- newTestProtocolManagerWithTxPool split out of newTestProtocolManager so tests can inject a blocking pool

## Verification

- go test ./eth ./core/txpool/legacypool -count=1 — pass
- go test -race ./eth -run 'TestPeerServesRequestsWhileTxPoolIsBlocked|TestSyncTransactions|TestTxsync|TestTrackedGate|TestProtocolManagerStopWaitsForInitialTxScan' -count=1 — pass
- make quick-test (includes full build) — pass
- gofmt, goimports, make tidy, make generate — clean

## Out of Scope (Follow-up PRs)

Stall watchdog reporting, lock-free pool statistics for diagnostics, and worker/queue throttling for connection storms are intentionally excluded from this PR and planned as separate changes.