### PR TITLE
fix(core/txpool): fix Sync deadlock in pool loop #28837

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -177,13 +177,12 @@ func (p *TxPool) loop(head *types.Header) {
 		resetForced bool       // Whether a forced reset was requested, only used in simulator mode
 		resetWaiter chan error // Channel waiting on a forced reset, only used in simulator mode
 	)
-	// Notify the live reset waiter without blocking if the txpool is closed.
+	// Notify the live reset waiter when the pool terminates. The send blocks
+	// until Sync() picks it up; it cannot abort via p.term (closed only after
+	// this defer runs), so the notification is guaranteed to be delivered.
 	defer func() {
 		if resetWaiter != nil {
-			select {
-			case resetWaiter <- errors.New("pool already terminated"):
-			default:
-			}
+			resetWaiter <- errors.New("pool already terminated")
 			resetWaiter = nil
 		}
 	}()
@@ -245,12 +244,12 @@ func (p *TxPool) loop(head *types.Header) {
 			// the forced op is still pending. In that case, wait another round
 			// of resets.
 			if resetWaiter != nil && !resetForced {
-				select {
-				case resetWaiter <- nil:
-					// notification delivered
-				default:
-					// no active listener; avoid blocking the event loop
-				}
+				// Block until the waiter receives the notification. Sync() is
+				// guaranteed to be waiting on its waiter channel (it cannot
+				// abort via p.term while this loop is still running), so a
+				// non-blocking send here could drop the notification and leave
+				// Sync() blocked forever.
+				resetWaiter <- nil
 				resetWaiter = nil
 			}
 

--- a/core/txpool/txpool_sync_test.go
+++ b/core/txpool/txpool_sync_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package txpool_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
+	"github.com/XinFinOrg/XDPoSChain/core"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/txpool"
+	"github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/event"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+var (
+	syncTestKey, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	syncTestAddress = crypto.PubkeyToAddress(syncTestKey.PublicKey)
+	syncTestFunds   = big.NewInt(1000000000000000000)
+	syncTestGenesis = &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			syncTestAddress: {Balance: syncTestFunds},
+		},
+		BaseFee: big.NewInt(params.InitialBaseFee),
+	}
+	syncTestSigner = types.LatestSigner(syncTestGenesis.Config)
+)
+
+// newSyncTestEnv builds a chain of n blocks (each consuming one nonce of the
+// test address) and a txpool layered on top of it.
+func newSyncTestEnv(t *testing.T, n int) (*core.BlockChain, *txpool.TxPool) {
+	t.Helper()
+
+	_, blocks, _ := core.GenerateChainWithGenesis(syncTestGenesis, ethash.NewFaker(), n, func(i int, gen *core.BlockGen) {
+		gasPrice := big.NewInt(params.InitialBaseFee)
+		if baseFee := gen.BaseFee(); baseFee != nil {
+			gasPrice = new(big.Int).Set(baseFee)
+		}
+		tx, err := types.SignTx(types.NewTransaction(gen.TxNonce(syncTestAddress), common.Address{0x00}, big.NewInt(1000), params.TxGas, gasPrice, nil), syncTestSigner, syncTestKey)
+		if err != nil {
+			panic(err)
+		}
+		gen.AddTx(tx)
+	})
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := core.NewBlockChain(db, nil, syncTestGenesis, ethash.NewFaker(), vm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create blockchain: %v", err)
+	}
+	legacyPool := legacypool.New(legacypool.DefaultConfig, chain)
+	pool, err := txpool.New(0, chain, []txpool.SubPool{legacyPool})
+	if err != nil {
+		t.Fatalf("Failed to create tx pool: %v", err)
+	}
+	if _, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("Failed to insert blocks: %v", err)
+	}
+	return chain, pool
+}
+
+// TestSyncCompletes guards against the Sync() deadlock: the loop must always
+// complete the forced reset and notify the waiting caller. Each call must
+// return promptly; a bounded timeout turns a deadlock into a fast failure
+// instead of hanging the whole test run until the package-wide timeout.
+func TestSyncCompletes(t *testing.T) {
+	chain, pool := newSyncTestEnv(t, 10)
+	defer chain.Stop()
+	defer pool.Close()
+
+	for i := 0; i < 100; i++ {
+		errc := make(chan error, 1)
+		go func() {
+			errc <- pool.Sync()
+		}()
+		select {
+		case err := <-errc:
+			if err != nil {
+				t.Fatalf("Sync call %d failed: %v", i, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Sync call %d did not return within 5s (deadlock?)", i)
+		}
+	}
+}
+
+// blockingResetPool is a SubPool whose Reset blocks until released, keeping a
+// Sync() request pending so the loop-termination path can be exercised.
+type blockingResetPool struct {
+	started chan struct{} // closed when Reset begins
+	release chan struct{} // closed to unblock Reset
+}
+
+func (p *blockingResetPool) Filter(tx *types.Transaction) bool { return false }
+
+func (p *blockingResetPool) Init(gasTip uint64, head *types.Header, reserver txpool.Reserver) error {
+	return nil
+}
+
+func (p *blockingResetPool) Close() error {
+	close(p.release)
+	return nil
+}
+
+func (p *blockingResetPool) Reset(oldHead, newHead *types.Header) {
+	close(p.started)
+	<-p.release
+}
+
+func (p *blockingResetPool) SetGasTip(tip *big.Int) error { return nil }
+
+func (p *blockingResetPool) Has(hash common.Hash) bool { return false }
+
+func (p *blockingResetPool) Get(hash common.Hash) *types.Transaction { return nil }
+
+func (p *blockingResetPool) ValidateTxBasics(tx *types.Transaction) error { return nil }
+
+func (p *blockingResetPool) Add(txs []*types.Transaction, sync bool) []error { return nil }
+
+func (p *blockingResetPool) Pending(filter txpool.PendingFilter) map[common.Address][]*txpool.LazyTransaction {
+	return nil
+}
+
+func (p *blockingResetPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription {
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		<-quit
+		return nil
+	})
+}
+
+func (p *blockingResetPool) Nonce(addr common.Address) uint64 { return 0 }
+
+func (p *blockingResetPool) Stats() (int, int) { return 0, 0 }
+
+func (p *blockingResetPool) Content() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction) {
+	return nil, nil
+}
+
+func (p *blockingResetPool) ContentFrom(addr common.Address) ([]*types.Transaction, []*types.Transaction) {
+	return nil, nil
+}
+
+func (p *blockingResetPool) Status(hash common.Hash) txpool.TxStatus { return txpool.TxStatusUnknown }
+
+func (p *blockingResetPool) SetSigner(f func(address common.Address) bool) {}
+
+func (p *blockingResetPool) IsSigner(addr common.Address) bool { return false }
+
+// TestSyncTerminatedOnClose covers the loop-termination path: a Sync() request
+// kept pending by a blocking subpool must receive "pool already terminated"
+// when the pool is closed, instead of blocking forever, and both the pool loop
+// and the Sync caller must finish.
+func TestSyncTerminatedOnClose(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	chain, err := core.NewBlockChain(db, nil, syncTestGenesis, ethash.NewFaker(), vm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create blockchain: %v", err)
+	}
+	defer chain.Stop()
+
+	block := &blockingResetPool{started: make(chan struct{}), release: make(chan struct{})}
+	pool, err := txpool.New(0, chain, []txpool.SubPool{block})
+	if err != nil {
+		t.Fatalf("Failed to create tx pool: %v", err)
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		errc <- pool.Sync()
+	}()
+	// Wait deterministically until the forced reset started and is stuck in the
+	// blocking subpool, i.e. the Sync waiter is live before Close runs.
+	select {
+	case <-block.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("forced reset did not start")
+	}
+
+	if err := pool.Close(); err != nil {
+		t.Fatalf("Failed to close pool: %v", err)
+	}
+	select {
+	case err := <-errc:
+		if err == nil || err.Error() != "pool already terminated" {
+			t.Fatalf("Sync returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Sync did not return after pool close")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a `pool.Sync()` deadlock that surfaced as a 45-minute test timeout on `core/txpool/locals`.

Ref: #28837

## Symptoms

CI hung until the 45-minute test timeout, with `running tests: TestTrackAllSameNonceReplacement`. The goroutine dump showed the test goroutine blocked at `TxPool.Sync()`'s `<-waiter` while `TxPool.loop` idled in select with no reset goroutine running — `Sync()` had sent its sync request and the loop had received it, but the waiter was never signaled back.

Ref: https://github.com/XinFinOrg/XDPoSChain/actions/runs/32908385602/job/97997298962

```text
ok  	github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool	7.075s	coverage: 43.0% of statements
coverage: 74.1% of statements
panic: test timed out after 45m0s
	running tests:
		TestTrackAllSameNonceReplacement (45m0s)

goroutine 235 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:2682 +0x359
created by time.goFunc
	/opt/hostedtoolcache/go/1.25.13/x64/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive, 44 minutes]:
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:1891 +0x451
testing.tRunner(0xc0000a4540, 0xc00029fc70)
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:1940 +0x123
testing.runTests(0xc0000124b0, {0x11646e0, 0xa, 0xa}, {0x11c3040?, 0x87da55bf9198f5db?, 0x11c0520?})
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:2475 +0x4b4
testing.(*M).Run(0xc0001b2e60)
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:2337 +0x63a
main.main()
	_testmain.go:73 +0x9b

goroutine 39 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/txpool.(*TxPool).Sync(...)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/txpool.go:511
github.com/XinFinOrg/XDPoSChain/core/txpool/locals.newTestEnv(0xc000103340, 0xa, 0x0, {0x0, 0x0})
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/locals/tx_tracker_test.go:90 +0x490
github.com/XinFinOrg/XDPoSChain/core/txpool/locals.TestTrackAllSameNonceReplacement(0xc000103340)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/locals/tx_tracker_test.go:203 +0x50
testing.tRunner(0xc000103340, 0xc022b8)
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.25.13/x64/src/testing/testing.go:1997 +0x465

goroutine 13 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core.(*txSenderCacher).cache(0x0?)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:72 +0x35
created by github.com/XinFinOrg/XDPoSChain/core.newTxSenderCacher in goroutine 8
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:64 +0x74

goroutine 14 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core.(*txSenderCacher).cache(0x0?)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:72 +0x35
created by github.com/XinFinOrg/XDPoSChain/core.newTxSenderCacher in goroutine 8
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:64 +0x74

goroutine 15 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core.(*txSenderCacher).cache(0x0?)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:72 +0x35
created by github.com/XinFinOrg/XDPoSChain/core.newTxSenderCacher in goroutine 8
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:64 +0x74

goroutine 16 [chan receive, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core.(*txSenderCacher).cache(0x0?)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:72 +0x35
created by github.com/XinFinOrg/XDPoSChain/core.newTxSenderCacher in goroutine 8
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/sender_cacher.go:64 +0x74

goroutine 156 [select]:
github.com/XinFinOrg/XDPoSChain/core.(*BlockChain).futureBlocksLoop(0xc000004808)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/blockchain.go:2669 +0xb4
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.13/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 39
	/opt/hostedtoolcache/go/1.25.13/x64/src/sync/waitgroup.go:237 +0x73

goroutine 157 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool.(*LegacyPool).scheduleReorgLoop(0xc0003e6e00)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/legacypool/legacypool.go:1257 +0x28c
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.13/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 39
	/opt/hostedtoolcache/go/1.25.13/x64/src/sync/waitgroup.go:237 +0x73

goroutine 158 [select]:
github.com/XinFinOrg/XDPoSChain/core/txpool/legacypool.(*LegacyPool).loop(0xc0003e6e00)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/legacypool/legacypool.go:364 +0x15b
sync.(*WaitGroup).Go.func1()
	/opt/hostedtoolcache/go/1.25.13/x64/src/sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 39
	/opt/hostedtoolcache/go/1.25.13/x64/src/sync/waitgroup.go:237 +0x73

goroutine 159 [select, 44 minutes]:
github.com/XinFinOrg/XDPoSChain/core/txpool.(*TxPool).loop(0xc0004303f0, 0xc000409688)
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/txpool.go:234 +0x4ec
created by github.com/XinFinOrg/XDPoSChain/core/txpool.New in goroutine 39
	/home/runner/work/XDPoSChain/XDPoSChain/src/XDPoSChain/core/txpool/txpool.go:124 +0x37f
FAIL	github.com/XinFinOrg/XDPoSChain/core/txpool/locals	2700.008s
ok  	github.com/XinFinOrg/XDPoSChain/core/types	0.625s	coverage: 43.3% of statements
ok  	github.com/XinFinOrg/XDPoSChain/core/vm	0.117s	coverage: 46.9% of statements
ok  	github.com/XinFinOrg/XDPoSChain/core/vm/privacy	6.150s	coverage: 82.2% of statements
ok  	github.com/XinFinOrg/XDPoSChain/core/vm/program	0.004s	coverage: 76.0% of statements
ok  	github.com/XinFinOrg/XDPoSChain/core/vm/runtime	0.055s	coverage: 90.2% of statements
FAIL
util.go:48: exit status 1
exit status 1
Error: Process completed with exit code 1.
```

## Root cause

Upstream geth notifies the sync waiter in the `resetDone` branch of `TxPool.loop` with a blocking send:

```go
if resetWaiter != nil && !resetForced {
    resetWaiter <- nil
    resetWaiter = nil
}
```

This fork's commit `a9be217e6 (#2132)` changed it to a non-blocking send followed by an unconditional clear:

```go
if resetWaiter != nil && !resetForced {
    select {
    case resetWaiter <- nil:
    default:
    }
    resetWaiter = nil
}
```

Deadlock chain:

1. `Sync()` sends its waiter over `p.sync`; the loop receives it and sets `resetWaiter`/`resetForced=true`;
2. `Sync()` then runs `return <-waiter` — a scheduling gap exists between these two steps;
3. if the reset finishes before `Sync()` reaches `<-waiter`, `resetWaiter <- nil` takes the `default` branch (no receiver yet), the notification is dropped, and `resetWaiter` is unconditionally cleared;
4. `Sync()`'s waiter never receives a value → blocked forever.

Why only CI hit it: coverage mode inserts counters at every statement, widening the descheduling window between sending the waiter and starting to receive; parallel high load worsens it. Plain local runs almost never trigger it.

## Fix

Restore the blocking send used upstream, which cannot lose the notification, and apply the same to the loop-termination notification so a pool closed while `Sync()` is pending also signals the waiter. Add `TestSyncCompletes`, which exercises repeated `Sync()` calls and hangs under `-cover` if the non-blocking notification regresses.

## Verification

- `core/txpool/locals`: 100 consecutive runs under `-cover` all pass (previously timed out at the same parameters);
- `core/txpool`: full package passes; `TestSyncCompletes` passes 100 runs under `-cover` and `-race`;
- regression check: with the fix reverted (non-blocking send), `TestSyncCompletes` hangs and times out under `-cover`, confirming it catches the deadlock.

## Compatibility

Internal txpool concurrency control only; no protocol, RPC, or state-transition changes.
