### PR TITLE
fix(core): queue all future blocks of a batch instead of failing

### DIFF
--- a/consensus/XDPoS/XDPoS.go
+++ b/consensus/XDPoS/XDPoS.go
@@ -353,7 +353,14 @@ func (x *XDPoS) CalcDifficulty(chain consensus.ChainReader, time uint64, parent 
 	}
 }
 
-func (x *XDPoS) HandleProposedBlock(chain consensus.ChainReader, header *types.Header) error {
+func (x *XDPoS) HandleProposedBlock(chain consensus.ProposedBlockChain, header *types.Header) error {
+	// This wrapper dispatches on header.Number before the engine's own guard
+	// can run, so a nil header or nil number must be judged here: log Error,
+	// return nil, count nothing — a caller bug is not a block observation.
+	if !consensus.IsJudgeableHeader(header) {
+		consensus.SkipNilHeaderLog(consensus.SkipSiteHandleProposedBlock)
+		return nil
+	}
 	switch x.config.BlockConsensusVersion(header.Number) {
 	case params.ConsensusEngineVersion2:
 		return x.EngineV2.ProposedBlockHandler(chain, header)

--- a/consensus/XDPoS/XDPoS_test.go
+++ b/consensus/XDPoS/XDPoS_test.go
@@ -1,12 +1,15 @@
 package XDPoS
 
 import (
+	"bytes"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/log"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/stretchr/testify/assert"
 )
@@ -133,4 +136,44 @@ func TestCacheNoneTIPSigningTxsWithRawReceiptRoundTrip(t *testing.T) {
 
 	assert.Len(t, cached, 1)
 	assert.Equal(t, signingTx.Hash(), cached[0].Hash())
+}
+
+// TestHandleProposedBlockSkipsNilHeader pins the wrapper-side nil-header
+// contract: the adaptor dispatches on BlockConsensusVersion(header.Number)
+// before the engine's own guard can run, so the wrapper must judge the nil
+// shapes itself — no panic, an Error-level skip through the skip table (a
+// caller bug is graded like a wiring bug), nil returned, and the engine
+// never reached.
+func TestHandleProposedBlockSkipsNilHeader(t *testing.T) {
+	database := rawdb.NewMemoryDatabase()
+	config := params.TestXDPoSMockChainConfig
+	engine, err := New(config, database)
+	assert.NoError(t, err)
+
+	// Capture the wrapper's logs and assert the nil-header skip surfaces
+	// at Error — a caller bug, graded like the wiring bugs.
+	var logBuf bytes.Buffer
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelInfo, false))
+	glog.Verbosity(log.LevelInfo)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	// Both nil shapes must be judged before BlockConsensusVersion
+	// dereferences header.Number: a fully nil header and a header
+	// without a number.
+	shapes := map[string]*types.Header{"nil": nil, "nil number": {}}
+	for name, header := range shapes {
+		assert.Nil(t, engine.HandleProposedBlock(nil, header),
+			"a %s header is a caller bug and must skip, not panic or error", name)
+	}
+
+	found := 0
+	for _, line := range strings.Split(logBuf.String(), "\n") {
+		if strings.Contains(line, "skip block: nil header") {
+			assert.True(t, strings.HasPrefix(line, "ERROR"), "nil-header skip must log at Error, got line %q", line)
+			found++
+		}
+	}
+	assert.Equal(t, 2, found, "both nil shapes must be logged, have %q", logBuf.String())
 }

--- a/consensus/XDPoS/engines/engine_v2/engine.go
+++ b/consensus/XDPoS/engines/engine_v2/engine.go
@@ -27,10 +27,37 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/core/vm"
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/XinFinOrg/XDPoSChain/trie"
 	"golang.org/x/sync/errgroup"
 )
+
+// skippedProposedBlock counts skips at this engine's two gates (before
+// processQC and before sendVote), at most once per handler invocation; the
+// reason also stays in the skip log. Every reason shares this one total and
+// also moves its own counter under skipped-proposed-block/ (see
+// consensus.IncSkipReasonCounter), so alert on the per-reason counters, not
+// the total: a fast-sync burst of body-not-stored is transient, a persistent
+// non-canonical rate is a stall. The unjudgeable reason carries no counter:
+// production wiring hands every entry point a ProposedBlockChain, so the
+// runtime defense in ShouldHandleProposedBlock cannot fire outside tests —
+// its Error logs are the alarm. Routine pre-filter skips are not counted.
+var skippedProposedBlock = metrics.NewRegisteredCounter("skipped-proposed-block", nil)
+
+// skipProposedBlock records a ShouldHandleProposedBlock denial at this
+// engine's two gates: it counts the skip and logs it at the reason's grade;
+// the caller returns nil, never an error — the fetcher's import loop treats a
+// handler error as an import failure and suppresses the block's broadcast.
+// The downloader pre-filter and the eth fetcher gate deliberately do not share
+// this helper: the former grades with PreFilterSkipLogLevel under its own
+// counter, the latter skips before any ShouldHandleProposedBlock judgment
+// and carries no reason at all.
+func skipProposedBlock(msg string, reason consensus.SkipReason, canonicalHash common.Hash, blockHeader *types.Header) {
+	skippedProposedBlock.Inc(1)
+	consensus.IncSkipReasonCounter(reason)
+	consensus.SkipLogLevel(reason)(msg, "reason", reason, "hash", blockHeader.Hash(), "number", blockHeader.Number, "canonicalHash", canonicalHash)
+}
 
 type XDPoS_v2 struct {
 	chainConfig *params.ChainConfig // Chain & network configuration
@@ -718,6 +745,12 @@ func (x *XDPoS_v2) SyncInfoHandler(chain consensus.ChainReader, syncInfo *types.
 		1. processQC
 		2. processTC
 	*/
+	// No canonicality gate here, unlike ProposedBlockHandler: the QC has
+	// already passed verifyQC's quorum signature threshold, so a QC whose
+	// block is a local side-chain block means the network's fork choice has
+	// diverged from ours. Accepting it is how a lagging or forked node
+	// catches up; gating would leave it unable to advance currentRound on
+	// the very evidence that its fork lost.
 	err := x.processQC(chain, syncInfo.HighestQuorumCert)
 	if err != nil {
 		return err
@@ -824,11 +857,39 @@ func (x *XDPoS_v2) TimeoutHandler(blockChainReader consensus.ChainReader, timeou
 /*
 Proposed Block workflow
 */
-func (x *XDPoS_v2) ProposedBlockHandler(chain consensus.ChainReader, blockHeader *types.Header) error {
+func (x *XDPoS_v2) ProposedBlockHandler(chain consensus.ProposedBlockChain, blockHeader *types.Header) error {
 	x.lock.Lock()
 	defer x.lock.Unlock()
 
-	// Get QC and Round from Extra
+	// getExtraFields dereferences header.Number, so judge before any
+	// dereference: log Error, return nil, no counter — a caller bug is not a
+	// block observation.
+	if !consensus.IsJudgeableHeader(blockHeader) {
+		consensus.SkipNilHeaderLog(consensus.SkipSiteProposedBlockHandler)
+		return nil
+	}
+
+	// x.lock serializes this handler, not InsertChain, so a reorg can land
+	// between the callers' gates and these checks. The first check protects
+	// this handler's processQC call, which writes highestQuorumCert,
+	// lockQuorumCert and the commit block before its own existence check;
+	// the second keeps the vote's unguarded window down to the broadcast.
+	// The other two processQC entries (SyncInfoHandler and the vote path)
+	// take quorum-signed QCs and deliberately skip this gate — see their
+	// call sites. Existence alone cannot tell a reorged-away block from a
+	// canonical one — forks stay in the database.
+	ok, reason, canonicalHash := consensus.ShouldHandleProposedBlock(chain, blockHeader)
+	if !ok {
+		skipProposedBlock(consensus.SkipSiteProposedBlockHandler+" skip block before processQC", reason, canonicalHash, blockHeader)
+		// Return nil, never an error — see skipProposedBlock. An unjudgeable
+		// skip stops this node voting for good; the counter makes that halt
+		// observable.
+		return nil
+	}
+
+	// Get QC and Round from Extra, after the skip judgment: a block that must be
+	// skipped returns nil even when its extra data is malformed, rather than
+	// failing the import.
 	quorumCert, round, _, err := x.getExtraFields(blockHeader)
 	if err != nil {
 		return err
@@ -856,6 +917,38 @@ func (x *XDPoS_v2) ProposedBlockHandler(chain consensus.ChainReader, blockHeader
 		return err
 	}
 	if verified {
+		// A reorg can still land between the processQC re-check and the
+		// broadcast, so drop the vote for a block reorged away meanwhile.
+		// processQC's writes are deliberately not rolled back: they are
+		// monotonic round-wise updates of shared consensus state, and this
+		// path has no rollback mechanism. The residual window they leave is
+		// wider than the embedded QC certifying N-1 suggests: a fork deeper
+		// than N-1 replaces N-1 as well,
+		// leaving highestQuorumCert, lockQuorumCert and highestCommitBlock
+		// pointing at reorged-away blocks; and the reorg-side committed-block
+		// refusal is a timing guarantee — it reads highestCommitBlock when the
+		// reorg lands, while this call's commit record is written inside
+		// processQC, after the first gate, so a reorg landing in that window
+		// is not blocked by it. That hazard predates this commit; the gates
+		// only shrink the window. Only the vote for the reorged block must go.
+		// TODO(convergence): close this residual window for real. Candidate:
+		// react to a reorg event (ChainEvent / chain-side insert) by
+		// invalidating highestQuorumCert, lockQuorumCert and
+		// highestCommitBlock when they point at reorged-away blocks, so the
+		// next processQC rebuilds them from the new canonical chain.
+		// The reorg invalidation must also cover the state written by the
+		// other two processQC entries (SyncInfoHandler and the vote path),
+		// which take quorum-signed QCs without a canonicality gate.
+		// Tracked separately; the gates above stay shrink-only until then. Another
+		// candidate for that topic: sink a canonicality check into processQC
+		// itself, before its writes, via an explicit caller-supplied parameter
+		// (the two quorum-signed entries must be able to skip it) — instead of
+		// leaving each new entry point to remember its own gate.
+		ok, reason, canonicalHash = consensus.ShouldHandleProposedBlock(chain, blockHeader)
+		if !ok {
+			skipProposedBlock(consensus.SkipSiteProposedBlockHandler+" skip vote for reorged block", reason, canonicalHash, blockHeader)
+			return nil
+		}
 		return x.sendVote(chain, blockInfo)
 	}
 

--- a/consensus/XDPoS/engines/engine_v2/vote.go
+++ b/consensus/XDPoS/engines/engine_v2/vote.go
@@ -217,6 +217,10 @@ func (x *XDPoS_v2) onVotePoolThresholdReached(chain consensus.ChainReader, poole
 		Signatures:        validSignatures,
 		GapNumber:         currentVoteMsg.(*types.Vote).GapNumber,
 	}
+	// No canonicality gate here, unlike ProposedBlockHandler: the pooled
+	// votes carry quorum-level signatures, so a QC for a locally side-chain
+	// block means the network's fork choice has diverged from ours —
+	// following the quorum majority is the convergence behavior.
 	err = x.processQC(chain, quorumCert)
 	if err != nil {
 		log.Error("Error while processing QC in the Vote handler after reaching pool threshold, ", err)

--- a/consensus/XDPoS/engines/engine_v2/vote_test.go
+++ b/consensus/XDPoS/engines/engine_v2/vote_test.go
@@ -48,21 +48,30 @@ func (h *memoryHandler) Records() []slog.Record {
 	return out
 }
 
-// MockChainReader is a mock implementation of consensus.ChainReader
+// MockChainReader is a mock implementation of consensus.ChainReader that
+// also satisfies consensus.BlockStorer, so handler-level tests can run
+// consensus.ShouldHandleProposedBlock against it without the integration
+// package. Headers registered via AddHeader serve as the canonical chain
+// (GetHeaderByNumber) and count as stored blocks (HasBlock): the mock
+// stores headers only, so header presence is its storage notion.
 type MockChainReader struct {
 	headers map[common.Hash]*types.Header
+	numbers map[uint64]*types.Header
 }
 
 // NewMockChainReader creates a new mock chain reader
 func NewMockChainReader() *MockChainReader {
 	return &MockChainReader{
 		headers: make(map[common.Hash]*types.Header),
+		numbers: make(map[uint64]*types.Header),
 	}
 }
 
-// AddHeader adds a header to the mock chain
+// AddHeader adds a header to the mock chain, making it the canonical
+// header at its height (last write wins) and marking its block stored.
 func (m *MockChainReader) AddHeader(header *types.Header) {
 	m.headers[header.Hash()] = header
+	m.numbers[header.Number.Uint64()] = header
 }
 
 // Config implements consensus.ChainReader
@@ -82,7 +91,13 @@ func (m *MockChainReader) GetHeader(hash common.Hash, number uint64) *types.Head
 
 // GetHeaderByNumber implements consensus.ChainReader
 func (m *MockChainReader) GetHeaderByNumber(number uint64) *types.Header {
-	return nil
+	return m.numbers[number]
+}
+
+// HasBlock implements consensus.BlockStorer: a registered header counts as
+// a stored block (the mock stores headers only).
+func (m *MockChainReader) HasBlock(hash common.Hash, number uint64) bool {
+	return m.headers[hash] != nil
 }
 
 // GetHeaderByHash implements consensus.ChainReader
@@ -121,4 +136,64 @@ func TestVerifyVoteMessage_VoteRoundTooOld(t *testing.T) {
 	// Should reject the vote without error
 	assert.False(t, verified, "Should return false for vote with round < currentRound")
 	assert.NoError(t, err, "Should not return an error for old round votes")
+}
+
+// blockInfoOf turns a header into the BlockInfo shape the voting rule and
+// forensics pass around. The round is irrelevant to isExtendingFromAncestor,
+// which only walks hashes and numbers.
+func blockInfoOf(h *types.Header) *types.BlockInfo {
+	return &types.BlockInfo{Hash: h.Hash(), Number: h.Number}
+}
+
+// TestIsExtendingFromAncestor covers the parent walk of the HotStuff voting
+// rule at the rule layer. The handler-level tests cannot reach the positive
+// branch anymore: since ProposedBlockHandler gates on canonicality, a
+// proposed block on the locked ancestor's own chain that passes the gate
+// always outranks the lockQC round and returns before the walk (see
+// TestShouldNotSendVoteMsgIfCanonicalBlockNotExtendedFromForkedAncestor),
+// and the forensics caller's positive path is only exercised by a skipped
+// test. Both branches of the walk are safety-critical — a false positive
+// lets a node vote off the locked chain, a false negative stalls it — so
+// the walk itself gets direct coverage here.
+func TestIsExtendingFromAncestor(t *testing.T) {
+	// 1 <- 2 <- 3, with 2' a same-height fork of 2.
+	mockChain := NewMockChainReader()
+	h1 := &types.Header{Number: big.NewInt(1)}
+	h2 := &types.Header{Number: big.NewInt(2), ParentHash: h1.Hash()}
+	h3 := &types.Header{Number: big.NewInt(3), ParentHash: h2.Hash()}
+	forkH2 := &types.Header{Number: big.NewInt(2), ParentHash: h1.Hash(), Coinbase: common.BytesToAddress([]byte{0x02})}
+	for _, h := range []*types.Header{h1, h2, h3} {
+		mockChain.AddHeader(h)
+	}
+	engine := &XDPoS_v2{}
+
+	// Positive branch: the walk runs two hops down the parent chain and
+	// lands exactly on the locked ancestor.
+	extended, err := engine.isExtendingFromAncestor(mockChain, blockInfoOf(h3), blockInfoOf(h1))
+	assert.NoError(t, err)
+	assert.True(t, extended, "h3 extends the locked ancestor h1")
+
+	// Negative branch with the walk executed: h3's parent chain bottoms out
+	// at h1, not at the forked ancestor 2', so the final hash comparison
+	// rejects the block. This is the geometry
+	// TestShouldNotSendVoteMsgIfCanonicalBlockNotExtendedFromForkedAncestor
+	// exercises through verifyVotingRule.
+	extended, err = engine.isExtendingFromAncestor(mockChain, blockInfoOf(h3), blockInfoOf(forkH2))
+	assert.NoError(t, err)
+	assert.False(t, extended, "h3 does not extend the forked ancestor 2'")
+
+	// Zero-iteration mismatch: the proposed block sits below the locked
+	// ancestor, so the walk never runs and only the direct hash comparison
+	// can reject it. This is the geometry of
+	// TestShouldNotSendVoteMsgIfBlockNotExtendedFromAncestor.
+	extended, err = engine.isExtendingFromAncestor(mockChain, blockInfoOf(h1), blockInfoOf(h2))
+	assert.NoError(t, err)
+	assert.False(t, extended, "h1 is below the locked ancestor h2")
+
+	// A missing parent aborts the walk with an error instead of silently
+	// reporting false: the proposed block's own header is not in the chain.
+	missing := &types.BlockInfo{Hash: common.StringToHash("missing"), Number: big.NewInt(3)}
+	extended, err = engine.isExtendingFromAncestor(mockChain, missing, blockInfoOf(h1))
+	assert.Error(t, err)
+	assert.False(t, extended)
 }

--- a/consensus/proposed_block.go
+++ b/consensus/proposed_block.go
@@ -1,0 +1,221 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package consensus
+
+import (
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/metrics"
+)
+
+// XDPoS v2 specific: the proposed-block gating judgment and the capability
+// interfaces it needs live here, so consensus and eth can share them without an
+// import cycle.
+
+// CanonicalChain is the canonicality half of the proposed-block judgment.
+type CanonicalChain interface {
+	// GetHeaderByNumber retrieves the canonical header at the given height.
+	GetHeaderByNumber(number uint64) *types.Header
+}
+
+// BlockStorer is the optional storage half. Header-only chains (e.g.
+// *core.HeaderChain) deliberately lack it, so they fail loudly as SkipUnjudgeable
+// instead of every block silently failing "not stored".
+type BlockStorer interface {
+	// HasBlock reports whether the block is stored in the database.
+	HasBlock(hash common.Hash, number uint64) bool
+}
+
+// ProposedBlockChain is what a proposed-block entry point must be handed:
+// the chain access the handler body needs plus the storage half of the
+// judgment. Entry points take this instead of ChainReader so a wiring that
+// passes a chain without HasBlock fails at compile time instead of skipping
+// every proposed block as SkipUnjudgeable at runtime. ShouldHandleProposedBlock
+// still keeps the narrower CanonicalChain parameter with its runtime
+// assertion as a defense, so the unjudgeable path cannot be silently
+// removed from the judgment itself; in production wiring the assertion
+// cannot fail, so the path is reachable only from test fakes.
+type ProposedBlockChain interface {
+	ChainReader
+	BlockStorer
+}
+
+// SkipReason describes why a proposed block header was rejected; empty means accepted.
+type SkipReason string
+
+// The reasons a header can be rejected. Each is graded and counted by the
+// skipReasons table below; register new reasons there.
+const (
+	// SkipNoCanonicalHeader: no canonical header exists at the height.
+	SkipNoCanonicalHeader SkipReason = "no canonical header at height"
+
+	// SkipNonCanonical: the header is not the canonical block at its height.
+	SkipNonCanonical SkipReason = "non-canonical"
+
+	// SkipBodyNotStored: the canonical block's body is not in the database yet (fast sync).
+	SkipBodyNotStored SkipReason = "block body not stored"
+
+	// SkipUnjudgeable: the chain lacks BlockStorer — a wiring bug: every block
+	// is skipped, halting processQC and voting. Unreachable in production
+	// (entry points take ProposedBlockChain); see skipReasons.
+	SkipUnjudgeable SkipReason = "unjudgeable"
+
+	// SkipNilHeader: a nil header or nil number — a caller bug.
+	SkipNilHeader SkipReason = "nil header"
+)
+
+// IsJudgeableHeader reports whether a proposed-block header has the minimum
+// shape the handlers dereference: a non-nil header with a non-nil number.
+func IsJudgeableHeader(header *types.Header) bool {
+	return header != nil && header.Number != nil
+}
+
+// SkipNilHeaderLog's call sites pass one of these constants instead of a string
+// literal: mistyping a constant name is a compile error, whereas a mistyped
+// literal would silently log a prefix nothing matches on.
+const (
+	// SkipSiteFetcher: the eth fetcher gate (eth/handler.go fast-sync path).
+	SkipSiteFetcher = "[fetcher]"
+	// SkipSiteProposedBlockHandler: the v2 engine's ProposedBlockHandler.
+	SkipSiteProposedBlockHandler = "[ProposedBlockHandler]"
+	// SkipSiteHandleProposedBlock: the XDPoS wrapper's HandleProposedBlock.
+	SkipSiteHandleProposedBlock = "[HandleProposedBlock]"
+)
+
+// SkipNilHeaderLog logs a nil-shape skip: a nil header or nil number is a
+// caller bug, not an observation about a block, so it logs at Error, counts
+// nothing, and the caller returns nil. Its three call sites (the XDPoS wrapper,
+// the v2 engine, the eth fetcher gate) must stay consistent: each passes one of
+// the SkipSite* constants above, and the message keeps the literal "nil header"
+// so tests can pin the guard without coupling to a site string.
+func SkipNilHeaderLog(site string) {
+	SkipLogLevel(SkipNilHeader)(site + " skip block: nil header")
+}
+
+// ShouldHandleProposedBlock reports whether a proposed block header should reach
+// the consensus handler, plus the SkipReason and the canonical hash at that
+// height (zero when the judgment fails before a canonical header is read). A
+// header is handled only if it is the canonical block at its height — an
+// existence check cannot distinguish a reorged-away fork, which stays in the
+// database — and its body is stored (fast sync marks a height canonical before
+// its body lands); HasBlock answers that half without decoding the body.
+// The reads are not atomic — a reorg can land between or after them — so the v2
+// engine re-checks before processQC and before sendVote. A chain without
+// BlockStorer, or a nil header or number, fails before any chain read. Storage
+// is graded at two strengths: this judgment and the engine gates require
+// HasBlock only, the fetcher gate requires HasBlockAndExecutedState.
+func ShouldHandleProposedBlock(chain CanonicalChain, header *types.Header) (bool, SkipReason, common.Hash) {
+	if header == nil || header.Number == nil {
+		return false, SkipNilHeader, common.Hash{}
+	}
+	storer, ok := chain.(BlockStorer)
+	if !ok {
+		// Not counted: production wiring cannot reach this branch — every
+		// entry point takes ProposedBlockChain (compile-time BlockStorer) and
+		// the downloader's BlockChain interface requires HasBlock. Only test
+		// fakes get here; every gate still logs this reason at Error (see
+		// skipReasons), which is the wiring-bug alarm.
+		return false, SkipUnjudgeable, common.Hash{}
+	}
+	canonical := chain.GetHeaderByNumber(header.Number.Uint64())
+	if canonical == nil {
+		return false, SkipNoCanonicalHeader, common.Hash{}
+	}
+	if canonical.Hash() != header.Hash() {
+		return false, SkipNonCanonical, canonical.Hash()
+	}
+	if !storer.HasBlock(header.Hash(), header.Number.Uint64()) {
+		return false, SkipBodyNotStored, canonical.Hash()
+	}
+	return true, "", canonical.Hash()
+}
+
+// skipRegistration is the single registration for one SkipReason: its log grade
+// at each call site and, when the reason can reach a counting gate, its own
+// counter (nil means the reason logs but counts nothing).
+type skipRegistration struct {
+	handler   func(msg string, ctx ...interface{})
+	preFilter func(msg string, ctx ...interface{})
+	counter   *metrics.Counter
+}
+
+// skipReasons is the single registration table for every SkipReason: one entry
+// grades a reason at both call sites and registers its counter, so a new
+// reason cannot be missed for one grader or one counter. Unregistered reasons
+// — including the misused empty reason — fall back to Warn and count nothing.
+// The fetcher's gate is outside the table: it produces no SkipReason.
+//
+// The counters separate what the engine-gate total skipped-proposed-block
+// cannot: a fast-sync burst of body-not-stored is transient, while a
+// persistent non-canonical rate is a stall. Only the engine gates count (see
+// the v2 engine's skipProposedBlock): the downloader pre-filter keeps its
+// aggregate skipped-proposed-block/prefilter, and the eth fetcher gate skips
+// before any judgment and carries no reason at all.
+var skipReasons = map[SkipReason]skipRegistration{
+	SkipUnjudgeable: {
+		handler:   log.Error,
+		preFilter: log.Error,
+		// No counter: production wiring cannot reach this reason (see the
+		// assertion in ShouldHandleProposedBlock), so a counter here would
+		// stay silent forever and be false assurance in alerting. The Error
+		// grades above are the wiring-bug alarm.
+	},
+	// SkipNilHeader logs but counts nothing: it is a caller bug, not an
+	// observation about a block (see SkipNilHeaderLog).
+	// No preFilter grade: the downloader's tail header is always built from
+	// fetched results, so the pre-filter can never produce this reason;
+	// PreFilterSkipLogLevel falls back to Warn if it ever did.
+	SkipNilHeader:         {handler: log.Error},
+	SkipNonCanonical:      {handler: log.Warn, preFilter: log.Info, counter: metrics.NewRegisteredCounter("skipped-proposed-block/non-canonical", nil)},
+	SkipNoCanonicalHeader: {handler: log.Warn, preFilter: log.Info, counter: metrics.NewRegisteredCounter("skipped-proposed-block/no-canonical-header", nil)},
+	SkipBodyNotStored:     {handler: log.Info, preFilter: log.Info, counter: metrics.NewRegisteredCounter("skipped-proposed-block/body-not-stored", nil)},
+}
+
+// SkipLogLevel grades a skip once the handler is reached: wiring and caller
+// bugs are Errors, reorg races Warn, the expected fast-sync skip Info. See
+// skipReasons.
+func SkipLogLevel(reason SkipReason) func(msg string, ctx ...interface{}) {
+	if g, ok := skipReasons[reason]; ok {
+		return g.handler
+	}
+	return log.Warn
+}
+
+// PreFilterSkipLogLevel grades a skip at the downloader's pre-filter, where fork
+// tails are routine noise (Info). Wiring bugs grade Error here too: the
+// downloader's only unjudgeable path is the narrow CanonicalChain defense in
+// ShouldHandleProposedBlock. A registration without a preFilter grade falls
+// back to Warn — only SkipNilHeader, which the pre-filter cannot produce.
+func PreFilterSkipLogLevel(reason SkipReason) func(msg string, ctx ...interface{}) {
+	if g, ok := skipReasons[reason]; ok && g.preFilter != nil {
+		return g.preFilter
+	}
+	return log.Warn
+}
+
+// IncSkipReasonCounter bumps the reason's own counter; reasons without a
+// dedicated counter — unknown ones, or SkipNilHeader — count nothing here.
+// Call it in addition to the engine-gate total consensus/skipped-proposed-
+// block, never instead: the total is that gate's aggregate view and the
+// per-reason counters are its breakdown, so their unjudgeable entry is the
+// only unjudgeable counter.
+func IncSkipReasonCounter(reason SkipReason) {
+	if g, ok := skipReasons[reason]; ok && g.counter != nil {
+		g.counter.Inc(1)
+	}
+}

--- a/consensus/proposed_block_test.go
+++ b/consensus/proposed_block_test.go
@@ -1,0 +1,421 @@
+// Copyright 2026 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package consensus
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"math/big"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/log"
+)
+
+// stubCanonicalChain is the minimal chain the judgment needs: the canonical
+// header per height and which hashes have a body stored behind them. It is
+// both a CanonicalChain and a BlockStorer — the judgement must never look at
+// anything else.
+type stubCanonicalChain struct {
+	headers map[uint64]*types.Header
+	bodies  map[common.Hash]bool
+}
+
+func (s *stubCanonicalChain) GetHeaderByNumber(number uint64) *types.Header {
+	return s.headers[number]
+}
+
+func (s *stubCanonicalChain) HasBlock(hash common.Hash, number uint64) bool {
+	return s.bodies[hash]
+}
+
+// stubHeaderOnlyChain is a CanonicalChain that is deliberately not a
+// BlockStorer, the way a header-only chain (e.g. *core.HeaderChain) looks to
+// the judgment: it must be skipped as SkipUnjudgeable, not judged "not stored".
+type stubHeaderOnlyChain struct {
+	headers map[uint64]*types.Header
+}
+
+func (s *stubHeaderOnlyChain) GetHeaderByNumber(number uint64) *types.Header {
+	return s.headers[number]
+}
+
+func TestShouldHandleProposedBlock(t *testing.T) {
+	const height = uint64(906)
+	canonical := &types.Header{Number: big.NewInt(int64(height)), Coinbase: common.BytesToAddress([]byte{0x01})}
+	fork := &types.Header{Number: big.NewInt(int64(height)), Coinbase: common.BytesToAddress([]byte{0x02})}
+
+	for _, c := range []struct {
+		name          string
+		headers       map[uint64]*types.Header
+		bodies        map[common.Hash]bool
+		header        *types.Header
+		storerless    bool
+		wantOK        bool
+		wantReason    SkipReason
+		wantCanonHash common.Hash
+	}{
+		{
+			name:          "no canonical header at height",
+			headers:       map[uint64]*types.Header{},
+			bodies:        map[common.Hash]bool{},
+			header:        canonical,
+			wantOK:        false,
+			wantReason:    SkipNoCanonicalHeader,
+			wantCanonHash: common.Hash{},
+		},
+		{
+			name:          "nil header is a caller bug, skipped before any chain read",
+			headers:       map[uint64]*types.Header{},
+			bodies:        map[common.Hash]bool{},
+			header:        nil,
+			wantOK:        false,
+			wantReason:    SkipNilHeader,
+			wantCanonHash: common.Hash{},
+		},
+		{
+			name:          "header without number is a caller bug too",
+			headers:       map[uint64]*types.Header{},
+			bodies:        map[common.Hash]bool{},
+			header:        &types.Header{Coinbase: common.BytesToAddress([]byte{0x03})},
+			wantOK:        false,
+			wantReason:    SkipNilHeader,
+			wantCanonHash: common.Hash{},
+		},
+		{
+			name: "non-canonical",
+			headers: map[uint64]*types.Header{
+				height: canonical,
+			},
+			bodies: map[common.Hash]bool{
+				fork.Hash(): true,
+			},
+			header:        fork,
+			wantOK:        false,
+			wantReason:    SkipNonCanonical,
+			wantCanonHash: canonical.Hash(),
+		},
+		{
+			name: "canonical header without stored body",
+			headers: map[uint64]*types.Header{
+				height: canonical,
+			},
+			bodies:        map[common.Hash]bool{},
+			header:        canonical,
+			wantOK:        false,
+			wantReason:    SkipBodyNotStored,
+			wantCanonHash: canonical.Hash(),
+		},
+		{
+			name: "canonical header with stored body",
+			headers: map[uint64]*types.Header{
+				height: canonical,
+			},
+			bodies: map[common.Hash]bool{
+				canonical.Hash(): true,
+			},
+			header:        canonical,
+			wantOK:        true,
+			wantReason:    "",
+			wantCanonHash: canonical.Hash(),
+		},
+		{
+			name: "header-only chain cannot answer the storage half",
+			headers: map[uint64]*types.Header{
+				height: canonical,
+			},
+			header:     canonical,
+			storerless: true,
+			wantOK:     false,
+			wantReason: SkipUnjudgeable,
+		},
+		{
+			name:       "header-only chain, absent height still unjudgeable",
+			headers:    map[uint64]*types.Header{},
+			header:     canonical,
+			storerless: true,
+			wantOK:     false,
+			wantReason: SkipUnjudgeable,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var chain CanonicalChain = &stubCanonicalChain{headers: c.headers, bodies: c.bodies}
+			if c.storerless {
+				chain = &stubHeaderOnlyChain{headers: c.headers}
+			}
+			ok, reason, canonicalHash := ShouldHandleProposedBlock(chain, c.header)
+			if ok != c.wantOK {
+				t.Errorf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if reason != c.wantReason {
+				t.Errorf("reason = %q, want %q", reason, c.wantReason)
+			}
+			if canonicalHash != c.wantCanonHash {
+				t.Errorf("canonicalHash = %v, want %v", canonicalHash, c.wantCanonHash)
+			}
+		})
+	}
+}
+
+// TestSkipLogLevelGradesByReason pins the skip-log grading contract at
+// SkipLogLevel's definition site: SkipUnjudgeable — the wiring-bug skip that
+// halts QC processing and voting — surfaces as Error and sits outside the
+// Info/Warn discipline, the reorg-race skips (SkipNonCanonical,
+// SkipNoCanonicalHeader) surface as Warn, while SkipBodyNotStored — the one
+// routine sync skip — stays at Info, both here at the unit level and
+// end-to-end at the handler level (TestProposedBlockHandlerGradesSkipLogLevelByReason).
+// The empty reason means a misused accept — a caller bug — and grades Warn.
+// Any other unregistered reason grades Warn: a future skip reason whose
+// registration is forgotten must surface loudly, not hide at Info.
+func TestSkipLogLevelGradesByReason(t *testing.T) {
+	var logBuf bytes.Buffer
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelInfo, false))
+	glog.Verbosity(log.LevelInfo)
+	prevLog := log.Root()
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	for _, c := range []struct {
+		reason SkipReason
+		want   string
+	}{
+		{
+			SkipUnjudgeable,
+			"ERROR",
+		},
+		{SkipNilHeader, "ERROR"},
+		{SkipNonCanonical, "WARN"},
+		{SkipNoCanonicalHeader, "WARN"},
+		{SkipBodyNotStored, "INFO"},
+		{SkipReason(""), "WARN"},
+		// An unregistered reason must grade as the anomaly it most likely is,
+		// so a future reason whose registration is forgotten surfaces loudly
+		// instead of hiding at Info. The default branch is Warn for exactly
+		// this case.
+		{SkipReason("unregistered-future-reason"), "WARN"},
+	} {
+		logBuf.Reset()
+		SkipLogLevel(c.reason)("skip level probe")
+		level := ""
+		for _, line := range strings.Split(logBuf.String(), "\n") {
+			if strings.Contains(line, "skip level probe") {
+				level = strings.Fields(line)[0]
+				// glog pads the level to five characters, so "ERROR" carries
+				// no trailing space and runs straight into the timestamp.
+				if i := strings.IndexByte(level, '['); i >= 0 {
+					level = level[:i]
+				}
+				break
+			}
+		}
+		if level != c.want {
+			t.Errorf("reason %q graded to %q, want %s (log: %q)", c.reason, level, c.want, logBuf.String())
+		}
+	}
+}
+
+// TestPreFilterSkipLogLevelGradesByReason pins the downloader pre-filter's
+// call-site grading: the three routine reasons are Info there (fork tails
+// are expected sync noise, unlike the reorg races at the handler),
+// SkipUnjudgeable stays Error, SkipNilHeader falls back to Warn (the
+// pre-filter cannot produce it, so it carries no preFilter grade), and an
+// unregistered reason grades Warn.
+func TestPreFilterSkipLogLevelGradesByReason(t *testing.T) {
+	var logBuf bytes.Buffer
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelInfo, false))
+	glog.Verbosity(log.LevelInfo)
+	prevLog := log.Root()
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	for _, c := range []struct {
+		reason SkipReason
+		want   string
+	}{
+		{SkipUnjudgeable, "ERROR"},
+		{SkipNilHeader, "WARN"}, // no preFilter grade; cannot reach the pre-filter anyway
+		{SkipNonCanonical, "INFO"},
+		{SkipNoCanonicalHeader, "INFO"},
+		{SkipBodyNotStored, "INFO"},
+		{SkipReason("unregistered-future-reason"), "WARN"},
+	} {
+		logBuf.Reset()
+		PreFilterSkipLogLevel(c.reason)("pre-filter level probe")
+		level := ""
+		for _, line := range strings.Split(logBuf.String(), "\n") {
+			if strings.Contains(line, "pre-filter level probe") {
+				level = strings.Fields(line)[0]
+				if i := strings.IndexByte(level, '['); i >= 0 {
+					level = level[:i]
+				}
+				break
+			}
+		}
+		if level != c.want {
+			t.Errorf("reason %q graded to %q, want %s (log: %q)", c.reason, level, c.want, logBuf.String())
+		}
+	}
+}
+
+// TestSkipReasonsTableCoversDeclaredReasons pins the single registration
+// table in both directions: every SkipReason constant declared in this
+// package must have an entry — otherwise both graders silently fall back to
+// Warn and a new reason's intended level never applies — and the table must
+// not hold entries beyond the declared constants. The declared set is
+// enumerated from the package source with go/parser rather than a
+// hand-maintained second list: two parallel lists only disagree loudly, but
+// a new constant that skips both passes a list-vs-table comparison
+// undetected. The AST enumeration has no second list to forget, so an
+// unregistered constant cannot hide.
+//
+// Counting invariants: SkipNilHeader logs but counts nothing (see
+// SkipNilHeaderLog), and SkipUnjudgeable also counts nothing — production
+// wiring hands every entry point a ProposedBlockChain, so the reason cannot
+// fire outside test fakes and a counter would be permanently silent in
+// production, false assurance in alerting; the Error logs are the alarm.
+// Every other declared reason can reach a counting gate and must carry one
+// that IncSkipReasonCounter moves.
+func TestSkipReasonsTableCoversDeclaredReasons(t *testing.T) {
+	declared := declaredSkipReasons(t)
+
+	for _, c := range declared {
+		entry, ok := skipReasons[c.reason]
+		if !ok {
+			t.Errorf("skipReasons has no entry for SkipReason constant %s = %q; register it in the skipReasons table", c.name, c.reason)
+			continue
+		}
+		if c.reason == SkipNilHeader || c.reason == SkipUnjudgeable {
+			if entry.counter != nil {
+				t.Errorf("%s must not carry a counter: it counts nothing (see skipReasons)", c.name)
+			}
+			continue
+		}
+		if entry.counter == nil {
+			t.Errorf("SkipReason constant %s can reach a counting gate but has no counter; register it in the skipReasons table", c.name)
+			continue
+		}
+		before := entry.counter.Snapshot().Count()
+		IncSkipReasonCounter(c.reason)
+		if got := entry.counter.Snapshot().Count(); got != before+1 {
+			t.Errorf("IncSkipReasonCounter(%s) did not move its counter: before = %d, after = %d", c.name, before, got)
+		}
+	}
+	if len(skipReasons) != len(declared) {
+		t.Errorf("skipReasons holds %d entries for %d declared SkipReasons; a table entry is not a declared constant", len(skipReasons), len(declared))
+	}
+}
+
+// declaredSkipReasons enumerates every constant of type SkipReason declared in
+// this package's non-test source files by parsing the AST. skipReasons is keyed
+// by the constants' values, so the walk collects each spec's string literal.
+// Only the shape the package actually uses — an explicit SkipReason type with
+// a string-literal value — is supported; any other shape is a loud failure,
+// never a silent skip or a panic.
+func declaredSkipReasons(t *testing.T) []struct {
+	name   string
+	reason SkipReason
+} {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("failed to read consensus package directory: %v", err)
+	}
+	var declared []struct {
+		name   string
+		reason SkipReason
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, entry.Name(), nil, 0)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", entry.Name(), err)
+		}
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			typed := false
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				// Go's grouped-const rule: a spec without its own type inherits the
+				// previous spec's type, so track it across the block. A spec whose
+				// value is a SkipReason(...) conversion carries no type and stays
+				// unsupported — it either Fatalfs on its value shape below or is
+				// caught by the declared-vs-table count check.
+				if vs.Type != nil {
+					id, ok := vs.Type.(*ast.Ident)
+					typed = ok && id.Name == "SkipReason"
+				}
+				if !typed {
+					continue
+				}
+				if len(vs.Values) != len(vs.Names) {
+					t.Fatalf("SkipReason const %s has %d names for %d values; omitted values are not supported", vs.Names[0].Name, len(vs.Names), len(vs.Values))
+				}
+				for i, name := range vs.Names {
+					lit, ok := vs.Values[i].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						t.Fatalf("SkipReason constant %s has an unsupported value expression; declaredSkipReasons only supports string literals", name.Name)
+					}
+					value, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						t.Fatalf("SkipReason constant %s has an unquotable value %s: %v", name.Name, lit.Value, err)
+					}
+					declared = append(declared, struct {
+						name   string
+						reason SkipReason
+					}{name.Name, SkipReason(value)})
+				}
+			}
+		}
+	}
+	if len(declared) == 0 {
+		t.Fatal("no SkipReason constants found in the consensus package; the AST walk itself is broken")
+	}
+	return declared
+}
+
+// TestIsJudgeableHeader pins the nil-shape half of the proposed-block header
+// contract at its single implementation: a nil header and a nil number are
+// both unjudgeable, and a real header with a number is judgeable. The three
+// call sites (XDPoS wrapper, v2 engine, eth fetcher gate) must reject the
+// same shapes — log Error, no counter, return nil.
+func TestIsJudgeableHeader(t *testing.T) {
+	if IsJudgeableHeader(nil) {
+		t.Error("nil header must not be judgeable")
+	}
+	if IsJudgeableHeader(&types.Header{}) {
+		t.Error("header with nil number must not be judgeable")
+	}
+	if !IsJudgeableHeader(&types.Header{Number: big.NewInt(1)}) {
+		t.Error("header with a number must be judgeable")
+	}
+}

--- a/consensus/tests/engine_v2_tests/future_block_test.go
+++ b/consensus/tests/engine_v2_tests/future_block_test.go
@@ -1,0 +1,85 @@
+package engine_v2_tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInsertChainQueuesFutureBatchEndToEnd combines the two halves the
+// future-batch fix relies on: the real XDPoS engine classifying children of a
+// future block as ErrFutureBlock (timestamp check precedes the parent lookup),
+// and insertChain consuming those results by queueing the whole tail instead
+// of failing the import. The core stub-based tests pin the loop mechanics and
+// the engine tests pin the classification; neither covers their composition,
+// which is the exact online scenario the fix targets.
+//
+// Deliberately not skipped in -short mode: the whole run (910-block harness
+// build included) stays well under a second, and this is the only test that
+// covers the composition.
+func TestInsertChainQueuesFutureBatchEndToEnd(t *testing.T) {
+	config := params.TestXDPoSMockChainConfig
+	blockchain, _, tip910, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 910, config, nil)
+	t.Cleanup(blockchain.Stop)
+	db := blockchain.ChainDb()
+
+	// Build blocks 911..915 in memory only; none is written into the DB.
+	switchBlock := config.XDPoS.V2.SwitchBlock.Int64()
+	blocks := make([]*types.Block, 0, 5)
+	current := tip910
+	for n := 911; n <= 915; n++ {
+		block := CreateBlock(
+			blockchain,
+			blockchain.Config(),
+			current,
+			n,
+			int64(n)-switchBlock,
+			signer.Hex(),
+			signer,
+			signFn,
+			nil,
+			nil,
+			"",
+		)
+		blocks = append(blocks, block)
+		current = block
+	}
+
+	// Re-timestamp the tail (912..915) into the near future. The hash changes
+	// so the QC no longer matches, which is fine: the timestamp check also
+	// precedes QC verification. Each re-stamped header also breaks the link to
+	// its built child, so the parents are re-chained along the clone line. Park
+	// the tail 15s inside addFutureBlock's 30s acceptance window: addFutureBlock
+	// re-reads time.Now() at enqueue time, so the 15s of slack also absorbs a
+	// wall-clock step back between stamping here and the enqueue check (a 25s
+	// offset would leave only 5s and fail on a ~6s NTP step back), and it stays
+	// far beyond the 100ms futureBlocksLoop period, so the queue cannot drain
+	// before the assertions run.
+	now := uint64(time.Now().Unix())
+	var batch types.Blocks
+	batch = append(batch, blocks[0]) // 911 keeps a past timestamp and imports
+	parent := blocks[0]
+	for _, block := range blocks[1:] {
+		header := block.Header()
+		header.ParentHash = parent.Hash()
+		header.Time = now + 15
+		parent = types.NewBlockWithHeader(header).WithBody(*block.Body())
+		batch = append(batch, parent)
+	}
+
+	n, err := blockchain.InsertChain(batch)
+	assert.Nil(t, err, "a future tail must not fail the import, the downloader would drop the peer")
+	assert.Equal(t, len(batch), n)
+
+	// The prefix imported, the tail did not reach the database.
+	assert.Equal(t, blocks[0].NumberU64(), blockchain.CurrentBlock().Number.Uint64())
+	assert.Equal(t, blocks[0].Hash(), blockchain.CurrentBlock().Hash())
+	for _, block := range batch[1:] {
+		assert.Nil(t, blockchain.GetBlockByNumber(block.NumberU64()), "future block %d must stay queued", block.NumberU64())
+		assert.Nil(t, rawdb.ReadBadBlock(db, block.Hash()), "future block %d must not be reported as bad block", block.NumberU64())
+	}
+}

--- a/consensus/tests/engine_v2_tests/proposed_block_test.go
+++ b/consensus/tests/engine_v2_tests/proposed_block_test.go
@@ -1,14 +1,21 @@
 package engine_v2_tests
 
 import (
+	"bytes"
 	"fmt"
+	"math/big"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/accounts/abi/bind/backends"
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/utils"
 	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/params"
 	"github.com/stretchr/testify/assert"
 )
@@ -318,18 +325,30 @@ func TestShouldNotSendVoteMsgIfBlockNotExtendedFromAncestor(t *testing.T) {
 		t.Fatal("Fail to decode extra data", err)
 	}
 	assert.Equal(t, types.Round(9), extraField.Round)
-	// Set the lockQC and other pre-requist properties by block 906
-	err = engineV2.ProposedBlockHandler(blockchain, currentBlock.Header())
-	if err != nil {
-		t.Fatal("Error while handling block 16", err)
-	}
-	vote := <-engineV2.BroadcastCh
-	assert.Equal(t, types.Round(6), vote.(*types.Vote).ProposedBlockInfo.Round)
 
-	// Find the first forked block at block 14th
-	firstForkedBlock := blockchain.GetBlockByHash(blockchain.GetBlockByHash(forkedBlock.ParentHash()).ParentHash())
-	engineV2.SetNewRoundFaker(blockchain, types.Round(7), false)
-	err = engineV2.ProposedBlockHandler(blockchain, firstForkedBlock.Header())
+	// Process the QC carried by block 906 to set the lockQC without voting,
+	// so the negative case below is not blocked by the highestVotedRound
+	// voting-rule gate. The lockQC is the QC embedded in the block the QC
+	// points at, i.e. block 905's own QC pointing at block 904.
+	var extra906 types.ExtraFields_v2
+	err = utils.DecodeBytesExtraFields(currentBlock.Extra(), &extra906)
+	if err != nil {
+		t.Fatal("Fail to decode extra data of block 906", err)
+	}
+	err = engineV2.ProcessQCFaker(blockchain, extra906.QuorumCert)
+	if err != nil {
+		t.Fatal("Fail to process QC of block 906", err)
+	}
+
+	// Negative case: propose the canonical block 903, whose height is below
+	// the locked ancestor block 904. verifyVotingRule must reject it as not
+	// extending from the lockQC ancestor, so no vote is broadcast. The
+	// block is canonical on purpose, so the entry canonicality re-check of
+	// ProposedBlockHandler does not short-circuit the branch under test.
+	olderCanonicalBlock := blockchain.GetBlockByNumber(903)
+	assert.Equal(t, olderCanonicalBlock.Hash(), blockchain.GetCanonicalHash(olderCanonicalBlock.NumberU64()))
+	engineV2.SetNewRoundFaker(blockchain, types.Round(3), false)
+	err = engineV2.ProposedBlockHandler(blockchain, olderCanonicalBlock.Header())
 	if err != nil {
 		t.Fatal("Fail propose proposedBlock handler", err)
 	}
@@ -340,7 +359,104 @@ func TestShouldNotSendVoteMsgIfBlockNotExtendedFromAncestor(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		// Shoud not trigger setNewRound
 		round, _, _, _, _, _ := engineV2.GetPropertiesFaker()
-		assert.Equal(t, types.Round(7), round)
+		assert.Equal(t, types.Round(3), round)
+	}
+
+	// Positive control: the canonical block 906 extends the locked ancestor,
+	// so its vote is broadcast as usual.
+	err = engineV2.ProposedBlockHandler(blockchain, currentBlock.Header())
+	if err != nil {
+		t.Fatal("Error while handling block 16", err)
+	}
+	vote := <-engineV2.BroadcastCh
+	assert.Equal(t, types.Round(6), vote.(*types.Vote).ProposedBlockInfo.Round)
+}
+
+// Block and round relationship diagram for this test:
+// 904(4) - 905(5) - 906(6)       (canonical)
+// \ 904'(7) - 905'(8) - 906'(9)   (fork)
+//
+// The proposed block is canonical and higher than the locked ancestor, but
+// the locked ancestor belongs to a fork that has been reorged away. This
+// forces isExtendingFromAncestor to walk back through the proposed block's
+// parents before the final hash comparison rejects it. The contrasting test
+// above uses a proposed block below the locked ancestor, so that walk does
+// not run.
+//
+// Only the non-matching branch of the parent walk is reachable through the
+// handler. Reaching the ancestor would require proposing the forked block,
+// which ProposedBlockHandler rejects at its canonicality check first.
+func TestShouldNotSendVoteMsgIfCanonicalBlockNotExtendedFromForkedAncestor(t *testing.T) {
+	skipLongInShortMode(t)
+	// Block number 905, 906 have forks and forkedBlock is the 906th
+	var numOfForks = new(int)
+	*numOfForks = 3
+	blockchain, _, currentBlock, _, _, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	forkedAncestor := blockchain.GetBlockByHash(blockchain.GetBlockByHash(forkedBlock.ParentHash()).ParentHash())
+	assert.NotEqual(t, blockchain.GetCanonicalHash(forkedAncestor.NumberU64()), forkedAncestor.Hash())
+
+	// Process the QC carried by the canonical block 906, then the QC carried
+	// by the forked block 906', to set the lockQC without voting, so the
+	// negative case below is not blocked by the highestVotedRound voting-rule
+	// gate. The lockQC is the QC embedded in the block the processed QC
+	// points at: the first call leaves it at the canonical block 905's own
+	// QC (pointing at the canonical block 904), and the second call replaces
+	// it with the forked block 905's own QC, which points at the forked
+	// block 904'.
+	var extra906 types.ExtraFields_v2
+	err := utils.DecodeBytesExtraFields(currentBlock.Extra(), &extra906)
+	if err != nil {
+		t.Fatal("Fail to decode extra data of block 906", err)
+	}
+	err = engineV2.ProcessQCFaker(blockchain, extra906.QuorumCert)
+	if err != nil {
+		t.Fatal("Fail to process QC of block 906", err)
+	}
+
+	var extraForked906 types.ExtraFields_v2
+	err = utils.DecodeBytesExtraFields(forkedBlock.Extra(), &extraForked906)
+	if err != nil {
+		t.Fatal("Fail to decode extra data of forked block 906'", err)
+	}
+	err = engineV2.ProcessQCFaker(blockchain, extraForked906.QuorumCert)
+	if err != nil {
+		t.Fatal("Fail to process QC of forked block 906'", err)
+	}
+
+	// Pin the preconditions the negative case below relies on: the lockQC
+	// points at the forked ancestor and the current round leaves room for a
+	// vote on the canonical block 906 (round 6).
+	_, lockQC, _, _, highestVotedRound, _ := engineV2.GetPropertiesFaker()
+	if assert.NotNil(t, lockQC) {
+		assert.Equal(t, forkedAncestor.Hash(), lockQC.ProposedBlockInfo.Hash)
+	}
+	assert.Equal(t, types.Round(0), highestVotedRound)
+
+	// Negative case: propose the canonical block 906. It passes the entry
+	// canonicality re-check of ProposedBlockHandler on purpose, so the branch
+	// under test is verifyVotingRule: the block's QC round does not outrank
+	// the lockQC round, so isExtendingFromAncestor walks two parents down to
+	// the canonical block 904, which is not the forked ancestor 904', and the
+	// vote must be dropped.
+	engineV2.SetNewRoundFaker(blockchain, types.Round(6), false)
+	err = engineV2.ProposedBlockHandler(blockchain, currentBlock.Header())
+	if err != nil {
+		t.Fatal("Fail propose proposedBlock handler", err)
+	}
+	// Should not receive anything from the channel
+	select {
+	case <-engineV2.BroadcastCh:
+		t.Fatal("Should not trigger vote")
+	case <-time.After(3 * time.Second):
+		// Should not trigger setNewRound
+		round, lockQC, _, _, _, _ := engineV2.GetPropertiesFaker()
+		assert.Equal(t, types.Round(6), round)
+		if assert.NotNil(t, lockQC) {
+			assert.Equal(t, forkedAncestor.Hash(), lockQC.ProposedBlockInfo.Hash)
+		}
 	}
 }
 
@@ -395,4 +511,515 @@ func TestProposedBlockMessageHandlerNotGenerateVoteIfSignerNotInMNlist(t *testin
 		round, _, _, _, _, _ := engineV2.GetPropertiesFaker()
 		assert.Equal(t, types.Round(6), round)
 	}
+}
+
+// TestProposedBlockHandlerSkipsNonCanonicalBlock pins the canonicality and
+// storage re-check directly in front of processQC: the callers' gates race
+// with concurrent imports, and processQC updates highestQuorumCert, the lock
+// QC and the commit block before its own existence check, which a stored
+// side-chain block passes. The forked block below is exactly what the
+// window leaves behind: stored, with a valid parent QC, but no longer
+// canonical at its height.
+func TestProposedBlockHandlerSkipsNonCanonicalBlock(t *testing.T) {
+	var numOfForks = new(int)
+	*numOfForks = 1
+	blockchain, _, currentBlock, _, _, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Precondition: the fork is stored but is not canonical at its height.
+	assert.NotNil(t, blockchain.GetBlockByHash(forkedBlock.Hash()))
+	assert.NotEqual(t, forkedBlock.Hash(), blockchain.GetCanonicalHash(forkedBlock.NumberU64()))
+	assert.Equal(t, currentBlock.Hash(), blockchain.GetCanonicalHash(forkedBlock.NumberU64()))
+
+	beforeRound, beforeLockQC, beforeHighestQC, beforeTimeoutCert, beforeVotedRound, beforeCommit := engineV2.GetPropertiesFaker()
+	skippedBefore := skippedProposedBlockCount(t)
+	nonCanonicalBefore := skipReasonCounterCount(t, "skipped-proposed-block/non-canonical")
+	err := engineV2.ProposedBlockHandler(blockchain, forkedBlock.Header())
+	assert.Nil(t, err)
+	assert.Equal(t, skippedBefore+1, skippedProposedBlockCount(t), "the first-gate skip must increment skipped-proposed-block")
+	assert.Equal(t, nonCanonicalBefore+1, skipReasonCounterCount(t, "skipped-proposed-block/non-canonical"), "the first-gate skip must increment the non-canonical reason counter")
+
+	round, lockQC, highestQC, timeoutCert, votedRound, commit := engineV2.GetPropertiesFaker()
+	assert.Equal(t, beforeRound, round)
+	assert.Equal(t, beforeLockQC, lockQC)
+	assert.Equal(t, beforeHighestQC, highestQC)
+	assert.Equal(t, beforeTimeoutCert, timeoutCert)
+	assert.Equal(t, beforeVotedRound, votedRound)
+	assert.Equal(t, beforeCommit, commit)
+
+	// Neither commitBlocks nor setNewRound (processQC's other state writes —
+	// commit, round bump, timeoutPool clear, newRoundCh signal) may have run:
+	// the gate sits before processQC. The engine state assertions above cover
+	// the fields; here we pin that no newRoundCh signal was emitted either.
+	// The handler runs synchronously and NewRoundCh is buffered, so a
+	// non-blocking read right after the call is deterministic — no clock wait
+	// that could let the round timeout fire instead.
+	chainEngine := blockchain.Engine().(*XDPoS.XDPoS)
+	select {
+	case newRound := <-chainEngine.NewRoundCh:
+		t.Fatalf("non-canonical block must not advance the round, got newRoundCh signal %v", newRound)
+	default:
+	}
+
+	// A non-canonical block must not reach the vote broadcast either.
+	select {
+	case vote := <-engineV2.BroadcastCh:
+		t.Fatalf("non-canonical block must not trigger a vote, got round %v", vote.(*types.Vote).ProposedBlockInfo.Round)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// TestProposedBlockHandlerCoversMinerSelfVotePath mirrors the miner's
+// self-vote path (miner/worker.go: after WriteBlockWithState returns, the
+// worker calls HandleProposedBlock on its own block) against both write
+// outcomes the worker can observe. The miner calls the same handler these
+// tests drive, so this test makes that coupling explicit: a gate-semantic
+// change that would silently stop the proposer from advancing processQC and
+// self-voting must fail here first.
+func TestProposedBlockHandlerCoversMinerSelfVotePath(t *testing.T) {
+	var numOfForks = new(int)
+	*numOfForks = 1
+	blockchain, _, currentBlock, _, _, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Own block written as canonical (WriteBlockWithState returned
+	// core.CanonStatTy): the gate must let it through, processQC runs and the
+	// self-vote is broadcast. No skip counter may move.
+	skippedBefore := skippedProposedBlockCount(t)
+	err := engineV2.ProposedBlockHandler(blockchain, currentBlock.Header())
+	assert.Nil(t, err)
+	vote := <-engineV2.BroadcastCh
+	assert.Equal(t, currentBlock.Hash(), vote.(*types.Vote).ProposedBlockInfo.Hash)
+	assert.Equal(t, types.Round(6), vote.(*types.Vote).ProposedBlockInfo.Round)
+	assert.Equal(t, skippedBefore, skippedProposedBlockCount(t), "a canonical self-mined block must pass the gate without any skip")
+
+	// Competing block at the same height written as a side chain
+	// (WriteBlockWithState returned core.SideStatTy, i.e. the peer's block
+	// landed first): the gate must skip it — no processQC, no self-vote —
+	// counting the non-canonical reason.
+	assert.NotNil(t, blockchain.GetBlockByHash(forkedBlock.Hash()))
+	assert.NotEqual(t, forkedBlock.Hash(), blockchain.GetCanonicalHash(forkedBlock.NumberU64()))
+	nonCanonicalBefore := skipReasonCounterCount(t, "skipped-proposed-block/non-canonical")
+	err = engineV2.ProposedBlockHandler(blockchain, forkedBlock.Header())
+	assert.Nil(t, err)
+	assert.Equal(t, skippedBefore+1, skippedProposedBlockCount(t), "a side-chain self-mined block must be skipped by the gate")
+	assert.Equal(t, nonCanonicalBefore+1, skipReasonCounterCount(t, "skipped-proposed-block/non-canonical"), "the side-chain skip must increment the non-canonical reason counter")
+
+	select {
+	case vote := <-engineV2.BroadcastCh:
+		t.Fatalf("a side-chain self-mined block must not trigger a vote, got round %v", vote.(*types.Vote).ProposedBlockInfo.Round)
+	case <-time.After(2 * time.Second):
+	}
+}
+
+// reorgingChainReader simulates a concurrent reorg landing inside the
+// handler: x.lock does not block InsertChain, so the canonical answer for
+// a height can change between two judgment gates. The injection is anchored
+// on the gate boundary, not on read ordinals: every ShouldHandleProposedBlock
+// call that gets past the canonicality check ends in exactly one HasBlock of
+// the watched height (the judgment's contract, fixated at the unit level in
+// consensus/proposed_block_test.go), so the wrapper counts those HasBlock
+// calls as completed gates and serves the fork header on every read of the
+// watched height once truthfulGates gates have completed. Reads added in
+// front of or between the handler's gates therefore stay truthful and cannot
+// consume the fork early — the injection tracks where the reorg lands
+// relative to the gates, not how many times the handler happens to read.
+type reorgingChainReader struct {
+	consensus.ChainReader
+	watchNumber   uint64
+	truthfulGates int
+	forkHeader    *types.Header
+
+	// gates counts the completed judgment gates (HasBlock calls of the
+	// watched height); it is the injection anchor, not an assertion.
+	gates int
+}
+
+func (r *reorgingChainReader) GetHeaderByNumber(number uint64) *types.Header {
+	if number == r.watchNumber && r.gates >= r.truthfulGates {
+		return r.forkHeader
+	}
+	return r.ChainReader.GetHeaderByNumber(number)
+}
+
+// HasBlock forwards the storage half of the proposed-block judgment to the
+// wrapped chain, which must be a consensus.BlockStorer — the wrapper only
+// rewrites canonicality, never storage. Each HasBlock of the watched height
+// marks one completed judgment gate (the canonicality half passed), which is
+// what drives the fork injection above.
+func (r *reorgingChainReader) HasBlock(hash common.Hash, number uint64) bool {
+	if number == r.watchNumber {
+		r.gates++
+	}
+	return r.ChainReader.(consensus.BlockStorer).HasBlock(hash, number)
+}
+
+// TestProposedBlockHandlerSkipsReorgedBlockBeforeProcessQC covers the first
+// re-check point, directly in front of processQC: x.lock does not block
+// InsertChain, so a concurrent import can take the height over before the
+// handler reaches it. The wrapper serves the fork header from the first read
+// of the watched height on, making the reorg deterministic instead of racing
+// a real InsertChain. Block 906's embedded QC certifies block 905 at round 5,
+// higher than the engine's initial highestQuorumCert (round 0), so any
+// processQC run would visibly move the engine state — exactly what the gate
+// must prevent for a reorged-away block.
+func TestProposedBlockHandlerSkipsReorgedBlockBeforeProcessQC(t *testing.T) {
+	skipLongInShortMode(t)
+	var numOfForks = new(int)
+	*numOfForks = 1
+	blockchain, _, currentBlock, _, _, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Precondition: the fork sits at the same height but is not canonical.
+	assert.NotNil(t, blockchain.GetBlockByHash(forkedBlock.Hash()))
+	assert.Equal(t, forkedBlock.NumberU64(), currentBlock.NumberU64())
+	assert.NotEqual(t, forkedBlock.Hash(), blockchain.GetCanonicalHash(forkedBlock.NumberU64()))
+
+	// The height is already reorged when the handler first reads it: zero
+	// truthful gates.
+	chain := &reorgingChainReader{
+		ChainReader:   blockchain,
+		watchNumber:   currentBlock.NumberU64(),
+		truthfulGates: 0,
+		forkHeader:    forkedBlock.Header(),
+	}
+	beforeRound, beforeLockQC, beforeHighQC, beforeHighTC, beforeVotedRound, beforeCommitBlock := engineV2.GetPropertiesFaker()
+	err := engineV2.ProposedBlockHandler(chain, currentBlock.Header())
+	assert.Nil(t, err)
+
+	// The block was reorged away before processQC: the engine state must be
+	// untouched — no QC processed, nothing locked, nothing committed, no
+	// round advanced.
+	afterRound, afterLockQC, afterHighQC, afterHighTC, afterVotedRound, afterCommitBlock := engineV2.GetPropertiesFaker()
+	assert.Equal(t, beforeRound, afterRound)
+	assert.Equal(t, beforeLockQC, afterLockQC)
+	assert.Equal(t, beforeHighQC, afterHighQC)
+	assert.Equal(t, beforeHighTC, afterHighTC)
+	assert.Equal(t, beforeVotedRound, afterVotedRound)
+	assert.Equal(t, beforeCommitBlock, afterCommitBlock)
+
+	// Nothing may be broadcast either.
+	select {
+	case vote := <-engineV2.BroadcastCh:
+		t.Fatalf("a block reorged away before processQC must not be voted for, got vote for round %v hash %v", vote.(*types.Vote).ProposedBlockInfo.Round, vote.(*types.Vote).ProposedBlockInfo.Hash)
+	case <-time.After(2 * time.Second):
+	}
+
+	// No gate anchor needed: truthfulGates is 0, so every read of the watched
+	// height sees the fork and the handler skips before processQC no matter
+	// where the gates sit — the state anchors above cover the drift.
+}
+
+// TestProposedBlockHandlerDropsVoteForReorgedBlock covers the second
+// re-check point, right before sendVote: x.lock does not block InsertChain,
+// so a concurrent import can take the height over after processQC ran on the
+// still canonical block but before the vote is broadcast. The wrapper serves
+// the real canonical header to the pre-processQC re-check and the fork
+// header from then on, making the mid-handler reorg deterministic instead of
+// racing a real InsertChain. processQC legitimately runs in this window (the
+// block was canonical when it read the chain, so its state write is
+// expected); the vote is what must be dropped.
+func TestProposedBlockHandlerDropsVoteForReorgedBlock(t *testing.T) {
+	skipLongInShortMode(t)
+	var numOfForks = new(int)
+	*numOfForks = 1
+	// Height 906, not 901: the state anchor below needs a processQC run
+	// that visibly moves the engine. Block 901's embedded QC certifies
+	// block 900 at round 0, which the engine already holds — processQC
+	// would be a complete state no-op there. Block 906's QC certifies
+	// block 905 at round 5, strictly above the engine's initial state,
+	// so a successful processQC run advances highestQuorumCert, lockQC,
+	// currentRound and the commit block and the anchor can detect it.
+	blockchain, _, currentBlock, _, _, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Precondition: the fork sits at the same height but is not canonical.
+	assert.NotNil(t, blockchain.GetBlockByHash(forkedBlock.Hash()))
+	assert.Equal(t, forkedBlock.NumberU64(), currentBlock.NumberU64())
+	assert.NotEqual(t, forkedBlock.Hash(), blockchain.GetCanonicalHash(forkedBlock.NumberU64()))
+
+	// One truthful gate — the pre-processQC re-check; every read of this
+	// height from the gate's completion on sees the reorg. The injection is
+	// anchored on gate completion (HasBlock of the watched height), so reads
+	// added in front of the first gate stay truthful instead of consuming
+	// the fork there.
+	chain := &reorgingChainReader{
+		ChainReader:   blockchain,
+		watchNumber:   currentBlock.NumberU64(),
+		truthfulGates: 1,
+		forkHeader:    forkedBlock.Header(),
+	}
+	beforeRound, _, beforeHighQC, _, _, _ := engineV2.GetPropertiesFaker()
+	skippedBefore := skippedProposedBlockCount(t)
+	err := engineV2.ProposedBlockHandler(chain, currentBlock.Header())
+	assert.Nil(t, err)
+	assert.Equal(t, skippedBefore+1, skippedProposedBlockCount(t), "the pre-vote drop must increment skipped-proposed-block")
+
+	// State anchor: processQC must have run and moved the engine between
+	// the two gates. With truthfulGates 1 the pre-processQC gate still sees
+	// the canonical header, so a reorg can only take over after that gate
+	// completes. The injection itself is anchored on gate completion, not on
+	// read ordinals, so reads added in front of or between the gates stay
+	// truthful and cannot turn this into a pre-processQC skip. Only a
+	// genuine pre-vote reorg lets processQC advance the state while the vote
+	// is still dropped; any drift breaks the assertions below loudly.
+	// The retained processQC state write is expected behavior, not a pending
+	// fix: block 906's embedded QC certifies its parent 905, and that
+	// certification stays valid even after 906 is reorged away, so advancing
+	// highestQuorumCert/lockQC/the commit block on it is semantically right —
+	// the reorg only invalidates the vote for 906 itself, which is exactly
+	// what this test pins down (see also the second gate in engine.go).
+	afterRound, afterLockQC, afterHighQC, _, _, afterCommitBlock := engineV2.GetPropertiesFaker()
+	assert.Greater(t, afterRound, beforeRound, "processQC must have advanced the current round")
+	assert.Greater(t, afterHighQC.ProposedBlockInfo.Round, beforeHighQC.ProposedBlockInfo.Round, "processQC must have advanced highestQuorumCert")
+	assert.NotNil(t, afterLockQC, "processQC must have locked a parent QC")
+	assert.NotNil(t, afterCommitBlock, "processQC must have committed a block")
+
+	// The block was reorged away before the vote: nothing may be broadcast.
+	select {
+	case vote := <-engineV2.BroadcastCh:
+		t.Fatalf("a block reorged away before the vote must not be voted for, got vote for round %v hash %v", vote.(*types.Vote).ProposedBlockInfo.Round, vote.(*types.Vote).ProposedBlockInfo.Hash)
+	case <-time.After(2 * time.Second):
+	}
+
+}
+
+// TestProposedBlockHandlerSkipsBlockWithoutBody covers the storage half of
+// the gate: canonicality is a property of the header, not of the block, so
+// the fast sync header phase marks a height canonical before its body lands,
+// and the fetcher calls this handler after an insertBlock that can return
+// nil without writing anything (fast sync, and the downloadingBlock
+// short circuit). Only the downloader gates on storage, so the other
+// callers are covered here: a canonical header without a body must not
+// reach processQC or the vote broadcast, and must leave the engine state
+// untouched.
+func TestProposedBlockHandlerSkipsBlockWithoutBody(t *testing.T) {
+	skipLongInShortMode(t)
+	blockchain, _, currentBlock, signer, signFn, _ := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, nil)
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Insert a valid header for height 907 header-only, the way the fast
+	// sync header phase does: the height becomes canonical before any body
+	// is written. The block is built with the chain's own config so the
+	// header passes ValidateHeaderChain.
+	testConfig := legacyExecutionConfigForV2Tests(params.TestXDPoSMockChainConfig)
+	header907 := CreateBlock(blockchain, testConfig, currentBlock, 907, 7, signer.Hex(), signer, signFn, nil, nil, "").Header()
+	if _, err := blockchain.InsertHeaderChain([]*types.Header{header907}, 0); err != nil {
+		t.Fatal("Fail to insert header chain", err)
+	}
+	assert.Equal(t, header907.Hash(), blockchain.GetCanonicalHash(907))
+	assert.Nil(t, blockchain.GetBlock(header907.Hash(), 907))
+
+	before, beforeLockQC, beforeHighQC, beforeHighTC, beforeVotedRound, beforeCommitBlock := engineV2.GetPropertiesFaker()
+	err := engineV2.ProposedBlockHandler(blockchain, header907)
+	if err != nil {
+		t.Fatal("Fail propose proposedBlock handler", err)
+	}
+	// Should not receive anything from the channel
+	select {
+	case <-engineV2.BroadcastCh:
+		t.Fatal("Should not trigger vote")
+	case <-time.After(3 * time.Second):
+	}
+
+	// The engine state must be untouched: no QC processed, nothing voted,
+	// no round advanced.
+	after, afterLockQC, afterHighQC, afterHighTC, afterVotedRound, afterCommitBlock := engineV2.GetPropertiesFaker()
+	assert.Equal(t, before, after)
+	assert.Equal(t, beforeLockQC, afterLockQC)
+	assert.Equal(t, beforeHighQC, afterHighQC)
+	assert.Equal(t, beforeHighTC, afterHighTC)
+	assert.Equal(t, beforeVotedRound, afterVotedRound)
+	assert.Equal(t, beforeCommitBlock, afterCommitBlock)
+}
+
+// TestProposedBlockHandlerGradesSkipLogLevelByReason fixates the skip-log
+// grading: the reorg-race skips (SkipNonCanonical, SkipNoCanonicalHeader)
+// surface as Warn — the fast sync header phase marks heights canonical, so
+// a missing marker is never a routine sync state — while SkipBodyNotStored,
+// the one routine sync skip, stays at Info so a Warn per header-only fast
+// sync height cannot drown the level reserved for anomalies.
+func TestProposedBlockHandlerGradesSkipLogLevelByReason(t *testing.T) {
+	var numOfForks = new(int)
+	*numOfForks = 1
+	blockchain, _, currentBlock, signer, signFn, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Capture the handler's own skip logs and assert on the level prefix of
+	// the specific skip line, so unrelated background logs cannot interfere.
+	var logBuf bytes.Buffer
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelInfo, false))
+	glog.Verbosity(log.LevelInfo)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	levelOf := func(msg string) string {
+		for _, line := range strings.Split(logBuf.String(), "\n") {
+			if strings.Contains(line, msg) {
+				return strings.Fields(line)[0]
+			}
+		}
+		return ""
+	}
+
+	// A fork block is a genuine reorg-race skip: it must stay at Warn.
+	err := engineV2.ProposedBlockHandler(blockchain, forkedBlock.Header())
+	assert.Nil(t, err)
+	assert.Equal(t, "WARN", levelOf(consensus.SkipSiteProposedBlockHandler+" skip block before processQC"),
+		"a non-canonical skip is a reorg race and must stay at Warn, have %q", logBuf.String())
+
+	// A height with no canonical header at all is a reorg-race skip too:
+	// markers only go missing above a contested head (a fork growing past
+	// the local chain, a displaced tip re-delivered, or a concurrent reorg),
+	// so it must stay at Warn. Reuse the fork header's extra data (so
+	// getExtraFields still parses) at a height nothing occupies.
+	noCanonical := *forkedBlock.Header()
+	noCanonical.Number = big.NewInt(99999)
+	logBuf.Reset()
+	err = engineV2.ProposedBlockHandler(blockchain, &noCanonical)
+	assert.Nil(t, err)
+	assert.Equal(t, "WARN", levelOf(consensus.SkipSiteProposedBlockHandler+" skip block before processQC"),
+		"a no-canonical-header skip is a reorg race and must stay at Warn, have %q", logBuf.String())
+
+	// A canonical header without a stored body is the one routine skip: the
+	// fast sync header phase marks a height canonical before its body lands,
+	// so it must stay at Info. Build the shape the way that phase does —
+	// InsertHeaderChain one height past the canonical tip — mirroring
+	// TestProposedBlockHandlerSkipsBlockWithoutBody, and assert the level of
+	// the very same skip line the two reorg-race sections above graded to Warn.
+	testConfig := legacyExecutionConfigForV2Tests(params.TestXDPoSMockChainConfig)
+	header907 := CreateBlock(blockchain, testConfig, currentBlock, 907, 7, signer.Hex(), signer, signFn, nil, nil, "").Header()
+	if _, err := blockchain.InsertHeaderChain([]*types.Header{header907}, 0); err != nil {
+		t.Fatal("Fail to insert header chain", err)
+	}
+	assert.Equal(t, header907.Hash(), blockchain.GetCanonicalHash(907))
+	assert.Nil(t, blockchain.GetBlock(header907.Hash(), 907))
+	logBuf.Reset()
+	err = engineV2.ProposedBlockHandler(blockchain, header907)
+	assert.Nil(t, err)
+	assert.Equal(t, "INFO", levelOf(consensus.SkipSiteProposedBlockHandler+" skip block before processQC"),
+		"a body-not-stored skip is routine fast-sync state and must stay at Info, have %q", logBuf.String())
+}
+
+// TestProposedBlockHandlerSkipsUnjudgeableChain was removed when the
+// proposed-block entry points started requiring consensus.ProposedBlockChain:
+// a chain without HasBlock can no longer reach the handler — the wiring
+// fails at compile time instead. The runtime unjudgeable contract lives on
+// only in the narrow CanonicalChain defense inside
+// consensus.ShouldHandleProposedBlock, pinned at the helper level by
+// TestShouldHandleProposedBlock (header-only-chain cases) and the
+// skipReasons grading tests in consensus/proposed_block_test.go.
+
+// TestProposedBlockHandlerSkipsNilHeader pins the engine-side nil-header
+// contract: getExtraFields dereferences header.Number before the
+// ShouldHandleProposedBlock guard runs, so the handler must judge the nil
+// shapes itself — no panic, an Error-level skip through the skip table (a
+// caller bug is graded like a wiring bug), nil returned, and no counter
+// increment (a caller bug is not a block observation).
+func TestProposedBlockHandlerSkipsNilHeader(t *testing.T) {
+	blockchain, _, _, _, _, _ := PrepareXDCTestBlockChainForV2Engine(t, 901, params.TestXDPoSMockChainConfig, nil)
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Capture the handler's logs and assert the nil-header skip surfaces
+	// at Error — a caller bug, graded like the wiring bugs.
+	var logBuf bytes.Buffer
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelInfo, false))
+	glog.Verbosity(log.LevelInfo)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	// Both nil shapes must be judged before getExtraFields dereferences
+	// header.Number: a fully nil header and a header without a number.
+	shapes := map[string]*types.Header{"nil": nil, "nil number": {}}
+	before := skippedProposedBlockCount(t)
+	for name, header := range shapes {
+		assert.Nil(t, engineV2.ProposedBlockHandler(blockchain, header),
+			"a %s header is a caller bug and must skip, not panic or error", name)
+	}
+	assert.Equal(t, before, skippedProposedBlockCount(t),
+		"a caller-bug skip must not touch the block-observation counter")
+
+	found := 0
+	for _, line := range strings.Split(logBuf.String(), "\n") {
+		if strings.Contains(line, "skip block: nil header") {
+			assert.True(t, strings.HasPrefix(line, "ERROR"), "nil-header skip must log at Error, got line %q", line)
+			found++
+		}
+	}
+	assert.Equal(t, 2, found, "both nil shapes must be logged, have %q", logBuf.String())
+}
+
+// TestProposedBlockHandlerSkipsNonCanonicalBlockWithMalformedExtra pins the
+// ordering between the skip judgment and extra parsing: the judgment reads
+// only the header's place in the chain, so a block that must be skipped
+// skips (nil) even when its extra data is malformed — surfacing an error
+// would make the fetcher treat the skip as an import failure and suppress
+// the block's broadcast.
+func TestProposedBlockHandlerSkipsNonCanonicalBlockWithMalformedExtra(t *testing.T) {
+	var numOfForks = new(int)
+	*numOfForks = 1
+	blockchain, _, _, _, _, forkedBlock := PrepareXDCTestBlockChainForV2Engine(t, 906, params.TestXDPoSMockChainConfig, &ForkedBlockOptions{numOfForkedBlocks: numOfForks})
+	defer blockchain.Stop()
+	engineV2 := blockchain.Engine().(*XDPoS.XDPoS).EngineV2
+
+	// Precondition: the fork is stored but is not canonical at its height.
+	assert.NotNil(t, blockchain.GetBlockByHash(forkedBlock.Hash()))
+	assert.NotEqual(t, forkedBlock.Hash(), blockchain.GetCanonicalHash(forkedBlock.NumberU64()))
+
+	// Corrupt the fork header's extra data so getExtraFields cannot decode
+	// it; the corrupted copy stays non-canonical at its height (its hash no
+	// longer matches the canonical entry either).
+	header := *forkedBlock.Header()
+	header.Extra = []byte("malformed extra")
+	assert.NotEqual(t, header.Hash(), blockchain.GetCanonicalHash(header.Number.Uint64()))
+
+	skippedBefore := skippedProposedBlockCount(t)
+	err := engineV2.ProposedBlockHandler(blockchain, &header)
+	assert.Nil(t, err, "a skippable block must skip even when its extra data is malformed")
+	assert.Equal(t, skippedBefore+1, skippedProposedBlockCount(t), "the skip must increment skipped-proposed-block")
+
+	// The skip must not reach the vote broadcast.
+	select {
+	case vote := <-engineV2.BroadcastCh:
+		t.Fatalf("malformed-extra block must not trigger a vote, got %v", vote)
+	default:
+	}
+}
+
+// skippedProposedBlockCount reads the engine gates' skip counter through the
+// metrics registry — the counter lives in the engine package and is otherwise
+// invisible from this external test package.
+//
+// The assertions in this file compare counts before and after a call on the
+// global registry, so no case in this file may use t.Parallel(): parallel
+// cases touching the same counter would race on the before/after deltas.
+func skippedProposedBlockCount(t *testing.T) int64 {
+	t.Helper()
+	counter, ok := metrics.Get("skipped-proposed-block").(*metrics.Counter)
+	if !ok {
+		t.Fatal("skipped-proposed-block is not registered in the metrics registry")
+	}
+	return counter.Snapshot().Count()
+}
+
+// skipReasonCounterCount reads a per-reason counter through the metrics
+// registry; the counters live in the consensus package and are otherwise
+// invisible from this external test package. Same no-t.Parallel() contract
+// as skippedProposedBlockCount.
+func skipReasonCounterCount(t *testing.T, name string) int64 {
+	t.Helper()
+	counter, ok := metrics.Get(name).(*metrics.Counter)
+	if !ok {
+		t.Fatalf("%s is not registered in the metrics registry", name)
+	}
+	return counter.Snapshot().Count()
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1306,6 +1306,14 @@ func (bc *BlockChain) insertStopped() bool {
 	return bc.procInterrupt.Load()
 }
 
+// proposedBlockHandler is the consensus hook invoked when the future-block
+// queue imports a block that advances the canonical head, letting the engine
+// process the new head (QC handling, voting). XDPoS implements it; the small
+// interface keeps procFutureBlocks testable with a stub engine.
+type proposedBlockHandler interface {
+	HandleProposedBlock(chain consensus.ChainReader, header *types.Header) error
+}
+
 func (bc *BlockChain) procFutureBlocks() {
 	capacity := bc.futureBlocks.Len()
 	if capacity == 0 {
@@ -1321,17 +1329,44 @@ func (bc *BlockChain) procFutureBlocks() {
 		types.BlockBy(types.Number).Sort(blocks)
 
 		// Insert one by one as chain insertion needs contiguous ancestry between blocks
+		var lastCanon *types.Block
 		for i := range blocks {
-			_, err := bc.InsertChain(blocks[i : i+1])
-			// let consensus engine handle the last block (e.g. for voting)
-			if i == len(blocks)-1 && err == nil {
-				engine, ok := bc.Engine().(*XDPoS.XDPoS)
-				if ok {
-					header := blocks[i].Header()
-					err = engine.HandleProposedBlock(bc, header)
-					if err != nil {
-						log.Info("[procFutureBlocks] handle proposed block has error", "err", err, "block hash", header.Hash(), "number", header.Number)
-					}
+			if _, err := bc.InsertChain(blocks[i : i+1]); err != nil {
+				// Retryable failures keep the block parked: it is still in the future
+				// (ErrFutureBlock), or its parent is itself parked in the queue
+				// (ErrUnknownAncestor) and may import on a later pass. Everything
+				// else — most notably an ErrUnknownAncestor whose parent is neither
+				// in the chain nor in the queue — can never succeed on a retry, so
+				// the block is evicted instead of being re-verified and re-reported
+				// as a bad block on every futureBlocksLoop tick. Blocks are sorted
+				// by number, so evicting a failed parent makes the Contains check
+				// of its queued children fail within the same pass and the whole
+				// orphaned chain drains.
+				if errors.Is(err, consensus.ErrFutureBlock) ||
+					(errors.Is(err, consensus.ErrUnknownAncestor) && bc.futureBlocks.Contains(blocks[i].ParentHash())) {
+					continue
+				}
+				bc.futureBlocks.Remove(blocks[i].Hash())
+				continue
+			}
+			// Only a write that advanced the canonical head qualifies for the
+			// engine hook below: known blocks that are skipped return a nil
+			// error without importing, and side-chain writes must not be
+			// treated as the head. Comparing hashes also keeps a same-height
+			// fork from being mistaken for the canonical head.
+			if bc.CurrentBlock().Hash() == blocks[i].Hash() {
+				lastCanon = blocks[i]
+			}
+		}
+		// Let the consensus engine handle the highest imported canonical block
+		// (e.g. for voting). The sorted queue tail cannot be the target: it may
+		// have failed to import while lower blocks advanced the head, or sit on
+		// a side branch.
+		if lastCanon != nil {
+			if engine, ok := bc.Engine().(proposedBlockHandler); ok {
+				header := lastCanon.Header()
+				if err := engine.HandleProposedBlock(bc, header); err != nil {
+					log.Info("[procFutureBlocks] handle proposed block has error", "err", err, "block hash", header.Hash(), "number", header.Number)
 				}
 			}
 		}
@@ -1745,6 +1780,12 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	return status, nil
 }
 
+// isQueueableImportErr reports whether a batch tail block should be parked in the
+// future queue instead of failing the import.
+func isQueueableImportErr(err error) bool {
+	return errors.Is(err, consensus.ErrUnknownAncestor) || errors.Is(err, consensus.ErrFutureBlock)
+}
+
 // addFutureBlock checks if the block is within the max allowed window to get
 // accepted for future processing, and returns an error if the block is too far
 // ahead and was not added.
@@ -1757,10 +1798,37 @@ func (bc *BlockChain) addFutureBlock(block *types.Block) error {
 	return nil
 }
 
+// queueFutureTail parks the batch tail in the future queue, starting at the
+// given block whose verification error err is queueable, and stops at the
+// first block that fails verification with a non-queueable error or at the end
+// of the batch. XDPoS v1/v2 (under full verification) check the timestamp
+// before the parent lookup (engine_v1/engine.go, engine_v2/verifyHeader.go),
+// so children of a future block surface as ErrFutureBlock. Engines that
+// resolve the parent first (e.g. ethash VerifyHeader), or XDPoS without
+// fullVerify, answer ErrUnknownAncestor instead; the loop accepts both.
+//
+// It returns the block and error that stopped the queueing — the caller
+// decides whether to report them as bad or ignore them — and a non-nil abort
+// error when addFutureBlock rejected the enqueue and the import must fail
+// whole.
+func (bc *BlockChain) queueFutureTail(it *insertIterator, block *types.Block, err error) (*types.Block, error, error) {
+	for block != nil && isQueueableImportErr(err) {
+		if aerr := bc.addFutureBlock(block); aerr != nil {
+			return block, err, aerr
+		}
+		block, err = it.next()
+	}
+	return block, err, nil
+}
+
 // InsertChain attempts to insert the given batch of blocks in to the canonical
 // chain or, otherwise, create a fork. If an error is returned it will return
 // the index number of the failing block as well an error describing what went
 // wrong.
+//
+// A nil error does not imply every block was written: a tail failing with
+// ErrFutureBlock/ErrUnknownAncestor is parked in the future queue and
+// processed later.
 //
 // After insertion is done, all accumulated events will be fired.
 func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
@@ -1849,11 +1917,17 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 
 	// First block is future, shove it (and all children) to the future queue (unknown ancestor)
 	case errors.Is(err, consensus.ErrFutureBlock) || (errors.Is(err, consensus.ErrUnknownAncestor) && bc.futureBlocks.Contains(it.first().ParentHash())):
-		for block != nil && (it.index == 0 || errors.Is(err, consensus.ErrUnknownAncestor)) {
-			if err := bc.addFutureBlock(block); err != nil {
-				return it.index, events, coalescedLogs, err
-			}
-			block, err = it.next()
+		stopped, err, abortErr := bc.queueFutureTail(it, block, err)
+		if abortErr != nil {
+			return it.index, events, coalescedLogs, abortErr
+		}
+		// The queueing stopped at a block that failed verification with a
+		// non-queueable error. Record the reject like the tail path below;
+		// future, known and pruned-ancestor errors are legitimate states,
+		// not invalid blocks.
+		if err != nil && stopped != nil && !errors.Is(err, ErrKnownBlock) &&
+			!errors.Is(err, consensus.ErrFutureBlock) && !errors.Is(err, consensus.ErrPrunedAncestor) {
+			bc.reportBlock(stopped, nil, err)
 		}
 		return it.index, events, coalescedLogs, err
 
@@ -1968,18 +2042,22 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []
 
 	// Any blocks remaining here? The only ones we care about are the future ones
 	if block != nil && errors.Is(err, consensus.ErrFutureBlock) {
-		if err := bc.addFutureBlock(block); err != nil {
-			return it.index, events, coalescedLogs, err
+		var abortErr error
+		block, err, abortErr = bc.queueFutureTail(it, block, err)
+		if abortErr != nil {
+			return it.index, events, coalescedLogs, abortErr
 		}
-		block, err = it.next()
+		// The queueing stopped at a block that failed verification with a
+		// non-queueable error. Record the reject like the first-block failure
+		// path; future, known and pruned-ancestor errors are legitimate
+		// states, not invalid blocks.
+		if err != nil && block != nil && !errors.Is(err, ErrKnownBlock) &&
+			!errors.Is(err, consensus.ErrFutureBlock) && !errors.Is(err, consensus.ErrPrunedAncestor) {
+			bc.reportBlock(block, nil, err)
+		}
+		return it.index, events, coalescedLogs, err
 
-		for ; block != nil && errors.Is(err, consensus.ErrUnknownAncestor); block, err = it.next() {
-			if err := bc.addFutureBlock(block); err != nil {
-				return it.index, events, coalescedLogs, err
-			}
-		}
 	}
-
 	// Append a single chain head event if we've progressed the chain
 	if lastCanon != nil && bc.CurrentBlock().Hash() == lastCanon.Hash() {
 		log.Debug("New ChainHeadEvent ", "number", lastCanon.NumberU64(), "hash", lastCanon.Hash())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -230,6 +230,13 @@ type BlockChain struct {
 	finalizedTrade      *lru.Cache[common.Hash, interface{}] // include both trades which force update to closed/liquidated by the protocol
 }
 
+// Compile-time check that the full chain answers both halves of the
+// proposed-block judgment (see consensus.ShouldHandleProposedBlock).
+var _ interface {
+	consensus.CanonicalChain
+	consensus.BlockStorer
+} = (*BlockChain)(nil)
+
 type blockchainOpenConfig struct {
 	readOnly        bool
 	chainConfig     *params.ChainConfig
@@ -1094,10 +1101,20 @@ func (bc *BlockChain) writeHeadBlock(block *types.Block, writeBlock bool) {
 	}
 }
 
+// hasExecutedState reports whether the state trie with the given root opens,
+// i.e. the block was executed or its state was synced. Shared by HasFullState
+// and HasBlockAndExecutedState so the criterion cannot drift between them.
+// A zero root and types.EmptyRootHash both open an empty trie without an
+// error (trie.New skips resolving them), so for a block with an empty state
+// root this check degenerates to HasBlock and reports the block as executed.
+func (bc *BlockChain) hasExecutedState(root common.Hash) bool {
+	_, err := bc.stateCache.OpenTrie(root)
+	return err == nil
+}
+
 // HasFullState checks if state trie is fully present in the database or not.
 func (bc *BlockChain) HasFullState(block *types.Block) bool {
-	_, err := bc.stateCache.OpenTrie(block.Root())
-	if err != nil {
+	if !bc.hasExecutedState(block.Root()) {
 		return false
 	}
 	engine, _ := bc.Engine().(*XDPoS.XDPoS)
@@ -1115,8 +1132,10 @@ func (bc *BlockChain) HasFullState(block *types.Block) bool {
 	return true
 }
 
-// HasBlockAndFullState checks if a block and associated state trie is fully present
-// in the database or not, caching it if present.
+// HasBlockAndFullState checks if a block and associated state trie is fully
+// present in the database. It looks the block up with GetBlock, which decodes
+// the whole block body from RLP — callers that must avoid decoding the body
+// should use HasBlockAndExecutedState instead.
 func (bc *BlockChain) HasBlockAndFullState(hash common.Hash, number uint64) bool {
 	// Check first that the block itself is known
 	block := bc.GetBlock(hash, number)
@@ -1124,6 +1143,24 @@ func (bc *BlockChain) HasBlockAndFullState(hash common.Hash, number uint64) bool
 		return false
 	}
 	return bc.HasFullState(block)
+}
+
+// HasBlockAndExecutedState checks that the block is known and its state trie
+// opens, i.e. the block was executed or its state was synced. Unlike
+// HasBlockAndFullState it deliberately leaves out the XDCX trading and lending
+// halves: a missing auxiliary state piece must not become a permanent voting
+// halt for a correctly executed block — callers needing the full guarantee
+// (block validation, dry-run import) must use HasBlockAndFullState. Only
+// HasBlock and the header are read, so no body is ever decoded.
+func (bc *BlockChain) HasBlockAndExecutedState(hash common.Hash, number uint64) bool {
+	if !bc.HasBlock(hash, number) {
+		return false
+	}
+	header := bc.GetHeader(hash, number)
+	if header == nil {
+		return false
+	}
+	return bc.hasExecutedState(header.Root)
 }
 
 // AreTwoBlockSamePath check if two blocks are same path

--- a/core/blockchain_futureblocks_test.go
+++ b/core/blockchain_futureblocks_test.go
@@ -1,0 +1,556 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/core/vm"
+	"github.com/XinFinOrg/XDPoSChain/crypto"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+// futureVerifyEngine fails header verification for a single block number, or for
+// every block from failFrom on (0 disables the range), so a batch can be made
+// to fail in the middle instead of at its first block. failFrom is atomic
+// because the chain's future-block loop calls VerifyHeaders concurrently.
+type futureVerifyEngine struct {
+	consensus.Engine
+	failNumber uint64
+	failFrom   atomic.Uint64
+	failErr    error
+
+	// handleMu guards handleCalls: the chain's background future-block loop
+	// invokes HandleProposedBlock concurrently with the test goroutine.
+	handleMu    sync.Mutex
+	handleCalls []*types.Header
+}
+
+func (e *futureVerifyEngine) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	abort := make(chan struct{})
+	results := make(chan error, len(headers))
+	go func() {
+		for _, header := range headers {
+			var err error
+			number := header.Number.Uint64()
+			failFrom := e.failFrom.Load()
+			if number == e.failNumber || (failFrom != 0 && number >= failFrom) {
+				err = e.failErr
+			}
+			select {
+			case <-abort:
+				return
+			case results <- err:
+			}
+		}
+	}()
+	return abort, results
+}
+
+// HandleProposedBlock records the compensated header so tests can assert which
+// block the future-block loop hands to the consensus engine after an import.
+// It also makes futureVerifyEngine satisfy the proposedBlockHandler interface
+// that procFutureBlocks asserts on the chain engine.
+func (e *futureVerifyEngine) HandleProposedBlock(chain consensus.ChainReader, header *types.Header) error {
+	e.handleMu.Lock()
+	defer e.handleMu.Unlock()
+	e.handleCalls = append(e.handleCalls, header)
+	return nil
+}
+
+func (e *futureVerifyEngine) lastHandled() *types.Header {
+	e.handleMu.Lock()
+	defer e.handleMu.Unlock()
+	if len(e.handleCalls) == 0 {
+		return nil
+	}
+	return e.handleCalls[len(e.handleCalls)-1]
+}
+
+func (e *futureVerifyEngine) handleSnapshot() []*types.Header {
+	e.handleMu.Lock()
+	defer e.handleMu.Unlock()
+	return append([]*types.Header(nil), e.handleCalls...)
+}
+
+// TestInsertChainQueuesMidBatchFutureBlocks verifies that a batch rejected as
+// future mid-way has its whole tail queued instead of failing the import:
+// children of a future block fail the timestamp check before the parent lookup
+// so they surface as ErrFutureBlock too, and returning that error would make
+// the downloader drop the peer on a valid delivery.
+func TestInsertChainQueuesMidBatchFutureBlocks(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+	)
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 5, nil)
+
+	engine := &futureVerifyEngine{Engine: ethash.NewFaker(), failErr: consensus.ErrFutureBlock}
+	engine.failFrom.Store(3)
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+
+	if n, err := chain.InsertChain(blocks); err != nil || n != len(blocks) {
+		t.Fatalf("failed to insert into chain: index %d err %v", n, err)
+	}
+	if want := uint64(2); chain.CurrentBlock().Number.Uint64() != want {
+		t.Fatalf("unexpected head number: have %d want %d", chain.CurrentBlock().Number.Uint64(), want)
+	}
+	for _, block := range blocks[2:] {
+		if !chain.futureBlocks.Contains(block.Hash()) {
+			t.Fatalf("block %d not queued as future block", block.NumberU64())
+		}
+		if bad := rawdb.ReadBadBlock(db, block.Hash()); bad != nil {
+			t.Fatalf("future block %d recorded as bad block", block.NumberU64())
+		}
+	}
+}
+
+// TestInsertChainQueuesFutureBatchFromFirstBlock verifies that a batch whose
+// first block is already in the future is queued in full instead of failing at
+// its second block, which made the downloader drop the delivering peer.
+func TestInsertChainQueuesFutureBatchFromFirstBlock(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+	)
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 5, nil)
+
+	engine := &futureVerifyEngine{Engine: ethash.NewFaker(), failErr: consensus.ErrFutureBlock}
+	engine.failFrom.Store(1)
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+
+	if n, err := chain.InsertChain(blocks); err != nil || n != len(blocks) {
+		t.Fatalf("failed to insert into chain: index %d err %v", n, err)
+	}
+	if want := uint64(0); chain.CurrentBlock().Number.Uint64() != want {
+		t.Fatalf("unexpected head number: have %d want %d", chain.CurrentBlock().Number.Uint64(), want)
+	}
+	for _, block := range blocks {
+		if !chain.futureBlocks.Contains(block.Hash()) {
+			t.Fatalf("block %d not queued as future block", block.NumberU64())
+		}
+	}
+}
+
+// TestInsertChainQueuesWrappedFutureError guards the errors.Is comparisons on
+// the future-block paths: header verification may hand back a %w-wrapped
+// ErrFutureBlock, and bare == comparisons would then abort the import (or
+// skip the tail queueing) instead of parking the batch for procFutureBlocks.
+func TestInsertChainQueuesWrappedFutureError(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+	)
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 5, nil)
+
+	wrapped := fmt.Errorf("verification: %w", consensus.ErrFutureBlock)
+	if !errors.Is(wrapped, consensus.ErrFutureBlock) {
+		t.Fatalf("test setup: error must wrap ErrFutureBlock")
+	}
+
+	// failFrom=1 rejects the whole batch at its first block (first-block queue
+	// path), failFrom=3 rejects it mid-way after blocks 1 and 2 imported (tail
+	// queue path). Either way the wrapped sentinel must still park the tail.
+	for _, tc := range []struct {
+		name     string
+		failFrom uint64
+		head     uint64
+		queued   int // number of tail blocks that must end up in the future queue
+	}{
+		{name: "first-block", failFrom: 1, head: 0, queued: 5},
+		{name: "mid-batch", failFrom: 3, head: 2, queued: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &futureVerifyEngine{Engine: ethash.NewFaker(), failErr: wrapped}
+			engine.failFrom.Store(tc.failFrom)
+
+			db := rawdb.NewMemoryDatabase()
+			chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+			if err != nil {
+				t.Fatalf("failed to create tester chain: %v", err)
+			}
+			defer chain.Stop()
+
+			if n, err := chain.InsertChain(blocks); err != nil || n != len(blocks) {
+				t.Fatalf("failed to insert into chain: index %d err %v", n, err)
+			}
+			if head := chain.CurrentBlock().Number.Uint64(); head != tc.head {
+				t.Fatalf("unexpected head number: have %d want %d", head, tc.head)
+			}
+			for i, block := range blocks {
+				if queued, want := chain.futureBlocks.Contains(block.Hash()), i >= len(blocks)-tc.queued; queued != want {
+					t.Fatalf("block %d queued = %v, want %v", block.NumberU64(), queued, want)
+				}
+				if bad := rawdb.ReadBadBlock(db, block.Hash()); bad != nil {
+					t.Fatalf("block %d recorded as bad block", block.NumberU64())
+				}
+			}
+		})
+	}
+}
+
+// TestInsertChainFutureBlocksBeyondEnqueueWindow pins the maxTimeFutureBlocks
+// boundary of the tail queueing: blocks are only parked while their timestamps
+// stay within maxTimeFutureBlocks (30s) of the wall clock. Once the tail spans
+// past the window, addFutureBlock rejects the first out-of-window block and
+// InsertChain fails with that non-sentinel error — the same visible outcome as
+// before queueing was extended — while the in-window prefix stays queued for
+// procFutureBlocks.
+func TestInsertChainFutureBlocksBeyondEnqueueWindow(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+		now = uint64(time.Now().Unix())
+	)
+	// Simulate a 2s block period with the batch starting 18s ahead of the
+	// clock: blocks 0..5 sit inside the 30s enqueue window, blocks 6.. jump
+	// past it by a wide margin. The last in-window block stops 2s short of
+	// the boundary, so a backward wall-clock step (e.g. an NTP correction)
+	// between the now capture and addFutureBlock's own time.Now read cannot
+	// push it out of the window; the out-of-window tail would need a 30s
+	// forward jump to sneak in, which cannot happen within a test run.
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 12, func(i int, gen *BlockGen) {
+		if i < 6 {
+			gen.header.Time = now + 18 + uint64(2*i)
+		} else {
+			gen.header.Time = now + 60 + uint64(i-6)
+		}
+	})
+
+	engine := &futureVerifyEngine{Engine: ethash.NewFaker(), failErr: consensus.ErrFutureBlock}
+	engine.failFrom.Store(1)
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+
+	n, err := chain.InsertChain(blocks)
+	if n != 6 {
+		t.Fatalf("unexpected failing index: have %d want 6", n)
+	}
+	if err == nil || !strings.Contains(err.Error(), "future block timestamp") || errors.Is(err, consensus.ErrFutureBlock) {
+		t.Fatalf("unexpected error for block %d: %v", n, err)
+	}
+	if head := chain.CurrentBlock().Number.Uint64(); head != 0 {
+		t.Fatalf("unexpected head number: have %d want 0", head)
+	}
+	for i, block := range blocks {
+		if queued, want := chain.futureBlocks.Contains(block.Hash()), i < 6; queued != want {
+			t.Fatalf("block %d queued = %v, want %v", block.NumberU64(), queued, want)
+		}
+		if bad := rawdb.ReadBadBlock(db, block.Hash()); bad != nil {
+			t.Fatalf("block %d recorded as bad block", block.NumberU64())
+		}
+	}
+}
+
+// TestInsertChainProcFutureBlocksResumesImport proves the queued tail is not
+// dropped: once headers verify again, the queued blocks import and the head
+// advances to the batch tip.
+func TestInsertChainProcFutureBlocksResumesImport(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+	)
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 5, nil)
+
+	engine := &futureVerifyEngine{Engine: ethash.NewFaker(), failErr: consensus.ErrFutureBlock}
+	engine.failFrom.Store(3)
+
+	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+
+	if _, err := chain.InsertChain(blocks); err != nil {
+		t.Fatalf("failed to insert into chain: %v", err)
+	}
+	if want := uint64(2); chain.CurrentBlock().Number.Uint64() != want {
+		t.Fatalf("unexpected head number: have %d want %d", chain.CurrentBlock().Number.Uint64(), want)
+	}
+
+	// The background future-block loop may drain the queue first; the explicit
+	// call is then a no-op and the head assertion still holds.
+	engine.failFrom.Store(0)
+	// The 100ms futureBlocksLoop also drains the queue; retry until it settles.
+	for i := 0; i < 100 && chain.CurrentBlock().Number.Uint64() != 5; i++ {
+		chain.procFutureBlocks()
+		time.Sleep(10 * time.Millisecond)
+	}
+	if want := uint64(5); chain.CurrentBlock().Number.Uint64() != want {
+		t.Fatalf("unexpected head number: have %d want %d", chain.CurrentBlock().Number.Uint64(), want)
+	}
+}
+
+// TestProcFutureBlocksHandlesHighestImportedCanonicalBlock verifies that the
+// consensus-engine compensation after a future-queue drain targets the highest
+// block that actually advanced the canonical head. The historical code only
+// compensated the sorted tail of the queue when its own import succeeded, so a
+// tail that failed to import (bad block, or still in the future) silently
+// skipped the engine hook for the lower blocks that did import, dropping their
+// processQC and vote handling.
+func TestProcFutureBlocksHandlesHighestImportedCanonicalBlock(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+	)
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 5, nil)
+
+	for _, tc := range []struct {
+		name       string
+		failNumber uint64 // block number that must fail to import (0 = none)
+		failErr    error
+		head       uint64 // canonical head after the drain, and hook target
+	}{
+		{name: "tail-rejected", failNumber: 5, failErr: errors.New("simulated bad tail block"), head: 4},
+		{name: "tail-still-future", failNumber: 5, failErr: consensus.ErrFutureBlock, head: 4},
+		{name: "whole-queue-imported", head: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := &futureVerifyEngine{Engine: ethash.NewFaker(), failNumber: tc.failNumber, failErr: tc.failErr}
+
+			chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, engine, vm.Config{})
+			if err != nil {
+				t.Fatalf("failed to create tester chain: %v", err)
+			}
+			defer chain.Stop()
+
+			// Park the whole batch as future blocks, as a failed import would have.
+			for _, block := range blocks {
+				chain.futureBlocks.Add(block.Hash(), block)
+			}
+			// The background 100ms future-block loop drains the queue too, so keep
+			// prodding until the hook has fired for the expected head.
+			deadline := time.Now().Add(2 * time.Second)
+			for chain.CurrentBlock().Number.Uint64() != tc.head && time.Now().Before(deadline) {
+				chain.procFutureBlocks()
+				time.Sleep(10 * time.Millisecond)
+			}
+			if last := engine.lastHandled(); last == nil || last.Number.Uint64() != tc.head {
+				t.Fatalf("consensus hook not called for imported head %d", tc.head)
+			}
+			if head := chain.CurrentBlock().Number.Uint64(); head != tc.head {
+				t.Fatalf("unexpected head number: have %d want %d", head, tc.head)
+			}
+			wantHash := blocks[tc.head-1].Hash()
+			for _, handled := range engine.handleSnapshot() {
+				if handled.Number.Uint64() > tc.head {
+					t.Fatalf("consensus hook called for block %d beyond the imported head %d", handled.Number.Uint64(), tc.head)
+				}
+				if handled.Number.Uint64() == tc.head && handled.Hash() != wantHash {
+					t.Fatalf("consensus hook called for the wrong block at height %d", tc.head)
+				}
+			}
+		})
+	}
+}
+
+// mutableErrEngine is a verification stub whose injected error can be switched
+// at runtime, modelling a future block whose timestamp expires between the
+// original park in the future queue and the queue retry.
+type mutableErrEngine struct {
+	consensus.Engine
+	verifyErr atomic.Value // error
+}
+
+func (e *mutableErrEngine) setErr(err error) { e.verifyErr.Store(err) }
+
+func (e *mutableErrEngine) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	abort := make(chan struct{})
+	results := make(chan error, len(headers))
+	err, _ := e.verifyErr.Load().(error)
+	go func() {
+		for range headers {
+			select {
+			case <-abort:
+				return
+			case results <- err:
+			}
+		}
+	}()
+	return abort, results
+}
+
+// TestProcFutureBlocksEvictsUnretryableFutureBlocks pins the eviction rule of
+// the future-block drain: a queued block is retried only while it is still in
+// the future, or while its parent is itself parked in the queue. A poison batch
+// of garbage blocks — delivered while its timestamps sat inside the future
+// window and therefore parked in full — must drain from the queue once those
+// timestamps expire, instead of being re-verified and re-reported as bad
+// blocks on every futureBlocksLoop tick forever.
+func TestProcFutureBlocksEvictsUnretryableFutureBlocks(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+		now = uint64(time.Now().Unix())
+	)
+
+	// buildPoisonChain returns a contiguous run of count blocks starting at
+	// height 1 whose root's parent is an unresolvable hash: once their
+	// timestamps expire, the root is a permanent orphan and every child hangs
+	// off a still-parked parent, so no block of the chain can ever import.
+	buildPoisonChain := func(count int) types.Blocks {
+		blocks := make(types.Blocks, 0, count)
+		parent := common.Hash{0xde, 0xad}
+		for i := 0; i < count; i++ {
+			header := &types.Header{
+				ParentHash: parent,
+				Number:     big.NewInt(int64(i + 1)),
+				GasLimit:   params.GenesisGasLimit,
+				Time:       now + 10,
+				Difficulty: common.Big1,
+			}
+			block := types.NewBlockWithHeader(header)
+			blocks = append(blocks, block)
+			parent = block.Hash()
+		}
+		return blocks
+	}
+
+	for _, tc := range []struct {
+		name   string
+		poison bool // garbage chain with an unresolvable root parent
+		count  int  // blocks delivered in a single batch
+		expire bool // switch the verification error to ErrUnknownAncestor
+	}{
+		{name: "small-orphaned-chain-drains", poison: true, count: 5, expire: true},
+		{name: "still-future-retained", count: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var blocks types.Blocks
+			if tc.poison {
+				blocks = buildPoisonChain(tc.count)
+			} else {
+				_, blocks, _ = GenerateChainWithGenesis(gspec, ethash.NewFaker(), tc.count, nil)
+			}
+
+			engine := &mutableErrEngine{Engine: ethash.NewFaker()}
+			engine.setErr(consensus.ErrFutureBlock) // every timestamp sits inside the future window
+
+			db := rawdb.NewMemoryDatabase()
+			chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+			if err != nil {
+				t.Fatalf("failed to create tester chain: %v", err)
+			}
+			defer chain.Stop()
+
+			// Deliver the batch while every block is future: the import reports
+			// success with the whole batch parked in the queue.
+			if n, err := chain.InsertChain(blocks); err != nil || n != len(blocks) {
+				t.Fatalf("failed to deliver batch: index %d err %v", n, err)
+			}
+			if have := chain.futureBlocks.Len(); have != tc.count {
+				t.Fatalf("unexpected queue length after delivery: have %d want %d", have, tc.count)
+			}
+
+			if !tc.expire {
+				// The blocks are still in the future: retrying must keep them
+				// parked, and must not report them as bad.
+				deadline := time.Now().Add(300 * time.Millisecond)
+				for time.Now().Before(deadline) {
+					chain.procFutureBlocks()
+					time.Sleep(10 * time.Millisecond)
+				}
+				if have := chain.futureBlocks.Len(); have != tc.count {
+					t.Fatalf("future blocks evicted while still in the future: have %d want %d", have, tc.count)
+				}
+				for _, block := range blocks {
+					if bad := rawdb.ReadBadBlock(db, block.Hash()); bad != nil {
+						t.Fatalf("future block %d reported as bad", block.NumberU64())
+					}
+				}
+				return
+			}
+
+			// Phase 2: the timestamps expired, so verification now fails on the
+			// unresolvable ancestor. The queue must drain instead of retrying
+			// and re-reporting the poison forever.
+			engine.setErr(consensus.ErrUnknownAncestor)
+			deadline := time.Now().Add(2 * time.Second)
+			for chain.futureBlocks.Len() > 0 && time.Now().Before(deadline) {
+				chain.procFutureBlocks()
+				time.Sleep(10 * time.Millisecond)
+			}
+			if have := chain.futureBlocks.Len(); have != 0 {
+				t.Fatalf("poisoned queue did not drain: %d blocks still queued", have)
+			}
+			if head := chain.CurrentBlock().Number.Uint64(); head != 0 {
+				t.Fatalf("garbage block imported, head at %d", head)
+			}
+			// Every parked block was reported as bad once, during the drain.
+			for _, block := range blocks {
+				if bad := rawdb.ReadBadBlock(db, block.Hash()); bad == nil {
+					t.Fatalf("garbage block %d not reported as bad", block.NumberU64())
+				}
+			}
+		})
+	}
+}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3036,5 +3037,144 @@ func TestHasBlockAndExecutedState(t *testing.T) {
 	}
 	if !blockchain.HasBlockAndFullState(head.Hash(), head.Number.Uint64()) {
 		t.Fatal("executed head block must also have full state")
+	}
+}
+
+// failVerifyEngine fails header verification for a single block number, or for
+// every block from failFrom on (0 disables the range), so a batch can be made
+// to fail in the middle instead of at its first block. failFrom is atomic
+// because the chain's future-block loop calls VerifyHeaders concurrently.
+type failVerifyEngine struct {
+	consensus.Engine
+	failNumber uint64
+	failFrom   atomic.Uint64
+	failErr    error
+
+	// failErrAt overrides the failing error for individual block numbers.
+	// Set up before the chain starts and read-only afterwards.
+	failErrAt map[uint64]error
+}
+
+func (e *failVerifyEngine) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	abort := make(chan struct{})
+	results := make(chan error, len(headers))
+	go func() {
+		for _, header := range headers {
+			var err error
+			number := header.Number.Uint64()
+			failFrom := e.failFrom.Load()
+			if custom, ok := e.failErrAt[number]; ok {
+				err = custom
+			} else if number == e.failNumber || (failFrom != 0 && number >= failFrom) {
+				err = e.failErr
+			}
+			select {
+			case <-abort:
+				return
+			case results <- err:
+			}
+		}
+	}()
+	return abort, results
+}
+
+// errNonQueueableTest is a verification error that is neither queueable nor
+// one of the legitimate skip states (future, known, pruned ancestor).
+var errNonQueueableTest = errors.New("non-queueable verification failure")
+
+// TestInsertChainReportsNonQueueableBlockAfterFuturePrefix verifies that a
+// batch stopping at a non-queueable verification error after a future prefix
+// records the reject like the tail path, instead of returning the error
+// without a bad-block record.
+func TestInsertChainReportsNonQueueableBlockAfterFuturePrefix(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+		now = uint64(time.Now().Unix())
+	)
+	// Block 1 is future and parks, block 2 fails with a non-queueable error.
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 2, func(i int, gen *BlockGen) {
+		gen.header.Time = now + 10
+	})
+
+	engine := &failVerifyEngine{Engine: ethash.NewFaker(), failErr: consensus.ErrFutureBlock}
+	engine.failFrom.Store(1)
+	engine.failErrAt = map[uint64]error{2: errNonQueueableTest}
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+
+	n, err := chain.InsertChain(blocks)
+	if n != 1 {
+		t.Fatalf("unexpected failing index: have %d want 1", n)
+	}
+	if !errors.Is(err, errNonQueueableTest) {
+		t.Fatalf("unexpected error for block %d: %v", n, err)
+	}
+	if bad := rawdb.ReadBadBlock(db, blocks[0].Hash()); bad != nil {
+		t.Fatalf("future block %d recorded as bad block", blocks[0].NumberU64())
+	}
+	if bad := rawdb.ReadBadBlock(db, blocks[1].Hash()); bad == nil {
+		t.Fatalf("non-queueable block %d not recorded as bad block", blocks[1].NumberU64())
+	}
+}
+
+// TestInsertChainReportsNonQueueableBlockAfterFutureTail verifies that a
+// batch whose tail parks a future block and then stops at a non-queueable
+// verification error records the reject and propagates the error instead of
+// silently swallowing it.
+func TestInsertChainReportsNonQueueableBlockAfterFutureTail(t *testing.T) {
+	var (
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{
+			Alloc:   types.GenesisAlloc{address: {Balance: funds}},
+			BaseFee: big.NewInt(params.InitialBaseFee),
+			Config:  params.TestChainConfig,
+		}
+		now = uint64(time.Now().Unix())
+	)
+	// Block 1 imports, block 2 is future and parks, block 3 fails with a
+	// non-queueable error.
+	_, blocks, _ := GenerateChainWithGenesis(gspec, ethash.NewFaker(), 3, func(i int, gen *BlockGen) {
+		gen.header.Time = now + 10
+	})
+
+	engine := &failVerifyEngine{Engine: ethash.NewFaker()}
+	engine.failErrAt = map[uint64]error{2: consensus.ErrFutureBlock, 3: errNonQueueableTest}
+
+	db := rawdb.NewMemoryDatabase()
+	chain, err := NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer chain.Stop()
+
+	n, err := chain.InsertChain(blocks)
+	if n != 2 {
+		t.Fatalf("unexpected failing index: have %d want 2", n)
+	}
+	if !errors.Is(err, errNonQueueableTest) {
+		t.Fatalf("unexpected error for block %d: %v", n, err)
+	}
+	if bad := rawdb.ReadBadBlock(db, blocks[1].Hash()); bad != nil {
+		t.Fatalf("future block %d recorded as bad block", blocks[1].NumberU64())
+	}
+	if bad := rawdb.ReadBadBlock(db, blocks[2].Hash()); bad == nil {
+		t.Fatalf("non-queueable block %d not recorded as bad block", blocks[2].NumberU64())
+	}
+	if !chain.futureBlocks.Contains(blocks[1].Hash()) {
+		t.Fatalf("future block %d not parked", blocks[1].NumberU64())
 	}
 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"encoding/binary"
 	"errors"
 	"math/big"
 	"math/rand"
@@ -2904,5 +2905,136 @@ func TestDeleteCreateRevert(t *testing.T) {
 
 	if n, err := chain.InsertChain(blocks); err != nil {
 		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
+	}
+}
+
+// TestProcFutureBlocksImportsParkedTail pins procFutureBlocks' existing import
+// mechanics: a block parked in futureBlocks whose timestamp has since become
+// consumable is imported as a one-block batch, making it the batch tail whose
+// header procFutureBlocks hands to the consensus handler. This test covers
+// only the import and the tail's position — a non-XDPoS engine skips the
+// handler call by type assertion, and the live-v2 hand-off is covered by the
+// engine re-check tests in consensus.
+func TestProcFutureBlocksImportsParkedTail(t *testing.T) {
+	engine := ethash.NewFaker()
+	// Backdate the genesis so the head and the generated child are already
+	// consumable instead of future: the state a parked future block reaches
+	// once time has passed its timestamp.
+	gspec := &Genesis{
+		BaseFee:   big.NewInt(params.InitialBaseFee),
+		Config:    params.AllEthashProtocolChanges,
+		Timestamp: uint64(time.Now().Unix()) - 60,
+	}
+	blockchain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer blockchain.Stop()
+
+	if _, err := blockchain.InsertChain(makeBlockChain(gspec.Config, blockchain.Genesis(), 1, engine, blockchain.db, 0)); err != nil {
+		t.Fatalf("failed to insert head: %v", err)
+	}
+
+	parked := makeBlockChain(gspec.Config, blockchain.GetBlockByHash(blockchain.CurrentBlock().Hash()), 1, engine, blockchain.db, 0)[0]
+	if parked.Time() > uint64(time.Now().Unix()) {
+		t.Fatalf("child timestamp %d is still future and would not be importable", parked.Time())
+	}
+	blockchain.futureBlocks.Add(parked.Hash(), parked)
+	if blockchain.GetBlockByNumber(parked.NumberU64()) != nil {
+		t.Fatal("parked block present before procFutureBlocks")
+	}
+
+	blockchain.procFutureBlocks()
+
+	if got := blockchain.GetBlockByNumber(parked.NumberU64()); got == nil || got.Hash() != parked.Hash() {
+		t.Fatalf("parked tail not imported as canonical: got %v", got)
+	}
+	if blockchain.CurrentBlock().Hash() != parked.Hash() {
+		t.Fatal("parked tail did not become the head")
+	}
+	if blockchain.futureBlocks.Contains(parked.Hash()) {
+		t.Fatal("parked tail not removed from the future queue")
+	}
+}
+
+// TestHasBlockAndExecutedState pins every branch of the fetcher gate's
+// existence check directly: an unknown block, a block whose header record is
+// undecodable, and a block whose state root opens nowhere are all false, while
+// a normally executed block is true. HasBlock requires the header key and the
+// body to exist, so the header-missing branch is reached with a corrupt
+// header RLP — the key exists (HasHeader passes) but ReadHeader fails.
+// The XDCX trading/lending divergence from HasBlockAndFullState is not
+// constructed here: it needs a real XDPoS engine with IsTIPXDCX and services
+// reporting missing state, and is pinned indirectly by the eth fetcher-gate
+// test (executed state passes) plus the method's doc comment.
+func TestHasBlockAndExecutedState(t *testing.T) {
+	engine := ethash.NewFaker()
+	gspec := &Genesis{
+		BaseFee:   big.NewInt(params.InitialBaseFee),
+		Config:    params.AllEthashProtocolChanges,
+		Timestamp: uint64(time.Now().Unix()) - 60,
+	}
+	blockchain, err := NewBlockChain(rawdb.NewMemoryDatabase(), nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	defer blockchain.Stop()
+
+	if _, err := blockchain.InsertChain(makeBlockChain(gspec.Config, blockchain.Genesis(), 1, engine, blockchain.db, 0)); err != nil {
+		t.Fatalf("failed to insert head: %v", err)
+	}
+	head := blockchain.CurrentBlock()
+
+	// A hash never written anywhere fails the HasBlock half.
+	if blockchain.HasBlockAndExecutedState(common.Hash{0x01}, 1) {
+		t.Fatal("unknown block must not count as executed state")
+	}
+
+	// A block whose header key exists but whose header RLP does not decode:
+	// HasBlock passes (key plus body) and GetHeader returns nil, so the
+	// header-missing guard must answer false instead of panicking on the
+	// nil header dereference.
+	corrupt := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+	rawdb.WriteBody(blockchain.db, corrupt.Hash(), 1, corrupt.Body())
+	headerKey := append(append([]byte("h"), binary.BigEndian.AppendUint64(nil, 1)...), corrupt.Hash().Bytes()...)
+	if err := blockchain.db.Put(headerKey, []byte{0xff}); err != nil {
+		t.Fatalf("failed to corrupt header record: %v", err)
+	}
+	if !blockchain.HasBlock(corrupt.Hash(), 1) {
+		t.Fatal("corrupt-header fixture must pass HasBlock to reach the header guard")
+	}
+	if blockchain.HasBlockAndExecutedState(corrupt.Hash(), 1) {
+		t.Fatal("block with undecodable header must not count as executed state")
+	}
+
+	// A stored block whose state root exists nowhere: the OpenTrie half fails.
+	unexecuted := types.CopyHeader(head)
+	unexecuted.Root = common.HexToHash("0xdeadbeef")
+	unexecuted.Number = new(big.Int).Add(head.Number, big.NewInt(1))
+	rawdb.WriteBlock(blockchain.db, types.NewBlockWithHeader(unexecuted))
+	if blockchain.HasBlockAndExecutedState(unexecuted.Hash(), unexecuted.Number.Uint64()) {
+		t.Fatal("block with unopenable state trie must not count as executed state")
+	}
+
+	// A stored block whose state root is the empty root: trie.New opens the
+	// empty trie without resolving anything, so the executed-state half
+	// degenerates to HasBlock for such a block — a criterion the method
+	// accepts as loose there (see hasExecutedState's doc comment). This
+	// branch pins that degenerate behavior so it cannot drift unnoticed.
+	emptyRoot := types.CopyHeader(head)
+	emptyRoot.Root = types.EmptyRootHash
+	emptyRoot.Number = new(big.Int).Add(head.Number, big.NewInt(2))
+	rawdb.WriteBlock(blockchain.db, types.NewBlockWithHeader(emptyRoot))
+	if !blockchain.HasBlockAndExecutedState(emptyRoot.Hash(), emptyRoot.Number.Uint64()) {
+		t.Fatal("stored block with the empty state root must count as executed state (degenerate to HasBlock)")
+	}
+
+	// A normally executed block passes, and for it HasBlockAndFullState
+	// agrees: the two methods only differ on the XDCX auxiliary state.
+	if !blockchain.HasBlockAndExecutedState(head.Hash(), head.Number.Uint64()) {
+		t.Fatal("executed head block must count as executed state")
+	}
+	if !blockchain.HasBlockAndFullState(head.Hash(), head.Number.Uint64()) {
+		t.Fatal("executed head block must also have full state")
 	}
 }

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -550,8 +550,10 @@ func (hc *HeaderChain) Config() *params.ChainConfig { return hc.config }
 // Engine retrieves the header chain's consensus engine.
 func (hc *HeaderChain) Engine() consensus.Engine { return hc.engine }
 
-// GetBlock implements consensus.ChainReader, and returns nil for every input as
-// a header chain does not have blocks available for retrieval.
+// GetBlock implements consensus.ChainReader and always returns nil: a header
+// chain has no blocks to retrieve. A header chain also deliberately does not
+// implement consensus.BlockStorer, so the proposed-block judgment fails loudly
+// as SkipUnjudgeable instead of silently reporting every block as not stored.
 func (hc *HeaderChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	return nil
 }

--- a/core/headerchain_test.go
+++ b/core/headerchain_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
+	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+// TestHeaderChainShouldHandleProposedBlock fixates the interface adaptation:
+// *HeaderChain satisfies consensus.ChainReader only so the interface stays
+// closed, but it stores no block bodies and deliberately does not implement
+// consensus.BlockStorer. The shared proposed-block gate must therefore skip
+// every block with SkipUnjudgeable — graded Error, not judge every block
+// "not stored" — so a HeaderChain handed to the consensus engine by mistake
+// cannot silently drop QC processing and voting behind an Info log.
+func TestHeaderChainShouldHandleProposedBlock(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	genesis := &types.Header{Number: big.NewInt(0)}
+	rawdb.WriteHeader(db, genesis)
+	rawdb.WriteCanonicalHash(db, genesis.Hash(), 0)
+	hc, err := NewHeaderChain(db, params.TestChainConfig, nil, func() bool { return false })
+	if err != nil {
+		t.Fatal("Fail to create header chain", err)
+	}
+
+	// A header stored header-only (the fast sync header phase shape): canonical
+	// at its height, so the gate reaches the storage half — which a header
+	// chain cannot answer — and must skip it as unjudgeable.
+	if ok, reason, _ := consensus.ShouldHandleProposedBlock(hc, genesis); ok || reason != consensus.SkipUnjudgeable {
+		t.Fatalf("a header chain must be skipped as unjudgeable by the proposed-block gate, got ok=%v reason=%q", ok, reason)
+	}
+
+	missing := &types.Header{Number: big.NewInt(5)}
+	// The BlockStorer assertion runs before any chain read, so an absent
+	// height is reported as unjudgeable too, not silently skipped on the
+	// canonicality half.
+	if ok, reason, canonicalHash := consensus.ShouldHandleProposedBlock(hc, missing); ok || reason != consensus.SkipUnjudgeable || canonicalHash != (common.Hash{}) {
+		t.Fatalf("an absent height must also be reported as unjudgeable on a header chain, got ok=%v reason=%q canonicalHash=%v", ok, reason, canonicalHash)
+	}
+
+	// The block-retrieval stub itself.
+	if block := hc.GetBlock(genesis.Hash(), 0); block != nil {
+		t.Fatalf("HeaderChain.GetBlock must return nil, got %v", block)
+	}
+}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/XinFinOrg/XDPoSChain"
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus"
 	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS/engines/engine_v2"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
 	"github.com/XinFinOrg/XDPoSChain/core/state"
@@ -212,6 +213,9 @@ type BlockChain interface {
 	// InsertChain inserts a batch of blocks into the local chain.
 	InsertChain(types.Blocks) (int, error)
 
+	// GetHeaderByNumber retrieves a canonical header from the local chain by height.
+	GetHeaderByNumber(number uint64) *types.Header
+
 	// InterruptInsert disables or enables chain insertion.
 	InterruptInsert(on bool)
 
@@ -257,6 +261,20 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, lightchai
 	go dl.qosTuner()
 	go dl.stateFetcher()
 	return dl
+}
+
+// ProposedBlockHandler returns the proposed-block callback this downloader was
+// wired with, mirroring the fetcher's accessor. Unlike the fetcher, which
+// normalizes a nil handler to a no-op in New, this returns the callback as
+// wired: without an XDPoS consensus engine NewProtocolManager passes nil, so
+// this accessor can return nil and callers must nil-check (as the import
+// pre-filter does). Tests use it to pin that NewProtocolManager hands the
+// downloader the bare consensus handler: the downloader's fast-sync
+// proposed-block calls run after the pivot commit, so gating the callback
+// here would skip every proposed block during fast sync and stall QC and
+// voting.
+func (d *Downloader) ProposedBlockHandler() func(*types.Header) error {
+	return d.handleProposedBlock
 }
 
 // SetPivotBlock sets the fixed pivot block number, hash and state root for fast sync.
@@ -1661,11 +1679,30 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 		}
 		return fmt.Errorf("%w: %v", errInvalidChain, err)
 	}
+	// A nil error from InsertChain does not make the tail canonical: a fork batch
+	// is stored as side entries, a parked tail not at all. Pre-filter with the
+	// handler's own judgment — an observability and early-out pass, not a
+	// correctness gate: it runs the same judgment, on the same goroutine, a
+	// few lines before the engine's own gates, so it catches nothing the engine
+	// would not. Its value is the per-site counter plus Info-grade per-reason
+	// logs for batch-tail noise, and one saved engine lock acquisition per skip;
+	// correctness comes from the engine re-checking before processQC and before
+	// the vote, so a reorg landing after this point is still caught.
 	if d.handleProposedBlock != nil {
-		header := blocks[len(blocks)-1].Header()
-		err := d.handleProposedBlock(header)
-		if err != nil {
-			log.Info("[downloader] handle proposed block has error", "err", err, "block hash", header.Hash(), "number", header.Number)
+		tail := blocks[len(blocks)-1]
+		ok, reason, canonicalHash := consensus.ShouldHandleProposedBlock(d.blockchain, tail.Header())
+		if ok {
+			if err := d.handleProposedBlock(tail.Header()); err != nil {
+				log.Info("[downloader] handle proposed block has error", "err", err, "hash", tail.Hash(), "number", tail.Number())
+			}
+		} else {
+			skippedProposedBlockPreFilter.Inc(1)
+			// SkipUnjudgeable is unreachable here: the BlockChain interface
+			// requires HasBlock. If that ever changes, skipReasons still grades it
+			// Error. The "hash" key matches the engine's
+			// skipProposedBlock and the eth fetcher gate, so a single hash=
+			// filter covers every proposed-block skip log that names a block.
+			consensus.PreFilterSkipLogLevel(reason)("[downloader] skipped proposed block handler", "hash", tail.Hash(), "number", tail.Number(), "reason", reason, "canonicalHash", canonicalHash)
 		}
 	}
 	return nil

--- a/eth/downloader/downloader_proposed_block_test.go
+++ b/eth/downloader/downloader_proposed_block_test.go
@@ -1,0 +1,614 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/core/types"
+	"github.com/XinFinOrg/XDPoSChain/event"
+	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/params"
+)
+
+// makeTestBlockWithDifficulty builds an empty block on top of parent with a
+// custom difficulty, so a shorter branch can out-cumulative-difficulty a
+// longer one the way production reorgs are decided. The seed goes into the
+// extra data, so chains from the same parent with different seeds are
+// distinct forks.
+func makeTestBlockWithDifficulty(parent *types.Block, difficulty int64, seed byte) *types.Block {
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     new(big.Int).Add(parent.Number(), common.Big1),
+		Difficulty: big.NewInt(difficulty),
+		GasLimit:   params.GenesisGasLimit,
+		Time:       parent.Header().Time + 10,
+		Extra:      []byte{seed},
+	}
+	return types.NewBlockWithHeader(header).WithBody(types.Body{})
+}
+
+// makeTestBlock builds an empty block on top of parent with the default
+// difficulty of one.
+func makeTestBlock(parent *types.Block, seed byte) *types.Block {
+	return makeTestBlockWithDifficulty(parent, common.Big1.Int64(), seed)
+}
+
+// extendTestChain builds n blocks on top of parent, seeding their extra data
+// with seed, seed+1 and so on. parent is not included.
+func extendTestChain(parent *types.Block, n int, seed byte) []*types.Block {
+	chain := make([]*types.Block, 0, n)
+	for i := 0; i < n; i++ {
+		block := makeTestBlock(parent, seed+byte(i))
+		chain = append(chain, block)
+		parent = block
+	}
+	return chain
+}
+
+// assertProposedBlock checks the handleProposedBlock call count and, when
+// wantTail is non-nil, the block the most recent call saw.
+func assertProposedBlock(t *testing.T, dl *downloadTester, wantCalls int, wantTail *types.Block) {
+	t.Helper()
+	calls, got := dl.proposedState()
+	if calls != wantCalls {
+		t.Fatalf("handleProposedBlock ran %d times, want %d", calls, wantCalls)
+	}
+	if wantTail == nil {
+		return
+	}
+	if got == nil || got.Hash() != wantTail.Hash() {
+		t.Fatalf("handleProposedBlock ran on %v, want %v", got, wantTail.Hash())
+	}
+}
+
+// TestImportBlockResultsProposedBlockHandler checks the downloader pre-filter:
+// the handler runs only when the imported batch tail is both stored and
+// canonical. The cases cover a parked tail, a stored side-chain tail, and a
+// fast-sync height whose canonical header arrived before its body.
+// The shared decision semantics are tested against a real BlockChain in
+// consensus/tests/engine_v2_tests. The tester-contract tests below pin the
+// storage and canonicality behavior this test relies on.
+func TestImportBlockResultsProposedBlockHandler(t *testing.T) {
+	t.Run("batch tail parked in the future queue", func(t *testing.T) {
+		// A parked tail is neither stored nor canonical, so the handler must
+		// not run.
+		dl := newTester()
+		defer dl.terminate()
+
+		local := extendTestChain(dl.genesis, 4, 0)
+		if _, err := dl.InsertChain(local); err != nil {
+			t.Fatalf("failed to set up the local chain: %v", err)
+		}
+		// The batch continues the local head, like a queued batch does.
+		batch := extendTestChain(local[len(local)-1], 4, 16)
+		tail := batch[len(batch)-1]
+		dl.parkTailOnce = true
+		before, _ := dl.proposedState()
+		if err := dl.downloader.importBlockResults(toFetchResults(batch)); err != nil {
+			t.Fatalf("failed to import the queued batch: %v", err)
+		}
+		assertProposedBlock(t, dl, before, nil)
+		if dl.GetBlock(tail.Hash(), tail.NumberU64()) != nil {
+			t.Fatalf("queued batch tail unexpectedly stored")
+		}
+		if got := dl.GetCanonicalHash(tail.NumberU64()); got != (common.Hash{}) {
+			t.Fatalf("parked tail height unexpectedly canonical: %v", got)
+		}
+	})
+
+	t.Run("imported batch", func(t *testing.T) {
+		// A fully written batch triggers the handler exactly once.
+		dl := newTester()
+		defer dl.terminate()
+
+		batch := extendTestChain(dl.genesis, 4, 32)
+		before, _ := dl.proposedState()
+		if err := dl.downloader.importBlockResults(toFetchResults(batch)); err != nil {
+			t.Fatalf("failed to import the batch: %v", err)
+		}
+		assertProposedBlock(t, dl, before+1, batch[len(batch)-1])
+		if dl.GetBlock(batch[len(batch)-1].Hash(), batch[len(batch)-1].NumberU64()) == nil {
+			t.Fatalf("imported batch tail not stored")
+		}
+	})
+
+	t.Run("stored side-chain batch re-delivered", func(t *testing.T) {
+		// A stored fork batch that is no longer the head must not reach the
+		// handler: storage is not canonicality.
+		dl := newTester()
+		defer dl.terminate()
+
+		fork := extendTestChain(dl.genesis, 4, 48)
+		// Freshly stored, the fork is ahead of the local chain, so it
+		// becomes the head and the handler firing once is expected.
+		if err := dl.downloader.importBlockResults(toFetchResults(fork)); err != nil {
+			t.Fatalf("failed to store the fork batch: %v", err)
+		}
+		// Growing the local chain past the fork turns its blocks into side
+		// entries.
+		local := extendTestChain(dl.genesis, 5, 64)
+		if _, err := dl.InsertChain(local); err != nil {
+			t.Fatalf("failed to set up the local chain: %v", err)
+		}
+		tail := fork[len(fork)-1]
+		if dl.GetBlock(tail.Hash(), tail.NumberU64()) == nil {
+			t.Fatalf("fork batch tail not stored")
+		}
+		// Re-delivering the stored fork must not reach the handler again.
+		// Capture logs to pin the pre-filter's call-site grading: the skip
+		// must surface at Info (PreFilterSkipLogLevel), not the Warn the same
+		// reason gets at the handler.
+		var logBuf bytes.Buffer
+		glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(&logBuf, log.LevelInfo, false))
+		glog.Verbosity(log.LevelInfo)
+		prevLog := log.Root()
+		log.SetDefault(log.NewLogger(glog))
+		defer log.SetDefault(prevLog)
+		prefilterSkipsBefore := skippedProposedBlockPreFilter.Snapshot().Count()
+		before, _ := dl.proposedState()
+		if err := dl.downloader.importBlockResults(toFetchResults(fork)); err != nil {
+			t.Fatalf("failed to re-import the fork batch: %v", err)
+		}
+		assertProposedBlock(t, dl, before, nil)
+		if got := skippedProposedBlockPreFilter.Snapshot().Count(); got != prefilterSkipsBefore+1 {
+			t.Fatalf("pre-filter skip not counted, before = %d, after = %d", prefilterSkipsBefore, got)
+		}
+		found := false
+		for _, line := range strings.Split(logBuf.String(), "\n") {
+			if strings.Contains(line, "skipped proposed block handler") {
+				if !strings.HasPrefix(line, "INFO") {
+					t.Fatalf("pre-filter skip must log at Info, got line %q", line)
+				}
+				if !strings.Contains(line, "non-canonical") {
+					t.Fatalf("pre-filter skip must carry the reason, got line %q", line)
+				}
+				// The hash attribute key must match the other skip sites
+				// (engine skipProposedBlock, the eth fetcher gate); "block
+				// hash=" would drop this emitter from hash= filtering.
+				if strings.Contains(line, "block hash=") {
+					t.Fatalf("pre-filter skip hash key regressed to 'block hash', got line %q", line)
+				}
+				if !strings.Contains(line, "hash=") {
+					t.Fatalf("pre-filter skip must carry the hash attribute, got line %q", line)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("pre-filter skip line not found in logs: %q", logBuf.String())
+		}
+	})
+
+	t.Run("head advanced past the canonical tail", func(t *testing.T) {
+		// The tail stays canonical at its own height even once the head
+		// moved past it, so the handler must still run.
+		dl := newTester()
+		defer dl.terminate()
+
+		base := extendTestChain(dl.genesis, 4, 80)
+		if _, err := dl.InsertChain(base); err != nil {
+			t.Fatalf("failed to set up the local chain: %v", err)
+		}
+		batch := extendTestChain(base[len(base)-1], 4, 96)
+		dl.extendTailAfterInsert = func(tail *types.Block) *types.Block {
+			// A concurrent import of the tail's child landing before
+			// importBlockResults reads the head.
+			return makeTestBlock(tail, 200)
+		}
+		before, _ := dl.proposedState()
+		if err := dl.downloader.importBlockResults(toFetchResults(batch)); err != nil {
+			t.Fatalf("failed to import the batch: %v", err)
+		}
+		assertProposedBlock(t, dl, before+1, batch[len(batch)-1])
+	})
+
+	t.Run("heavier fork stays canonical", func(t *testing.T) {
+		// The head goes to the highest total difficulty, not to the last
+		// insert, so a lighter chain stored later must not displace the
+		// heavier fork.
+		dl := newTester()
+		defer dl.terminate()
+
+		fork := extendTestChain(dl.genesis, 6, 112)
+		if err := dl.downloader.importBlockResults(toFetchResults(fork)); err != nil {
+			t.Fatalf("failed to store the fork batch: %v", err)
+		}
+		local := extendTestChain(dl.genesis, 2, 128)
+		if _, err := dl.InsertChain(local); err != nil {
+			t.Fatalf("failed to set up the local chain: %v", err)
+		}
+		// The fork is still canonical, so re-delivering it reaches the
+		// handler again.
+		before, _ := dl.proposedState()
+		if err := dl.downloader.importBlockResults(toFetchResults(fork)); err != nil {
+			t.Fatalf("failed to re-import the fork batch: %v", err)
+		}
+		assertProposedBlock(t, dl, before+1, fork[len(fork)-1])
+	})
+
+	t.Run("fast-sync canonical tail without body", func(t *testing.T) {
+		// The header phase makes the tail's height canonical before its body
+		// is imported, so HasBlock has to gate the handler too.
+		dl := newTester()
+		defer dl.terminate()
+
+		batch := extendTestChain(dl.genesis, 4, 144)
+		headers := make([]*types.Header, len(batch))
+		for i, block := range batch {
+			headers[i] = block.Header()
+		}
+		if _, err := dl.InsertHeaderChain(headers, 0); err != nil {
+			t.Fatalf("failed to set up the header phase: %v", err)
+		}
+		// The tail height is canonical already, but its body is missing.
+		tail := batch[len(batch)-1]
+		if got := dl.GetCanonicalHash(tail.NumberU64()); got != tail.Hash() {
+			t.Fatalf("tail height not canonical after the header phase: have %v, want %v", got, tail.Hash())
+		}
+		if dl.HasBlock(tail.Hash(), tail.NumberU64()) {
+			t.Fatalf("tail block unexpectedly stored before the body phase")
+		}
+		dl.parkTailOnce = true
+		before, _ := dl.proposedState()
+		if err := dl.downloader.importBlockResults(toFetchResults(batch)); err != nil {
+			t.Fatalf("failed to import the queued batch: %v", err)
+		}
+		assertProposedBlock(t, dl, before, nil)
+		if dl.HasBlock(tail.Hash(), tail.NumberU64()) {
+			t.Fatalf("queued batch tail unexpectedly stored")
+		}
+	})
+}
+
+// Tester-contract test: this verifies downloadTester's modeled behavior, not
+// production code. See TestImportBlockResultsProposedBlockHandler for how
+// these tester guarantees support the higher-level import cases.
+// TestInsertChainErrorReportsPosition checks that a failing storeBlock is
+// reported with the block's index in the batch and the batch length, so a
+// broken batch can be located without re-deriving the position.
+func TestInsertChainErrorReportsPosition(t *testing.T) {
+	dl := newTester()
+	defer dl.terminate()
+
+	base := extendTestChain(dl.genesis, 2, 208)
+	// A child hanging off a parent that is not in the chain.
+	orphanChild := makeTestBlock(makeTestBlock(dl.genesis, 250), 251)
+
+	t.Run("main loop", func(t *testing.T) {
+		batch := []*types.Block{base[0], orphanChild}
+		i, err := dl.InsertChain(batch)
+		if err == nil {
+			t.Fatalf("expected an error for the unknown parent")
+		}
+		want := fmt.Sprintf("InsertChain: unknown parent %s at position 1 / 2", orphanChild.ParentHash())
+		if err.Error() != want {
+			t.Fatalf("error mismatch: have %q, want %q", err.Error(), want)
+		}
+		if i != 1 {
+			t.Fatalf("returned index mismatch: have %d, want 1", i)
+		}
+	})
+
+	t.Run("parked tail prefix", func(t *testing.T) {
+		dl.parkTailOnce = true
+		batch := []*types.Block{orphanChild, base[1]}
+		i, err := dl.InsertChain(batch)
+		if err == nil {
+			t.Fatalf("expected an error for the unknown parent")
+		}
+		want := fmt.Sprintf("InsertChain: unknown parent %s at position 0 / 2", orphanChild.ParentHash())
+		if err.Error() != want {
+			t.Fatalf("error mismatch: have %q, want %q", err.Error(), want)
+		}
+		if i != 0 {
+			t.Fatalf("returned index mismatch: have %d, want 0", i)
+		}
+	})
+
+	t.Run("extended tail child", func(t *testing.T) {
+		// The hook's child fails on its unknown parent, reported at the
+		// position right after the batch.
+		dl.extendTailAfterInsert = func(tail *types.Block) *types.Block {
+			return orphanChild
+		}
+		batch := []*types.Block{base[0], base[1]}
+		i, err := dl.InsertChain(batch)
+		if err == nil {
+			t.Fatalf("expected an error for the unknown parent")
+		}
+		want := fmt.Sprintf("InsertChain: unknown parent %s at position 2 / 3", orphanChild.ParentHash())
+		if err.Error() != want {
+			t.Fatalf("error mismatch: have %q, want %q", err.Error(), want)
+		}
+		if i != 2 {
+			t.Fatalf("returned index mismatch: have %d, want 2", i)
+		}
+	})
+}
+
+// Tester-contract test: this verifies downloadTester's modeled behavior, not
+// production code. The rollback behavior checked here supports the canonical
+// storage assumptions used by TestImportBlockResultsProposedBlockHandler.
+// TestRollbackClearsCanonicalMarkers checks that Rollback drops the
+// canonical entries of the removed blocks, so GetCanonicalHash stops
+// reporting them, while the surviving ancestors stay canonical.
+func TestRollbackClearsCanonicalMarkers(t *testing.T) {
+	dl := newTester()
+	defer dl.terminate()
+
+	chain := extendTestChain(dl.genesis, 4, 208)
+	if _, err := dl.InsertChain(chain); err != nil {
+		t.Fatalf("failed to set up the chain: %v", err)
+	}
+	for _, block := range chain {
+		if got := dl.GetCanonicalHash(block.NumberU64()); got != block.Hash() {
+			t.Fatalf("height %d not canonical before the rollback: have %v, want %v", block.NumberU64(), got, block.Hash())
+		}
+	}
+
+	rolledBack := chain[2:]
+	hashes := make([]common.Hash, len(rolledBack))
+	for i, block := range rolledBack {
+		hashes[i] = block.Hash()
+	}
+	dl.Rollback(hashes)
+
+	// The rolled-back heights no longer report a canonical hash.
+	for _, block := range rolledBack {
+		if got := dl.GetCanonicalHash(block.NumberU64()); got != (common.Hash{}) {
+			t.Fatalf("height %d still canonical after the rollback: %v", block.NumberU64(), got)
+		}
+	}
+	// The surviving ancestors keep their canonical entries.
+	for _, block := range chain[:2] {
+		if got := dl.GetCanonicalHash(block.NumberU64()); got != block.Hash() {
+			t.Fatalf("ancestor height %d lost its canonical entry: have %v, want %v", block.NumberU64(), got, block.Hash())
+		}
+	}
+	if got := dl.GetCanonicalHash(0); got != dl.genesis.Hash() {
+		t.Fatalf("genesis height lost its canonical entry: have %v, want %v", got, dl.genesis.Hash())
+	}
+}
+
+// toFetchResults converts a chain of blocks into the fetch-result shape
+// importBlockResults consumes: headers plus empty transaction bodies.
+func toFetchResults(blocks []*types.Block) []*fetchResult {
+	results := make([]*fetchResult, 0, len(blocks))
+	for _, block := range blocks {
+		results = append(results, &fetchResult{Header: block.Header(), Transactions: types.Transactions{}})
+	}
+	return results
+}
+
+// Tester-contract test: this verifies downloadTester's modeled behavior, not
+// production code. It checks that a reorg also removes stale canonical
+// markers above the new head, as required by the import pre-filter tests.
+// TestStoreBlockCleansStaleCanonicalMarkers checks that taking over the
+// canonical table with a shorter but heavier branch drops the stale
+// canonical markers above the new head, mirroring the reorg cleanup of
+// real insertChain: without the cleanup, GetCanonicalHash keeps answering
+// with the replaced branch at the heights above the new head.
+func TestStoreBlockCleansStaleCanonicalMarkers(t *testing.T) {
+	dl := newTester()
+	defer dl.terminate()
+
+	base := extendTestChain(dl.genesis, 2, 208)
+	if _, err := dl.InsertChain(base); err != nil {
+		t.Fatalf("failed to set up the base chain: %v", err)
+	}
+	baseHead := base[len(base)-1]
+
+	// A longer branch of difficulty-1 blocks: heights baseHead+1..+3.
+	longBranch := extendTestChain(baseHead, 3, 226)
+	if _, err := dl.InsertChain(longBranch); err != nil {
+		t.Fatalf("failed to import the long branch: %v", err)
+	}
+
+	// A shorter branch of difficulty-2 blocks: heights baseHead+1..+2
+	// only, but its head carries the higher total difficulty.
+	var shortBranch []*types.Block
+	parent := baseHead
+	for i := 0; i < 2; i++ {
+		parent = makeTestBlockWithDifficulty(parent, 2, 240+byte(i))
+		shortBranch = append(shortBranch, parent)
+	}
+	if _, err := dl.InsertChain(shortBranch); err != nil {
+		t.Fatalf("failed to import the short heavier branch: %v", err)
+	}
+
+	// The short branch took the canonical table over up to its head.
+	head := shortBranch[len(shortBranch)-1]
+	if got := dl.GetCanonicalHash(head.NumberU64()); got != head.Hash() {
+		t.Fatalf("heavier fork head not canonical: have %v, want %v", got, head.Hash())
+	}
+	if got := dl.GetCanonicalHash(shortBranch[0].NumberU64()); got != shortBranch[0].Hash() {
+		t.Fatalf("replaced height %d lost its new canonical entry: have %v, want %v", shortBranch[0].NumberU64(), got, shortBranch[0].Hash())
+	}
+	// The heights above the new head must not answer with the replaced
+	// branch; production reorg deletes those markers.
+	above := longBranch[len(longBranch)-1]
+	if got := dl.GetCanonicalHash(above.NumberU64()); got != (common.Hash{}) {
+		t.Fatalf("stale canonical marker above the new head survived: have %v", got)
+	}
+}
+
+// Tester-contract test: this verifies downloadTester's modeled behavior, not
+// production code. It covers the canonical-choice tie-break used by the
+// import pre-filter: a higher block number wins an equal-difficulty tie,
+// while a same-height branch remains non-canonical.
+// TestStoreBlockEqualDifficultyTieBreaksByNumber checks that the fork
+// choice mirror of insertChain splits an equal-total-difficulty tie by
+// number: a higher-height block takes over the canonical table while a
+// same-height one stays a side entry, matching the selfish-mining guard
+// of writeBlockWithState.
+func TestStoreBlockEqualDifficultyTieBreaksByNumber(t *testing.T) {
+	dl := newTester()
+	defer dl.terminate()
+
+	base := extendTestChain(dl.genesis, 2, 250)
+	if _, err := dl.InsertChain(base); err != nil {
+		t.Fatalf("failed to set up the base chain: %v", err)
+	}
+	baseHead := base[len(base)-1]
+
+	// A difficulty-2 block at height baseHead+1 takes the head with a
+	// strictly higher total difficulty.
+	heavy := makeTestBlockWithDifficulty(baseHead, 2, 251)
+	if _, err := dl.InsertChain([]*types.Block{heavy}); err != nil {
+		t.Fatalf("failed to import the heavy fork: %v", err)
+	}
+	if got := dl.GetCanonicalHash(heavy.NumberU64()); got != heavy.Hash() {
+		t.Fatalf("heavier fork head not canonical: have %v, want %v", got, heavy.Hash())
+	}
+
+	// A same-height block with the same total difficulty must not
+	// displace the head.
+	twin := makeTestBlockWithDifficulty(baseHead, 2, 252)
+	if _, err := dl.InsertChain([]*types.Block{twin}); err != nil {
+		t.Fatalf("failed to import the twin fork: %v", err)
+	}
+	if got := dl.GetCanonicalHash(twin.NumberU64()); got != heavy.Hash() {
+		t.Fatalf("same-height equal-difficulty fork displaced the head: have %v, want %v", got, heavy.Hash())
+	}
+
+	// A branch of difficulty-1 blocks ties the head's total difficulty
+	// exactly one height above it; production promotes that block, so
+	// the mirror must too.
+	tie := extendTestChain(baseHead, 2, 253)
+	if _, err := dl.InsertChain(tie); err != nil {
+		t.Fatalf("failed to import the tying branch: %v", err)
+	}
+	if got := dl.GetCanonicalHash(tie[1].NumberU64()); got != tie[1].Hash() {
+		t.Fatalf("equal-difficulty higher-height fork not promoted: have %v, want %v", got, tie[1].Hash())
+	}
+	if got := dl.GetCanonicalHash(tie[0].NumberU64()); got != tie[0].Hash() {
+		t.Fatalf("tying branch lost its canonical segment: have %v, want %v", got, tie[0].Hash())
+	}
+	if got := dl.GetCanonicalHash(baseHead.NumberU64()); got != baseHead.Hash() {
+		t.Fatalf("reorg rewired the shared prefix: have %v, want %v", got, baseHead.Hash())
+	}
+}
+
+// Tester-contract test: this verifies downloadTester's modeled behavior, not
+// production code. It ensures the chain's head getters follow the canonical
+// table after side-chain insertion and after a shorter, heavier branch takes
+// over.
+// TestHeadGettersFollowCanonicalTable checks that the head getters report
+// the canonical head rather than the last stored block, the way production
+// reads its own chain state: a lighter side chain stored after a heavier
+// fork must not displace what CurrentHeader, CurrentBlock and
+// CurrentSnapBlock report, and a shorter heavier branch taking over must
+// move the getters onto its own head, off the replaced branch's tail.
+func TestHeadGettersFollowCanonicalTable(t *testing.T) {
+	dl := newTester()
+	defer dl.terminate()
+
+	fork := extendTestChain(dl.genesis, 6, 112)
+	if err := dl.downloader.importBlockResults(toFetchResults(fork)); err != nil {
+		t.Fatalf("failed to store the fork batch: %v", err)
+	}
+	local := extendTestChain(dl.genesis, 2, 128)
+	if _, err := dl.InsertChain(local); err != nil {
+		t.Fatalf("failed to set up the local chain: %v", err)
+	}
+	want := fork[len(fork)-1].NumberU64()
+	if have := dl.CurrentHeader().Number.Uint64(); have != want {
+		t.Fatalf("CurrentHeader reported the side chain: have %v, want %v", have, want)
+	}
+	if have := dl.CurrentBlock().Number.Uint64(); have != want {
+		t.Fatalf("CurrentBlock reported the side chain: have %v, want %v", have, want)
+	}
+	if have := dl.CurrentSnapBlock().Number.Uint64(); have != want {
+		t.Fatalf("CurrentSnapBlock reported the side chain: have %v, want %v", have, want)
+	}
+
+	// A shorter heavier branch taking over the canonical table must move the
+	// head getters onto its own head and off the replaced branch's stale tail.
+	dl2 := newTester()
+	defer dl2.terminate()
+
+	base := extendTestChain(dl2.genesis, 2, 208)
+	if _, err := dl2.InsertChain(base); err != nil {
+		t.Fatalf("failed to set up the base chain: %v", err)
+	}
+	baseHead := base[len(base)-1]
+	longBranch := extendTestChain(baseHead, 3, 226)
+	if _, err := dl2.InsertChain(longBranch); err != nil {
+		t.Fatalf("failed to import the long branch: %v", err)
+	}
+	var shortBranch []*types.Block
+	parent := baseHead
+	for i := 0; i < 2; i++ {
+		parent = makeTestBlockWithDifficulty(parent, 2, 240+byte(i))
+		shortBranch = append(shortBranch, parent)
+	}
+	if _, err := dl2.InsertChain(shortBranch); err != nil {
+		t.Fatalf("failed to import the short heavier branch: %v", err)
+	}
+	want = shortBranch[len(shortBranch)-1].NumberU64()
+	if have := dl2.CurrentHeader().Number.Uint64(); have != want {
+		t.Fatalf("CurrentHeader kept the replaced branch: have %v, want %v", have, want)
+	}
+	if have := dl2.CurrentBlock().Number.Uint64(); have != want {
+		t.Fatalf("CurrentBlock kept the replaced branch: have %v, want %v", have, want)
+	}
+	if have := dl2.CurrentSnapBlock().Number.Uint64(); have != want {
+		t.Fatalf("CurrentSnapBlock kept the replaced branch: have %v, want %v", have, want)
+	}
+}
+
+// TestImportBlockResultsNilProposedBlockHandler pins the non-XDPoS shape of
+// the import pre-filter: a downloader wired without a proposed-block handler
+// (what NewProtocolManager passes for a non-XDPoS engine) skips the whole
+// pre-filter block — no judgment, no counter movement, no log — and imports
+// normally. Normalizing the nil callback to a no-op instead would make the
+// pre-filter run and count skips for a handler that does nothing.
+func TestImportBlockResultsNilProposedBlockHandler(t *testing.T) {
+	dl := newTester()
+	defer dl.terminate()
+
+	local := extendTestChain(dl.genesis, 4, 0)
+	if _, err := dl.InsertChain(local); err != nil {
+		t.Fatalf("failed to set up the local chain: %v", err)
+	}
+	batch := extendTestChain(local[len(local)-1], 4, 16)
+	tail := batch[len(batch)-1]
+
+	// Rebuild the tester's downloader with a nil handler, mirroring the
+	// non-XDPoS wiring in eth.NewProtocolManager. The original downloader is
+	// terminated first so its goroutines do not leak.
+	dl.downloader.Terminate()
+	dl.downloader = New(dl.stateDb, new(event.TypeMux), dl, nil, dl.dropPeer, nil)
+
+	before := skippedProposedBlockPreFilter.Snapshot().Count()
+	if err := dl.downloader.importBlockResults(toFetchResults(batch)); err != nil {
+		t.Fatalf("nil-handler import failed: %v", err)
+	}
+	if got := skippedProposedBlockPreFilter.Snapshot().Count(); got != before {
+		t.Fatalf("pre-filter moved with a nil handler, before = %d, after = %d", before, got)
+	}
+	if dl.GetBlock(tail.Hash(), tail.NumberU64()) == nil {
+		t.Fatalf("nil-handler import did not store the batch tail")
+	}
+}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -68,13 +68,28 @@ type downloadTester struct {
 	peerDb  ethdb.Database // Database of the peers containing all data
 	peers   map[string]*downloadTesterPeer
 
-	ownHashes   []common.Hash                  // Hash chain belonging to the tester
-	ownHeaders  map[common.Hash]*types.Header  // Headers belonging to the tester
-	ownBlocks   map[common.Hash]*types.Block   // Blocks belonging to the tester
-	ownReceipts map[common.Hash]types.Receipts // Receipts belonging to the tester
-	ownChainTd  map[common.Hash]*big.Int       // Total difficulties of the blocks in the local chain
+	ownHashes    []common.Hash                  // Canonical hash chain in height order, rebuilt from ownCanonical
+	ownHeaders   map[common.Hash]*types.Header  // Headers belonging to the tester
+	ownBlocks    map[common.Hash]*types.Block   // Blocks belonging to the tester
+	ownReceipts  map[common.Hash]types.Receipts // Receipts belonging to the tester
+	ownChainTd   map[common.Hash]*big.Int       // Total difficulties of the blocks in the local chain
+	ownCanonical map[uint64]common.Hash         // Canonical number-to-hash table, mirroring the real chain's marker writes
 
 	insertHeaderChainHook func([]*types.Header) error
+	// parkTailOnce makes the next InsertChain park the batch tail, the way
+	// insertChain parks future blocks: everything but the tail is written.
+	// Consumed by that one call.
+	parkTailOnce bool
+	// extendTailAfterInsert, when set, is called after the next InsertChain
+	// with the batch tail and stores the child it returns, simulating a
+	// concurrent import landing before importBlockResults reads the head.
+	// Consumed by that one call.
+	extendTailAfterInsert func(tail *types.Block) *types.Block
+
+	// proposedCalls and lastProposedHeader record handleProposedBlock calls
+	// for assertions; read them together via proposedState.
+	proposedCalls      int
+	lastProposedHeader *types.Header
 
 	// headHeaderCap, when non-zero, caps the height reported by CurrentHeader.
 	// It models the real chain, where importing blocks moves the header head
@@ -104,14 +119,15 @@ func newTester() *downloadTester {
 // shared test genesis.
 func newTesterWithGenesis(genesis *types.Block, peerDb ethdb.Database) *downloadTester {
 	tester := &downloadTester{
-		genesis:     genesis,
-		peerDb:      peerDb,
-		peers:       make(map[string]*downloadTesterPeer),
-		ownHashes:   []common.Hash{genesis.Hash()},
-		ownHeaders:  map[common.Hash]*types.Header{genesis.Hash(): genesis.Header()},
-		ownBlocks:   map[common.Hash]*types.Block{genesis.Hash(): genesis},
-		ownReceipts: map[common.Hash]types.Receipts{genesis.Hash(): nil},
-		ownChainTd:  map[common.Hash]*big.Int{genesis.Hash(): genesis.Difficulty()},
+		genesis:      genesis,
+		peerDb:       peerDb,
+		peers:        make(map[string]*downloadTesterPeer),
+		ownHashes:    []common.Hash{genesis.Hash()},
+		ownHeaders:   map[common.Hash]*types.Header{genesis.Hash(): genesis.Header()},
+		ownBlocks:    map[common.Hash]*types.Block{genesis.Hash(): genesis},
+		ownReceipts:  map[common.Hash]types.Receipts{genesis.Hash(): nil},
+		ownChainTd:   map[common.Hash]*big.Int{genesis.Hash(): genesis.Difficulty()},
+		ownCanonical: map[uint64]common.Hash{0: genesis.Hash()},
 	}
 	tester.stateDb = rawdb.NewMemoryDatabase()
 	tester.triedb = trie.NewDatabase(tester.stateDb)
@@ -157,9 +173,13 @@ func (dl *downloadTester) HasHeader(hash common.Hash, number uint64) bool {
 	return dl.GetHeaderByHash(hash) != nil
 }
 
-// HasBlock checks if a block is present in the testers canonical chain.
+// HasBlock checks whether a full block is present at the requested height.
 func (dl *downloadTester) HasBlock(hash common.Hash, number uint64) bool {
-	return dl.GetBlockByHash(hash) != nil
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	block := dl.ownBlocks[hash]
+	return block != nil && block.NumberU64() == number
 }
 
 // HasFastBlock checks if a block is present in the testers canonical chain.
@@ -282,7 +302,12 @@ func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq i
 		hashes = append(hashes, hash)
 	}
 	hashes = append(hashes, headers[len(headers)-1].Hash())
+	// Anchor of the WriteHeader comparison: the current head header. A nil
+	// total difficulty means the entry was rolled back.
+	_, headHash := dl.canonicalHead(false)
+	headTd := dl.ownChainTd[headHash]
 	// Do a full insert if pre-checks passed
+	tookOver := false
 	for i, header := range headers {
 		hash := hashes[i]
 		if dl.getHeaderByHash(hash) != nil {
@@ -292,11 +317,26 @@ func (dl *downloadTester) InsertHeaderChain(headers []*types.Header, checkFreq i
 			// This _should_ be impossible, due to precheck and induction
 			return i, fmt.Errorf("InsertHeaderChain: unknown parent at position %d", i)
 		}
-		dl.ownHashes = append(dl.ownHashes, hash)
 		dl.ownHeaders[hash] = header
 
 		td := dl.getTd(header.ParentHash)
 		dl.ownChainTd[hash] = new(big.Int).Add(td, header.Difficulty)
+
+		// Mirror WriteHeader: a header with a higher total difficulty than
+		// the head takes over the canonical table, before any body exists.
+		// WriteHeader's equal-total-difficulty clause splits ties randomly
+		// (mrand.Float64() < 0.5), which cannot be mirrored deterministically;
+		// this tester keeps the strict comparison, the conservative side of
+		// that distribution.
+		if headTd == nil || dl.ownChainTd[hash].Cmp(headTd) > 0 {
+			dl.canonicalize(hash, header.Number.Uint64())
+			dl.removeAbove(header.Number.Uint64())
+			headTd = dl.ownChainTd[hash]
+			tookOver = true
+		}
+	}
+	if tookOver {
+		dl.rebuildOwnHashes()
 	}
 	return len(headers), nil
 }
@@ -306,19 +346,29 @@ func (dl *downloadTester) InsertChain(blocks types.Blocks) (i int, err error) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 
+	if dl.parkTailOnce {
+		dl.parkTailOnce = false
+		// Park the tail the way insertChain does with future blocks.
+		for i, block := range blocks[:len(blocks)-1] {
+			if err := dl.storeBlock(block); err != nil {
+				return i, fmt.Errorf("InsertChain: %v at position %d / %d", err, i, len(blocks))
+			}
+		}
+		return len(blocks) - 1, nil
+	}
+
 	for i, block := range blocks {
-		if parent, ok := dl.ownBlocks[block.ParentHash()]; !ok {
-			return i, fmt.Errorf("InsertChain: unknown parent at position %d / %d", i, len(blocks))
-		} else if _, err := dl.stateDb.Get(parent.Root().Bytes()); err != nil {
-			return i, fmt.Errorf("InsertChain: unknown parent state %x: %v", parent.Root(), err)
+		if err := dl.storeBlock(block); err != nil {
+			return i, fmt.Errorf("InsertChain: %v at position %d / %d", err, i, len(blocks))
 		}
-		if _, ok := dl.ownHeaders[block.Hash()]; !ok {
-			dl.ownHashes = append(dl.ownHashes, block.Hash())
-			dl.ownHeaders[block.Hash()] = block.Header()
+	}
+	if hook := dl.extendTailAfterInsert; hook != nil {
+		dl.extendTailAfterInsert = nil
+		if child := hook(blocks[len(blocks)-1]); child != nil {
+			if err := dl.storeBlock(child); err != nil {
+				return len(blocks), fmt.Errorf("InsertChain: %v at position %d / %d", err, len(blocks), len(blocks)+1)
+			}
 		}
-		dl.ownBlocks[block.Hash()] = block
-		dl.stateDb.Put(block.Root().Bytes(), []byte{0x00})
-		dl.ownChainTd[block.Hash()] = new(big.Int).Add(dl.ownChainTd[block.ParentHash()], block.Difficulty())
 	}
 	return len(blocks), nil
 }
@@ -347,6 +397,152 @@ func (dl *downloadTester) writeBlockWithoutState(block *types.Block) error {
 	return nil
 }
 
+// storeBlock records a block in the tester's chain, validating its parent.
+// It must be called with dl.lock held for writing.
+func (dl *downloadTester) storeBlock(block *types.Block) error {
+	parent, ok := dl.ownBlocks[block.ParentHash()]
+	if !ok {
+		return fmt.Errorf("unknown parent %s", block.ParentHash())
+	}
+	if _, err := dl.stateDb.Get(parent.Root().Bytes()); err != nil {
+		return fmt.Errorf("unknown parent state %x: %v", parent.Root(), err)
+	}
+	dl.ownHeaders[block.Hash()] = block.Header()
+	dl.ownBlocks[block.Hash()] = block
+	dl.stateDb.Put(block.Root().Bytes(), []byte{0x00})
+	dl.ownChainTd[block.Hash()] = new(big.Int).Add(dl.ownChainTd[block.ParentHash()], block.Difficulty())
+	// Mirror insertChain: only a block heavier than the head block takes
+	// over the canonical table; a lighter one is written as a side entry.
+	// On an equal total difficulty, production splits the tie by number:
+	// a higher-height block takes over, a same-height one stays a side
+	// entry (the selfish-mining guard of writeBlockWithState).
+	headNumber, headHash := dl.canonicalHead(true)
+	headTd := dl.ownChainTd[headHash]
+	blockTd := dl.ownChainTd[block.Hash()]
+	if headTd == nil || blockTd.Cmp(headTd) > 0 || (blockTd.Cmp(headTd) == 0 && block.NumberU64() > headNumber) {
+		dl.canonicalize(block.Hash(), block.NumberU64())
+		// Mirror the reorg cleanup of real insertChain: when a shorter but
+		// heavier branch takes over, the stale markers above the new head
+		// must go, so GetCanonicalHash stops answering with the replaced
+		// branch at those heights.
+		dl.removeAbove(block.NumberU64())
+		// ownHashes is the canonical snapshot, so refresh it only after
+		// removeAbove: rebuilding earlier would re-enter the replaced
+		// branch's stale markers still present in the table.
+		dl.rebuildOwnHashes()
+	}
+	return nil
+}
+
+// The methods below (canonicalize, removeAbove, rebuildOwnHashes,
+// canonicalHead, GetCanonicalHash, GetHeaderByNumber, GetBlock and their
+// helpers in storeBlock) form the tester's fork-choice mirror: ownCanonical
+// is the single source of truth for canonicality, ownHashes its
+// height-ordered snapshot, and every proposed-block test downstream reads
+// the judgment through these accessors. Keep the mirror consistent — a
+// canonical-table write without the matching snapshot rebuild (or vice
+// versa) silently changes what every later test judges canonical.
+//
+// Equivalence with the real chain: the mirror reproduces the canonical-table
+// semantics of WriteHeader and insertChain (heavier branch takes over, equal
+// TD split by height, stale-marker cleanup on takeover), and the real-chain
+// side of the same judgment is covered directly by core/blockchain_test.go
+// and consensus/proposed_block_test.go on *core.BlockChain. The mirror is
+// kept deliberately small rather than cross-validated against a real chain
+// here: the downloader fixture needs a fake consensus engine and cannot host
+// one without duplicating the core test rig.
+// canonicalize makes hash the canonical entry at number and rewires the
+// segment below it, mirroring the marker writes of WriteHeader and
+// insertChain. Caller must hold dl.lock for writing.
+func (dl *downloadTester) canonicalize(hash common.Hash, number uint64) {
+	for n, h := number, hash; n > 0 && dl.ownCanonical[n] != h; n-- {
+		dl.ownCanonical[n] = h
+		header := dl.ownHeaders[h]
+		if header == nil {
+			break
+		}
+		h = header.ParentHash
+	}
+}
+
+// removeAbove drops canonical entries above number, the stale-marker cleanup
+// of WriteHeader. Caller must hold dl.lock for writing.
+func (dl *downloadTester) removeAbove(number uint64) {
+	for n := number + 1; ; n++ {
+		if _, ok := dl.ownCanonical[n]; !ok {
+			break
+		}
+		delete(dl.ownCanonical, n)
+	}
+}
+
+// rebuildOwnHashes refreshes ownHashes from the canonical table, keeping it
+// the height-ordered snapshot of the canonical chain that the head getters
+// report. It must run after removeAbove, so the stale markers of a replaced
+// branch never re-enter the list. Caller must hold dl.lock for writing.
+func (dl *downloadTester) rebuildOwnHashes() {
+	numbers := make([]uint64, 0, len(dl.ownCanonical))
+	for n, h := range dl.ownCanonical {
+		if dl.ownHeaders[h] != nil {
+			numbers = append(numbers, n)
+		}
+	}
+	slices.Sort(numbers)
+	dl.ownHashes = dl.ownHashes[:0]
+	for _, n := range numbers {
+		dl.ownHashes = append(dl.ownHashes, dl.ownCanonical[n])
+	}
+}
+
+// canonicalHead returns the highest canonical entry. With requireBlock,
+// entries without a stored block are skipped, giving the head block that
+// insertChain reorganizes against; without it, the head header that
+// WriteHeader compares against. Caller must hold dl.lock.
+func (dl *downloadTester) canonicalHead(requireBlock bool) (uint64, common.Hash) {
+	headNum, headHash := uint64(0), dl.ownCanonical[0]
+	for n, h := range dl.ownCanonical {
+		if n > headNum && (!requireBlock || dl.ownBlocks[h] != nil) {
+			headNum, headHash = n, h
+		}
+	}
+	return headNum, headHash
+}
+
+// GetCanonicalHash returns the hash of the canonical block at the given
+// height, or the zero hash when the height is unknown. Entries are advanced
+// by header and block inserts that overtake the head's total difficulty,
+// mirroring WriteHeader and insertChain.
+func (dl *downloadTester) GetCanonicalHash(number uint64) common.Hash {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	return dl.ownCanonical[number]
+}
+
+// GetHeaderByNumber returns the canonical header at the given height, or nil
+// when the height is unknown, mirroring the real chain's canonical marker
+// reads used by consensus.ShouldHandleProposedBlock.
+func (dl *downloadTester) GetHeaderByNumber(number uint64) *types.Header {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	return dl.ownHeaders[dl.ownCanonical[number]]
+}
+
+// GetBlock returns the stored block with the requested hash and height, or
+// nil when it is not stored. Test-only accessor for the assertions below:
+// the judgment itself reads storage through HasBlock.
+func (dl *downloadTester) GetBlock(hash common.Hash, number uint64) *types.Block {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+
+	block := dl.ownBlocks[hash]
+	if block == nil || block.NumberU64() != number {
+		return nil
+	}
+	return block
+}
+
 // InsertReceiptChain injects a new batch of receipts into the simulated chain.
 func (dl *downloadTester) InsertReceiptChain(blocks types.Blocks, receipts []types.Receipts) (i int, err error) {
 	dl.lock.Lock()
@@ -371,14 +567,22 @@ func (dl *downloadTester) Rollback(hashes []common.Hash) {
 	defer dl.lock.Unlock()
 
 	for i := len(hashes) - 1; i >= 0; i-- {
-		if dl.ownHashes[len(dl.ownHashes)-1] == hashes[i] {
-			dl.ownHashes = dl.ownHashes[:len(dl.ownHashes)-1]
+		// Drop the canonical marker as well, otherwise GetCanonicalHash
+		// keeps reporting blocks that Rollback just removed. The height is
+		// read before the header itself is deleted below.
+		if header := dl.ownHeaders[hashes[i]]; header != nil {
+			if number := header.Number.Uint64(); dl.ownCanonical[number] == hashes[i] {
+				delete(dl.ownCanonical, number)
+			}
 		}
 		delete(dl.ownChainTd, hashes[i])
 		delete(dl.ownHeaders, hashes[i])
 		delete(dl.ownReceipts, hashes[i])
 		delete(dl.ownBlocks, hashes[i])
 	}
+	// ownHashes is the canonical snapshot, so rebuild it from the markers
+	// the loop above may have dropped.
+	dl.rebuildOwnHashes()
 }
 
 // newPeer registers a new block download source into the downloader.
@@ -400,9 +604,21 @@ func (dl *downloadTester) dropPeer(id string) {
 	dl.downloader.UnregisterPeer(id)
 }
 
-// an empty handleProposedBlock function
+// handleProposedBlock records the invocation and its argument for assertions.
 func (dl *downloadTester) handleProposedBlock(header *types.Header) error {
+	dl.lock.Lock()
+	dl.proposedCalls++
+	dl.lastProposedHeader = header
+	dl.lock.Unlock()
 	return nil
+}
+
+// proposedState returns the invocation count and the header of the most
+// recent handleProposedBlock call.
+func (dl *downloadTester) proposedState() (int, *types.Header) {
+	dl.lock.RLock()
+	defer dl.lock.RUnlock()
+	return dl.proposedCalls, dl.lastProposedHeader
 }
 
 // Config retrieves the blockchain's chain configuration.
@@ -2588,6 +2804,10 @@ func testReorgProtectionDoesNotStallSync(t *testing.T, protocol int, mode SyncMo
 			tester.ownHashes = append(tester.ownHashes[:0], localChain.chain...)
 			for hash, header := range localChain.headerm {
 				tester.ownHeaders[hash] = header
+				// Mirror the canonical markers as well: rebuildOwnHashes sources
+				// from ownCanonical, and the first canonicalize of the sync
+				// would otherwise wipe the preset chain back to genesis.
+				tester.ownCanonical[header.Number.Uint64()] = hash
 			}
 			for _, block := range localChain.blockm {
 				tester.ownBlocks[block.Hash()] = block

--- a/eth/downloader/metrics.go
+++ b/eth/downloader/metrics.go
@@ -42,4 +42,12 @@ var (
 	stateDropMeter = metrics.NewRegisteredMeter("eth/downloader/states/drop", nil)
 
 	throttleCounter = metrics.NewRegisteredCounter("eth/downloader/throttle", nil)
+
+	// skippedProposedBlockPreFilter counts pre-filter skips of the proposed-block
+	// handler on each imported batch tail: the tail was judged non-canonical or
+	// unstored, so no QC or vote runs on it. Sustained growth under a reorg
+	// storm means whole batch tails keep landing on a fork. Every proposed-block
+	// skip counter shares the skipped-proposed-block root (engine gates, this
+	// pre-filter, the eth fetcher gate), so one alert regex aggregates them all.
+	skippedProposedBlockPreFilter = metrics.NewRegisteredCounter("skipped-proposed-block/prefilter", nil)
 )

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -45,6 +45,15 @@ const (
 	blockLimit   = 64  // Maximum number of unique blocks a peer may have delivered
 )
 
+const (
+	// parkedImportTimeout bounds the wait for the future-block loop to import
+	// a block that was parked in the future queue before its signature is
+	// dropped. The enqueue window in core is maxTimeFutureBlocks (30s), so a
+	// threefold margin covers clock skew and queue congestion.
+	parkedImportTimeout      = 90 * time.Second
+	parkedImportPollInterval = 100 * time.Millisecond // same cadence as the future-block loop
+)
+
 // IsPlausibleAnnouncement reports whether a block announcement at the given
 // number is within the fetcher's plausibility window of the current chain
 // height. Untrusted announced numbers must be gated on this check before being
@@ -783,6 +792,33 @@ func (f *BlockFetcher) insert(peer string, block *types.Block) {
 			return
 		}
 
+		// Signing and consensus handling require the block to actually be in
+		// the chain: the import can report success while only parking the
+		// block (or its ancestors) in the future queue. Signing an unimported
+		// block, or voting on it, would corrupt the consensus state. Relaying
+		// is safe either way — a future block is simply parked again by the
+		// receivers — so the broadcast below must not depend on whether the
+		// block was parked locally.
+		if f.getBlock(block.Hash()) == nil {
+			log.Debug("Block parked in the future queue, deferring signing", "peer", peer, "number", block.Number(), "hash", hash)
+			// The future-block loop imports the block once its timestamp
+			// arrives; create the signature transaction then. The vote is
+			// not compensated: procFutureBlocks feeds the imported block
+			// to the consensus engine itself. Only nodes with a signing
+			// hook (XDPoS) compensate; without one there is nothing to
+			// wait for, so no waiter is spawned.
+			if f.signHook != nil {
+				go f.compensateSignHook(block)
+			}
+			if isM2 {
+				blockBroadcastOutTimer.UpdateSince(block.ReceivedAt)
+				go f.broadcastBlock(block, true)
+			} else {
+				blockAnnounceOutTimer.UpdateSince(block.ReceivedAt)
+				go f.broadcastBlock(block, false)
+			}
+			return
+		}
 		if f.signHook != nil {
 			if err := f.signHook(block); err != nil {
 				log.Error("Can't sign the imported block", "err", err)
@@ -803,6 +839,37 @@ func (f *BlockFetcher) insert(peer string, block *types.Block) {
 			go f.broadcastBlock(block, false)
 		}
 	}()
+}
+
+// compensateSignHook waits for the future-block loop to import a block that
+// was parked in the future queue at delivery time and then runs the signing
+// hook that insert had to skip. Voting is not compensated: procFutureBlocks
+// feeds the imported block to the consensus engine itself. Giving up after
+// parkedImportTimeout only loses the signature of a block that was never
+// imported (evicted, rejected or reorged away).
+func (f *BlockFetcher) compensateSignHook(block *types.Block) {
+	hash := block.Hash()
+	deadline := time.NewTimer(parkedImportTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(parkedImportPollInterval)
+	defer ticker.Stop()
+
+	for f.getBlock(hash) == nil {
+		select {
+		case <-f.quit:
+			return
+		case <-deadline.C:
+			log.Warn("Parked block was not imported in time, dropping its signature", "number", block.Number(), "hash", hash)
+			return
+		case <-ticker.C:
+		}
+	}
+
+	if f.signHook != nil {
+		if err := f.signHook(block); err != nil {
+			log.Error("Can't sign the imported block", "err", err)
+		}
+	}
 }
 
 // forgetHash removes all traces of a block announcement from the fetcher's

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -196,6 +196,13 @@ type BlockFetcher struct {
 
 // NewBlockFetcher creates a block fetcher to retrieve blocks based on hash announcements.
 func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, handleProposedBlock proposeBlockHandlerFn, broadcastBlock blockBroadcasterFn, chainHeight chainHeightFn, insertBlock blockInsertFn, prepareBlock blockPrepareFn, dropPeer peerDropFn) *BlockFetcher {
+	// A nil proposed-block handler means "not wired": normalize it to a no-op so
+	// the import path needs no nil guard. The downloader is not symmetric — it
+	// keeps the callback nil and checks it at the call site.
+	handler := handleProposedBlock
+	if handler == nil {
+		handler = func(*types.Header) error { return nil }
+	}
 	return &BlockFetcher{
 		notify:              make(chan *blockAnnounce),
 		inject:              make(chan *blockInject),
@@ -214,13 +221,22 @@ func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, h
 		knowns:              lru.NewCache[common.Hash, struct{}](blockLimit),
 		getBlock:            getBlock,
 		verifyHeader:        verifyHeader,
-		handleProposedBlock: handleProposedBlock,
+		handleProposedBlock: handler,
 		broadcastBlock:      broadcastBlock,
 		chainHeight:         chainHeight,
 		insertBlock:         insertBlock,
 		prepareBlock:        prepareBlock,
 		dropPeer:            dropPeer,
 	}
+}
+
+// ProposedBlockHandler returns the proposed-block callback this fetcher was
+// wired with, mirroring the downloader's accessor. NewProtocolManager must pass
+// the snapSync-gated closure, not the bare consensus handler; the wiring tests
+// read this accessor to assert the gates survive the NewProtocolManager →
+// NewBlockFetcher hop.
+func (f *BlockFetcher) ProposedBlockHandler() func(*types.Header) error {
+	return f.handleProposedBlock
 }
 
 // Start boots up the announcement based synchroniser, accepting and processing

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -955,3 +955,178 @@ func TestNewBlockFetcherNormalizesNilHandler(t *testing.T) {
 		t.Fatalf("normalized handler must be a no-op, got %v", err)
 	}
 }
+
+// Tests that the consensus handler is skipped and the signing hook deferred
+// when the import reported success without the block actually reaching the
+// chain (e.g. the block or one of its ancestors was parked in the future
+// queue): signing and voting on an unimported block would corrupt consensus
+// state, while relaying it is safe and happens regardless.
+func TestUnimportedBlockSkipsConsensusHandling(t *testing.T) {
+	block := types.NewBlockWithHeader(&types.Header{
+		ParentHash: genesis.Hash(),
+		Number:     common.Big1,
+		Difficulty: common.Big1,
+		GasLimit:   params.GenesisGasLimit,
+	}).WithBody(types.Body{})
+
+	// Simulate insertBlock queueing the block in the future queue and still
+	// reporting success: neither the sign hook nor the consensus handler may run.
+	tester := newTester()
+	testSkipConsensusHandlingForUnimportedBlock(t, tester, block)
+
+	// A block that actually lands in the chain keeps its consensus handling.
+	tester = newTester()
+	testConsensusHandlingForImportedBlock(t, tester, block)
+}
+
+// testSkipConsensusHandlingForUnimportedBlock injects a block whose import
+// reports success without storing anything and asserts that neither the
+// signing hook nor the consensus handler runs for it: both are consensus
+// actions reserved for blocks that actually reached the chain.
+func testSkipConsensusHandlingForUnimportedBlock(t *testing.T, tester *fetcherTester, block *types.Block) {
+	imported := make(chan *types.Block, 1)
+	tester.fetcher.insertBlock = func(block *types.Block) error {
+		imported <- block
+		return nil
+	}
+	signed := make(chan *types.Block, 1)
+	tester.fetcher.signHook = func(block *types.Block) error {
+		signed <- block
+		return nil
+	}
+	proposed := make(chan *types.Header, 1)
+	tester.fetcher.handleProposedBlock = func(header *types.Header) error {
+		proposed <- header
+		return nil
+	}
+	tester.fetcher.Enqueue("test", block)
+
+	// Wait for the import attempt to finish before checking the hooks.
+	select {
+	case <-imported:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("import of the unimported block never finished")
+	}
+	select {
+	case b := <-signed:
+		t.Fatalf("sign hook ran for unimported block %v", b.Hash())
+	case <-time.After(300 * time.Millisecond):
+	}
+	select {
+	case header := <-proposed:
+		t.Fatalf("consensus handler ran for unimported block %v", header.Hash())
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// testConsensusHandlingForImportedBlock injects a block that reaches the
+// chain and asserts both the signing hook and the consensus handler run for it.
+func testConsensusHandlingForImportedBlock(t *testing.T, tester *fetcherTester, block *types.Block) {
+	signed := make(chan *types.Block, 1)
+	tester.fetcher.signHook = func(block *types.Block) error {
+		signed <- block
+		return nil
+	}
+	proposed := make(chan *types.Header, 1)
+	tester.fetcher.handleProposedBlock = func(header *types.Header) error {
+		proposed <- header
+		return nil
+	}
+	tester.fetcher.Enqueue("test", block)
+
+	// The signing hook runs before the consensus handler.
+	select {
+	case b := <-signed:
+		if b.Hash() != block.Hash() {
+			t.Fatalf("sign hook ran for block %v, want %v", b.Hash(), block.Hash())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("sign hook never ran for the imported block")
+	}
+	select {
+	case header := <-proposed:
+		if header.Hash() != block.Hash() {
+			t.Fatalf("consensus handler ran for block %v, want %v", header.Hash(), block.Hash())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("consensus handler never ran for the imported block")
+	}
+}
+
+// TestParkedBlockSignsAfterFutureImport verifies that a block parked in the
+// future queue at delivery time still gets its signature transaction once
+// the future-block loop imports it, while the consensus handler stays
+// reserved for procFutureBlocks.
+func TestParkedBlockSignsAfterFutureImport(t *testing.T) {
+	block := types.NewBlockWithHeader(&types.Header{
+		ParentHash: genesis.Hash(),
+		Number:     common.Big1,
+		Difficulty: common.Big1,
+		GasLimit:   params.GenesisGasLimit,
+	}).WithBody(types.Body{})
+
+	tester := newTester()
+	defer tester.fetcher.Stop()
+
+	imported := make(chan *types.Block, 1)
+	tester.fetcher.insertBlock = func(block *types.Block) error {
+		imported <- block
+		return nil // block parked, nothing stored
+	}
+	signed := make(chan *types.Block, 1)
+	tester.fetcher.signHook = func(block *types.Block) error {
+		signed <- block
+		return nil
+	}
+	proposed := make(chan *types.Header, 1)
+	tester.fetcher.handleProposedBlock = func(header *types.Header) error {
+		proposed <- header
+		return nil
+	}
+	broadcasts := make(chan *types.Block, 1)
+	tester.fetcher.broadcastBlock = func(block *types.Block, propagate bool) {
+		broadcasts <- block
+	}
+	tester.fetcher.Enqueue("test", block)
+
+	// Wait for the import attempt: the block is parked, so the signing hook
+	// and the consensus handler must not run yet.
+	select {
+	case <-imported:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("import of the parked block never finished")
+	}
+	select {
+	case b := <-signed:
+		t.Fatalf("sign hook ran before the block was imported: %v", b.Hash())
+	case <-time.After(300 * time.Millisecond):
+	}
+	// Relaying does not wait for the import.
+	select {
+	case b := <-broadcasts:
+		if b.Hash() != block.Hash() {
+			t.Fatalf("broadcast ran for block %v, want %v", b.Hash(), block.Hash())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("parked block was never broadcast")
+	}
+
+	// Simulate the future-block loop importing the parked block.
+	tester.insertChain(types.Blocks{block})
+
+	// The deferred signing hook now runs for the imported block.
+	select {
+	case b := <-signed:
+		if b.Hash() != block.Hash() {
+			t.Fatalf("sign hook ran for block %v, want %v", b.Hash(), block.Hash())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("sign hook never ran for the imported parked block")
+	}
+	// The consensus handler stays reserved for procFutureBlocks.
+	select {
+	case header := <-proposed:
+		t.Fatalf("consensus handler ran for parked block %v", header.Hash())
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -940,3 +940,18 @@ func TestBlockMemoryExhaustionAttack(t *testing.T) {
 	}
 	verifyImportDone(t, imported)
 }
+
+// TestNewBlockFetcherNormalizesNilHandler pins the nil-callback contract: a
+// nil proposed-block handler means "not wired" and must be normalized to a
+// no-op inside NewBlockFetcher, mirroring the downloader's nil tolerance, so
+// the import path never needs a nil guard and a caller can never nil-panic
+// by copying the downloader's wiring style.
+func TestNewBlockFetcherNormalizesNilHandler(t *testing.T) {
+	f := NewBlockFetcher(nil, nil, nil, nil, nil, nil, nil, nil)
+	if f.handleProposedBlock == nil {
+		t.Fatal("nil proposed-block handler must be normalized to a no-op")
+	}
+	if err := f.handleProposedBlock(nil); err != nil {
+		t.Fatalf("normalized handler must be a no-op, got %v", err)
+	}
+}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -40,6 +40,7 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/ethdb"
 	"github.com/XinFinOrg/XDPoSChain/event"
 	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/p2p"
 	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -62,6 +63,33 @@ const (
 var (
 	syncChallengeTimeout = 15 * time.Second // Time allowance for a node to reply to the DAO handshake challenge
 )
+
+// skippedProposedBlockState counts fetcher-gate skips on unexecuted state: the
+// block is absent or its state trie does not open, so no QC or vote runs on it.
+// A skip can be a benign fast-sync race, but sustained growth is a liveness
+// stall. It fires only on unexecuted state — XDCX trading/lending state
+// completeness is deliberately not a voting precondition. Every proposed-block
+// skip counter shares the skipped-proposed-block root (engine gates, downloader
+// pre-filter, this fetcher gate), so one alert regex aggregates them all.
+var skippedProposedBlockState = metrics.NewRegisteredCounter("skipped-proposed-block/state", nil)
+
+// skippedProposedBlockSnapSync counts fetcher-gate skips while fast sync is
+// running: snapSync discards propagated blocks before executing them, so
+// every propagation skips here by design. Growth during fast sync is
+// expected; sustained growth after the pivot commit means the snapSync flag
+// never cleared — a sync cycle keeps failing — and QC processing and voting
+// are stalled.
+var skippedProposedBlockSnapSync = metrics.NewRegisteredCounter("skipped-proposed-block/snap-sync", nil)
+
+// proposedBlockStallWindow bounds how far behind the head the fetcher gate's
+// Error escalation reaches. Voting happens within a few blocks of the head,
+// so only a near-head canonical block with unopenable state can mean a live
+// voting stall; farther back the same shape is expected — fast sync stores
+// only headers and bodies below the pivot, so old canonical blocks
+// legitimately have no state — and a late announce for such a height must
+// not pollute the stall alert. Sixty-four covers any plausible voting depth
+// with a wide margin.
+const proposedBlockStallWindow = 64
 
 func errResp(code errCode, format string, v ...interface{}) error {
 	return fmt.Errorf("%v - %v", code, fmt.Sprintf(format, v...))
@@ -164,18 +192,42 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		manager.snapSync = uint32(1)
 	}
 
-	var handleProposedBlock func(header *types.Header) error
+	var handleProposedBlock func(*types.Header) error
+
+	// While fast sync runs, the fetcher must not reach the consensus handler:
+	// snapSync discards propagated blocks before executing them, so a body
+	// written by the receipt phase would pass both halves of the handler's own
+	// judgment on a block whose state was never validated. The snapSync flag
+	// carries the guard inserter and prepare already have, but it reads too
+	// late to be the whole story — Synchronise can flip it between insert and
+	// callback. The executed-state check below is what holds: its HasBlock half
+	// is hash-keyed, so a discarded block with no body fails there, before the
+	// root-keyed OpenTrie half could pass an empty block whose root repeats the
+	// parent's.
+	//
+	// fetcherHandler is that gated closure. Its gate behaviour is verified on
+	// the closure directly, without driving the fetcher loops; the wiring is
+	// pinned by TestFetcherWiresGatedHandlerWithXDPoS through the fetcher's
+	// ProposedBlockHandler accessor.
+	var fetcherHandler func(*types.Header) error
 	if config.XDPoS != nil {
 		handleProposedBlock = func(header *types.Header) error {
 			return engine.(*XDPoS.XDPoS).HandleProposedBlock(blockchain, header)
 		}
+		fetcherHandler = newFetcherProposedBlockHandler(manager, handleProposedBlock)
 	} else {
-		handleProposedBlock = func(header *types.Header) error {
-			return nil
-		}
+		// No XDPoS engine, so there is nothing to gate and nothing to handle:
+		// the downloader keeps nil (it nil-checks at its call site), the fetcher
+		// gets an explicit no-op.
+		fetcherHandler = func(*types.Header) error { return nil }
 	}
 
-	// Construct the different synchronisation mechanisms
+	// Construct the different synchronisation mechanisms. The downloader keeps
+	// the ungated closure: its fast sync calls run after the pivot commit, so
+	// gating it here would skip every proposed block during fast sync and
+	// stall QC and voting; the call site's pre-filter runs the handler's own
+	// judgment. TestDownloaderWiresUngatedHandlerWithXDPoS pins this wiring
+	// through the downloader's ProposedBlockHandler accessor.
 	manager.downloader = downloader.New(chaindb, manager.eventMux, blockchain, nil, manager.removePeer, handleProposedBlock)
 
 	validator := func(header *types.Header) error {
@@ -205,7 +257,9 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
 		return manager.blockchain.PrepareBlock(block)
 	}
-	manager.blockFetcher = fetcher.NewBlockFetcher(blockchain.GetBlockByHash, validator, handleProposedBlock, manager.BroadcastBlock, heighter, inserter, prepare, manager.removePeer)
+	// fetcherHandler, not the bare handleProposedBlock: swapping the argument
+	// back would silently drop both gates during fast sync.
+	manager.blockFetcher = fetcher.NewBlockFetcher(blockchain.GetBlockByHash, validator, fetcherHandler, manager.BroadcastBlock, heighter, inserter, prepare, manager.removePeer)
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := manager.peers.Peer(peer)
@@ -232,6 +286,78 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 	}
 
 	return manager, nil
+}
+
+// newFetcherProposedBlockHandler builds the callback the fetcher runs. It gates
+// the consensus handler on the snapSync flag and on executed state (see the
+// wiring in NewProtocolManager for why) and leaves canonicality to the engine's
+// own judgment. It reads pm.blockchain instead of taking a chain argument, so
+// the gate cannot diverge from the manager's chain.
+func newFetcherProposedBlockHandler(pm *ProtocolManager, handleProposedBlock func(*types.Header) error) func(*types.Header) error {
+	return func(header *types.Header) error {
+		// A nil header or nil number is a caller bug, not an observation about
+		// a block; this closure dereferences the header before any chain read,
+		// so keep the SkipNilHeader contract instead of panicking.
+		if !consensus.IsJudgeableHeader(header) {
+			consensus.SkipNilHeaderLog(consensus.SkipSiteFetcher)
+			return nil
+		}
+		if atomic.LoadUint32(&pm.snapSync) == 1 {
+			// The flag is deliberately left set when a sync cycle fails
+			// (eth/sync.go): until fast sync completes the node has no state
+			// to judge blocks with, and clearing it early would also reopen tx
+			// handling (the snapSync uses in the broadcast paths above). A
+			// failure loop that keeps the flag stuck shows up as sustained
+			// growth of the skipped-proposed-block/snap-sync counter.
+			skippedProposedBlockSnapSync.Inc(1)
+			log.Debug("[fetcher] skipped proposed block handler during fast sync", "hash", header.Hash(), "number", header.Number)
+			return nil
+		}
+		// Canonicality is the engine's half — the gates interlock, they do not
+		// duplicate. Deliberately not HasBlockAndFullState: a missing XDCX
+		// trading/lending piece is not re-derivable, so demanding it would
+		// permanently halt voting on a correctly executed block.
+		// Residual risk: if the trie root never becomes available this gate
+		// stays false forever — the block is already on chain and will not
+		// re-execute, and the fetcher judges each propagation only once, so
+		// nothing heals it; pruning, a SetHead rollback, and trie corruption
+		// can all produce that shape, not just a fast-sync race. The stall is
+		// confined to this PBOR path: the block's QC still converges through
+		// the two deliberately ungated, quorum-signed entries (SyncInfoHandler
+		// and the vote-threshold path). There is no automatic fallback to
+		// HasBlock — that would undo this gate's protection — so the alert is
+		// the near-head Error below together with sustained growth of the
+		// skipped-proposed-block/state counter; both mean manual intervention
+		// (inspect pruning and trie integrity).
+		//
+		// The gate runs once per propagated block; one stateCache OpenTrie per
+		// block is negligible next to block processing, so the openability
+		// check is deliberately not cached.
+		if !pm.blockchain.HasBlockAndExecutedState(header.Hash(), header.Number.Uint64()) {
+			skippedProposedBlockState.Inc(1)
+			// A fast-sync race and a stall look identical here; separate them
+			// by canonicality and recency. A canonical block whose state never
+			// executes will not re-execute, so its gate stays false and QC
+			// processing and voting halt — near the head that is the alertable
+			// form and logs at Error. Farther back the same shape is expected
+			// noise: fast sync stores only headers and bodies below the pivot,
+			// so old canonical blocks legitimately have no state, and a late
+			// announce for such a height must not pollute the stall alert —
+			// those Warn.
+			head := pm.blockchain.CurrentBlock()
+			// Difference form: a sum with the window could wrap uint64 near
+			// MaxUint64; the guard clause keeps the subtraction from underflow.
+			stale := head != nil && head.Number.Uint64() > header.Number.Uint64() &&
+				head.Number.Uint64()-header.Number.Uint64() > proposedBlockStallWindow
+			if canonical := pm.blockchain.GetHeaderByNumber(header.Number.Uint64()); canonical != nil && canonical.Hash() == header.Hash() && !stale {
+				log.Error("[fetcher] skipped proposed block handler: canonical block state not executed, voting stalled", "hash", header.Hash(), "number", header.Number)
+			} else {
+				log.Warn("[fetcher] skipped proposed block handler: state not executed", "hash", header.Hash(), "number", header.Number)
+			}
+			return nil
+		}
+		return handleProposedBlock(header)
+	}
 }
 
 func (pm *ProtocolManager) addOrderPoolProtocol(orderpool orderPool) {

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -21,11 +21,14 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/XinFinOrg/XDPoSChain/common"
+	"github.com/XinFinOrg/XDPoSChain/consensus/XDPoS"
 	"github.com/XinFinOrg/XDPoSChain/consensus/ethash"
 	"github.com/XinFinOrg/XDPoSChain/core"
 	"github.com/XinFinOrg/XDPoSChain/core/rawdb"
@@ -36,6 +39,8 @@ import (
 	"github.com/XinFinOrg/XDPoSChain/eth/downloader"
 	"github.com/XinFinOrg/XDPoSChain/eth/ethconfig"
 	"github.com/XinFinOrg/XDPoSChain/event"
+	"github.com/XinFinOrg/XDPoSChain/log"
+	"github.com/XinFinOrg/XDPoSChain/metrics"
 	"github.com/XinFinOrg/XDPoSChain/p2p"
 	"github.com/XinFinOrg/XDPoSChain/p2p/enode"
 	"github.com/XinFinOrg/XDPoSChain/params"
@@ -924,4 +929,370 @@ func TestRegisterDownloaderPeerUndoesRacedRemoval(t *testing.T) {
 		t.Fatalf("reconnect blocked by stale downloader entry: %v", err)
 	}
 	pm.downloader.UnregisterPeer(p.id)
+}
+
+// TestFetcherWiresNoopHandlerWithoutConsensus pins the non-XDPoS wiring:
+// without a consensus engine the fetcher handler is an explicit no-op —
+// no gate logs, no counter movement, in either sync mode.
+func TestFetcherWiresNoopHandlerWithoutConsensus(t *testing.T) {
+	logBuf := new(lockedBuffer)
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(logBuf, log.LevelDebug, false))
+	glog.Verbosity(log.LevelDebug)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	for _, mode := range []downloader.SyncMode{downloader.FastSync, downloader.FullSync} {
+		pm, _ := newTestProtocolManagerMust(t, mode, 0, nil, nil)
+		defer pm.Stop()
+		// Read the wired handler through the fetcher's accessor instead of a
+		// ProtocolManager field: the accessor is the single source of truth for
+		// what NewBlockFetcher was handed (which also normalizes nil to no-op).
+		wired := pm.blockFetcher.ProposedBlockHandler()
+		// A nil check here would be unreachable: NewBlockFetcher normalizes a nil
+		// handler to a no-op, so the accessor can never return nil.
+		if err := wired(pm.blockchain.CurrentBlock()); err != nil {
+			t.Fatalf("no-op fetcher handler returned error: %v", err)
+		}
+		if strings.Contains(logBuf.String(), "skipped proposed block handler") {
+			t.Fatalf("non-XDPoS manager must wire a no-op without gate logs, have %q", logBuf.String())
+		}
+		logBuf.Reset()
+	}
+}
+
+// TestDownloaderKeepsNilHandlerWithoutConsensus pins the non-XDPoS downloader
+// wiring: without a consensus engine NewProtocolManager passes nil, and the
+// downloader — unlike the fetcher, which normalizes nil to a no-op in New —
+// keeps it, so this accessor returns nil and callers nil-check (as the import
+// pre-filter does). Normalizing the nil callback to a no-op instead would
+// make the pre-filter run and count skips for a handler that does nothing.
+func TestDownloaderKeepsNilHandlerWithoutConsensus(t *testing.T) {
+	for _, mode := range []downloader.SyncMode{downloader.FastSync, downloader.FullSync} {
+		pm, _ := newTestProtocolManagerMust(t, mode, 0, nil, nil)
+		defer pm.Stop()
+		if wired := pm.downloader.ProposedBlockHandler(); wired != nil {
+			t.Fatalf("non-XDPoS manager must wire the downloader with a nil handler, got a non-nil %T", wired)
+		}
+	}
+}
+
+// TestFetcherProposedBlockHandlerGates exercises newFetcherProposedBlockHandler
+// directly (an ethash test manager wires the no-op — see the wiring test
+// above): fast sync skips before the handler; full sync passes an executed
+// block through; a block whose state was never executed is skipped with a
+// Warn and counted, independent of the snapSync flag. A nil header or nil
+// number fails the SkipNilHeader guard (Error, uncounted) without panicking.
+func TestFetcherProposedBlockHandlerGates(t *testing.T) {
+	logBuf := new(lockedBuffer)
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(logBuf, log.LevelDebug, false))
+	glog.Verbosity(log.LevelDebug)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	// The chain is grown past proposedBlockStallWindow so the stale half of
+	// the escalation logic (canonical but far behind the head) can be
+	// exercised below; the earlier sections only need an executed head.
+	pm, db := newTestProtocolManagerMust(t, downloader.FullSync, proposedBlockStallWindow+2, nil, nil)
+	defer pm.Stop()
+	called := false
+	gated := newFetcherProposedBlockHandler(pm, func(*types.Header) error {
+		called = true
+		return nil
+	})
+
+	// During fast sync the closure must skip before reaching the handler.
+	atomic.StoreUint32(&pm.snapSync, 1)
+	snapSyncSkipsBefore := skippedProposedBlockSnapSync.Snapshot().Count()
+	if err := gated(pm.blockchain.CurrentBlock()); err != nil {
+		t.Fatalf("gated handler returned error in fast sync: %v", err)
+	}
+	if called {
+		t.Fatal("fast sync call must not reach the consensus handler")
+	}
+	if !strings.Contains(logBuf.String(), "skipped proposed block handler during fast sync") {
+		t.Fatalf("fast sync skip not logged, have %q", logBuf.String())
+	}
+	if got := skippedProposedBlockSnapSync.Snapshot().Count(); got != snapSyncSkipsBefore+1 {
+		t.Fatalf("fast sync skip not counted, before = %d, after = %d", snapSyncSkipsBefore, got)
+	}
+	logBuf.Reset()
+
+	// With fast sync off, the same call reaches the handler without the skip
+	// log: the guard must not over-block full sync.
+	atomic.StoreUint32(&pm.snapSync, 0)
+	if err := gated(pm.blockchain.CurrentBlock()); err != nil {
+		t.Fatalf("gated handler returned error in full sync: %v", err)
+	}
+	if !called {
+		t.Fatal("full sync call must reach the consensus handler")
+	}
+	if strings.Contains(logBuf.String(), "skipped proposed block handler") {
+		t.Fatalf("executed genesis block must pass both gates, have %q", logBuf.String())
+	}
+	logBuf.Reset()
+
+	// The snapSync flag alone is read too late: the fetcher runs signHook
+	// between its insert and this callback, so Synchronise can flip the
+	// flag to 0 inside that gap. A block whose inserter was skipped never
+	// had its state executed, so the state guard must catch it even with
+	// the flag already cleared. Forge such a block for real: write its
+	// header and body straight into the database so the hash-keyed GetBlock
+	// half of HasBlockAndExecutedState finds it, with a root that exists
+	// nowhere in the state database so the state half — the OpenTrie — is
+	// the part that fails. Merely mutating the current header's root would
+	// change its hash and fail the guard at the GetBlock half instead, never
+	// exercising the state check this scenario exists for.
+	current := pm.blockchain.CurrentBlock()
+	unexecuted := types.CopyHeader(current)
+	unexecuted.Root = common.HexToHash("0xdeadbeef")
+	unexecuted.Number = new(big.Int).Add(current.Number, big.NewInt(1))
+	rawdb.WriteBlock(db, types.NewBlockWithHeader(unexecuted))
+	called = false
+	before := skippedProposedBlockState.Snapshot().Count()
+	if err := gated(unexecuted); err != nil {
+		t.Fatalf("gated handler returned error for unexecuted state: %v", err)
+	}
+	if called {
+		t.Fatal("unexecuted-state call must not reach the consensus handler")
+	}
+	if !strings.Contains(logBuf.String(), "state not executed") {
+		t.Fatalf("state guard skip not logged, have %q", logBuf.String())
+	}
+	if got := skippedProposedBlockState.Snapshot().Count(); got != before+1 {
+		t.Fatalf("state guard skip not counted, before = %d, after = %d", before, got)
+	}
+	if strings.Contains(logBuf.String(), "skipped proposed block handler during fast sync") {
+		t.Fatalf("state guard must be independent of the snapSync flag, have %q", logBuf.String())
+	}
+	logBuf.Reset()
+	called = false
+
+	// A canonical block near the head with unopenable state is the alertable
+	// form: voting depends on recent heights, so the skip escalates to Error.
+	// Forge one just past the head with a bad root and mark it canonical —
+	// GetHeaderByNumber answers from the canonical-hash marker.
+	stalled := types.CopyHeader(current)
+	stalled.Root = common.HexToHash("0xbeefdead")
+	stalled.Number = new(big.Int).Add(current.Number, big.NewInt(1))
+	rawdb.WriteBlock(db, types.NewBlockWithHeader(stalled))
+	rawdb.WriteCanonicalHash(db, stalled.Hash(), stalled.Number.Uint64())
+	if err := gated(stalled); err != nil {
+		t.Fatalf("gated handler returned error for stalled canonical block: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "voting stalled") {
+		t.Fatalf("near-head canonical skip must escalate to Error, have %q", logBuf.String())
+	}
+	logBuf.Reset()
+	called = false
+
+	// The same shape far behind the head is expected noise: fast sync stores
+	// only headers and bodies below the pivot, so old canonical blocks
+	// legitimately have no state there. It must stay at Warn and not pollute
+	// the stall alert. Height 1 is more than proposedBlockStallWindow behind
+	// the head, so the escalation bound must hold it at Warn.
+	base := pm.blockchain.GetHeaderByNumber(1)
+	old := types.CopyHeader(base)
+	old.Root = common.HexToHash("0xbeefcafe")
+	rawdb.WriteBlock(db, types.NewBlockWithHeader(old))
+	rawdb.WriteCanonicalHash(db, old.Hash(), old.Number.Uint64())
+	if err := gated(old); err != nil {
+		t.Fatalf("gated handler returned error for stale canonical block: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "state not executed") {
+		t.Fatalf("stale canonical skip not logged, have %q", logBuf.String())
+	}
+	if strings.Contains(logBuf.String(), "voting stalled") {
+		t.Fatalf("stale canonical skip must not escalate to Error, have %q", logBuf.String())
+	}
+	logBuf.Reset()
+	called = false
+
+	// A nil header or nil number must fail the SkipNilHeader guard — the same
+	// caller-bug contract as ShouldHandleProposedBlock — instead of panicking
+	// on the dereference, without reaching the handler or moving the state
+	// counter.
+	skippedBefore := skippedProposedBlockState.Snapshot().Count()
+	for _, nilCase := range []*types.Header{nil, {}} {
+		if err := gated(nilCase); err != nil {
+			t.Fatalf("gated handler returned error for nil header: %v", err)
+		}
+	}
+	if called {
+		t.Fatal("nil header must not reach the consensus handler")
+	}
+	if !strings.Contains(logBuf.String(), "nil header") {
+		t.Fatalf("nil header skip not logged, have %q", logBuf.String())
+	}
+	if got := skippedProposedBlockState.Snapshot().Count(); got != skippedBefore {
+		t.Fatalf("nil header must not move the state counter, before = %d, after = %d", skippedBefore, got)
+	}
+}
+
+// TestFetcherGateCounterNames pins the registered metric names of the
+// fetcher-gate counters. Every proposed-block skip counter shares the
+// skipped-proposed-block root (engine gates, downloader pre-filter, this
+// gate) so one alert regex aggregates them; a silent rename would orphan
+// external alerts.
+func TestFetcherGateCounterNames(t *testing.T) {
+	for _, name := range []string{
+		"skipped-proposed-block/state",
+		"skipped-proposed-block/snap-sync",
+	} {
+		if metrics.Get(name) == nil {
+			t.Fatalf("counter %q is not registered in the metrics registry", name)
+		}
+	}
+}
+
+// TestFetcherWiresGatedHandlerWithXDPoS pins the production fetcher wiring: with
+// an XDPoS chain config the NewProtocolManager branch must hand the fetcher the
+// snapSync-gated closure, not the bare consensus handler. The ethash test
+// managers wire the no-op (see TestFetcherWiresNoopHandlerWithoutConsensus) and
+// TestFetcherProposedBlockHandlerGates drives the closure directly, so this is
+// the only place the NewProtocolManager → NewBlockFetcher hop is asserted:
+// swapping the fetcher argument back to the bare handleProposedBlock would
+// silently drop both gates, and this test fails on exactly that mutation.
+func TestFetcherWiresGatedHandlerWithXDPoS(t *testing.T) {
+	logBuf := new(lockedBuffer)
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(logBuf, log.LevelDebug, false))
+	glog.Verbosity(log.LevelDebug)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	db := rawdb.NewMemoryDatabase()
+	gspec := &core.Genesis{
+		Alloc:  types.GenesisAlloc{testBank: {Balance: new(big.Int).SetUint64(10000000000000000000)}},
+		Config: params.TestXDPoSMockChainConfig,
+		// The genesis commit rejects an XDPoS chain without signers: pad
+		// ExtraData past 32+65 bytes the way ethclient/simulated does.
+		ExtraData: append(make([]byte, 32), make([]byte, crypto.SignatureLength)...),
+	}
+	engine := XDPoS.NewFaker(db, gspec.Config)
+	if engine == nil {
+		t.Fatal("failed to create XDPoS fake engine")
+	}
+	blockchain, err := core.NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create XDPoS blockchain: %v", err)
+	}
+	pm, err := NewProtocolManager(gspec.Config, downloader.FastSync, ethconfig.Defaults.NetworkId, new(event.TypeMux), &testTxPool{pool: make(map[common.Hash]*types.Transaction)}, engine, blockchain, db)
+	if err != nil {
+		t.Fatalf("failed to create XDPoS protocol manager: %v", err)
+	}
+	// Cleanup mirrors what pm.Stop() does for started managers, but this test
+	// never calls pm.Start(), so pm.Stop() itself would panic on the nil txsSub
+	// subscription. The downloader already runs qosTuner/stateFetcher goroutines
+	// from New, and the chain holds trie resources, so terminate both directly.
+	defer pm.downloader.Terminate()
+	defer blockchain.Stop()
+	// NewBlockFetcher normalizes a nil handler to a no-op, so ProposedBlockHandler
+	// can never return nil and a nil check here would be unreachable. An
+	// explicitly no-op wiring is excluded behaviorally: the assertions below
+	// require the skip log and the counter to move, which a no-op never does.
+	wired := pm.blockFetcher.ProposedBlockHandler()
+	// In fast sync the wired closure must skip before reaching the consensus
+	// handler: a regression to the bare handleProposedBlock would neither log
+	// nor count the gate.
+	before := skippedProposedBlockSnapSync.Snapshot().Count()
+	if err := wired(pm.blockchain.CurrentBlock()); err != nil {
+		t.Fatalf("wired handler returned error: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "skipped proposed block handler during fast sync") {
+		t.Fatalf("fetcher-wired handler is not snapSync-gated, have %q", logBuf.String())
+	}
+	if got := skippedProposedBlockSnapSync.Snapshot().Count(); got != before+1 {
+		t.Fatalf("fetcher-wired handler skip not counted, before = %d, after = %d", before, got)
+	}
+}
+
+// TestDownloaderWiresUngatedHandlerWithXDPoS mirrors TestFetcherWiresGatedHandlerWithXDPoS
+// for the downloader wiring: with an XDPoS chain config NewProtocolManager must hand
+// downloader.New the bare consensus handler, not the snapSync-gated closure. The
+// downloader's fast-sync proposed-block calls run after the pivot commit
+// (processFastSyncContent), so the ungated closure is correct there — gating it
+// would skip every proposed block during fast sync and stall QC and voting. The
+// call site's pre-filter already runs the handler's own judgment, and the
+// downloader tests build their own downloader, so this is the only place the
+// NewProtocolManager → downloader.New hop is asserted. The gate-free checks
+// alone only exclude the gated closure: a no-op or any other non-consensus
+// closure passes them too, so the fork-header pin below asserts the engine's
+// own skip path, which only the bare consensus handler can produce.
+func TestDownloaderWiresUngatedHandlerWithXDPoS(t *testing.T) {
+	logBuf := new(lockedBuffer)
+	prevLog := log.Root()
+	glog := log.NewGlogHandler(log.NewTerminalHandlerWithLevel(logBuf, log.LevelDebug, false))
+	glog.Verbosity(log.LevelDebug)
+	log.SetDefault(log.NewLogger(glog))
+	defer log.SetDefault(prevLog)
+
+	db := rawdb.NewMemoryDatabase()
+	gspec := &core.Genesis{
+		Alloc:  types.GenesisAlloc{testBank: {Balance: new(big.Int).SetUint64(10000000000000000000)}},
+		Config: params.TestXDPoSMockChainConfig,
+		// The genesis commit rejects an XDPoS chain without signers: pad
+		// ExtraData past 32+65 bytes the way ethclient/simulated does.
+		ExtraData: append(make([]byte, 32), make([]byte, crypto.SignatureLength)...),
+	}
+	engine := XDPoS.NewFaker(db, gspec.Config)
+	if engine == nil {
+		t.Fatal("failed to create XDPoS fake engine")
+	}
+	blockchain, err := core.NewBlockChain(db, nil, gspec, engine, vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create XDPoS blockchain: %v", err)
+	}
+	pm, err := NewProtocolManager(gspec.Config, downloader.FastSync, ethconfig.Defaults.NetworkId, new(event.TypeMux), &testTxPool{pool: make(map[common.Hash]*types.Transaction)}, engine, blockchain, db)
+	if err != nil {
+		t.Fatalf("failed to create XDPoS protocol manager: %v", err)
+	}
+	// Cleanup mirrors what pm.Stop() does for started managers, but this test
+	// never calls pm.Start(), so pm.Stop() itself would panic on the nil txsSub
+	// subscription. The downloader already runs qosTuner/stateFetcher goroutines
+	// from New, and the chain holds trie resources, so terminate both directly.
+	defer pm.downloader.Terminate()
+	defer blockchain.Stop()
+	// Unlike the fetcher, the downloader does not normalize a nil handler — the
+	// production wiring always passes a non-nil closure, so a nil here is a
+	// wiring regression.
+	wired := pm.downloader.ProposedBlockHandler()
+	if wired == nil {
+		t.Fatal("downloader must be wired with a proposed-block handler")
+	}
+	// In fast sync the downloader-wired closure must reach the consensus
+	// handler, so the snapSync gate must neither log nor count. The handler's
+	// own return value is not asserted: on this fixture the bare handler runs
+	// the engine and may legitimately error on the genesis extra data.
+	before := skippedProposedBlockSnapSync.Snapshot().Count()
+	wired(pm.blockchain.CurrentBlock())
+	if strings.Contains(logBuf.String(), "skipped proposed block handler") {
+		t.Fatalf("downloader-wired handler is snapSync-gated, have %q", logBuf.String())
+	}
+	if got := skippedProposedBlockSnapSync.Snapshot().Count(); got != before {
+		t.Fatalf("downloader-wired handler must not hit the snapSync gate, before = %d, after = %d", before, got)
+	}
+	// Pin the handler's identity, not just the absence of the gate: a no-op or
+	// any other non-consensus closure also produces no gate log and no gate
+	// count. A header above the v2 switch block has no canonical block at its
+	// height (the fixture only holds genesis), so it fails the engine's first
+	// gate (no canonical header at height) — before any extra parsing — and
+	// only the bare consensus handler reaches that gate. The height must sit
+	// above the switch block because the wrapper dispatches on it: a genesis-
+	// height header goes to the v1 engine and returns nil without counting.
+	// The engine_v2 counter is unexported, so read it through the registry.
+	fork := &types.Header{Number: new(big.Int).Add(gspec.Config.XDPoS.V2.SwitchBlock, big.NewInt(1))}
+	counter, ok := metrics.Get("skipped-proposed-block").(*metrics.Counter)
+	if !ok {
+		t.Fatal("skipped-proposed-block is not registered in the metrics registry")
+	}
+	engineSkips := counter.Snapshot().Count()
+	wired(fork)
+	if got := counter.Snapshot().Count(); got != engineSkips+1 {
+		t.Fatalf("downloader must be wired with the bare consensus handler: fork skip not counted by the engine, before = %d, after = %d", engineSkips, got)
+	}
+	if !strings.Contains(logBuf.String(), "[ProposedBlockHandler] skip block before processQC") {
+		t.Fatalf("downloader-wired handler did not run the engine skip path, have %q", logBuf.String())
+	}
 }


### PR DESCRIPTION
## Summary

`insertChain` treats a mid-batch `ErrFutureBlock` as a fatal verification error: both future-block loops only accepted `ErrUnknownAncestor`, so a batch whose first or middle block was in the future stopped at its second block and returned `consensus.ErrFutureBlock`. The downloader wraps any non-nil `InsertChain` error into `errInvalidChain` (`eth/downloader/downloader.go`) and `Synchronise` answers that by **dropping the delivering peer**, aborting the round and retrying with another peer. Near the chain tip this repeats and continuously evicts innocent peers.

## Root cause

The XDPoS engines check the header timestamp **before** the parent lookup and with zero tolerance (`header.Time > now`), unlike upstream geth's 15-second `allowedFutureBlockTimeSeconds`. Consequently the children of a future block fail the future check too — they surface as `ErrFutureBlock`, never as `ErrUnknownAncestor`, so the inner loops (which only accept `ErrUnknownAncestor`) stop at the second block and the rest of the batch is silently skipped.

Before #2534 the same scenario silently dropped the tail and failed one batch later with a bogus bad-block report.

## Fix

Accept `consensus.ErrFutureBlock` in both future-block loops of `insertChain` (first-block path and tail path), so the whole tail enters the `futureBlocks` queue and the import reports success. No error is swallowed: the loops drain naturally to `(nil, nil)` and genuine verification errors still propagate. The queued blocks are imported by `procFutureBlocks` (100 ms ticker) once their timestamps are reached, matching the upstream geth design intent.

Blocks beyond the `now+30s` future window still return an error (abort + peer drop), which is the documented behaviour for a local clock more than 30 seconds behind — an environment problem, not an invalid chain.

A genuine verification error on a block **after** the queued future tail (e.g. a malformed validator field, which the XDPoS engines check before the timestamp) also surfaces: it is recorded as a bad block and returned, so only a fully drained tail reports success. Future, pruned-ancestor and known blocks remain exempt from the bad-block report — they are legitimate chain states. The same applies to a genuine error **after the queued prefix** when the batch starts with a future block: it is recorded and returned as well. When the known-block import PR lands, its final-return filter reports the same block again; `WriteBadBlock` deduplicates by (number, hash), so the only effect is one extra BAD BLOCK log line.

## Tests

New `core/blockchain_futureblocks_test.go` (self-contained, own `failRangeEngine` with an `atomic.Uint64` fail range because the chain's future-block loop calls `VerifyHeaders` concurrently):

- `TestInsertChainQueuesMidBatchFutureBlocks` — a batch rejected as future mid-way returns `n == len(blocks)`, err nil, head stays at blocks[1], the whole tail is in `futureBlocks`, no bad-block records.
- `TestInsertChainQueuesFutureBatchFromFirstBlock` — same for a batch whose first block is already in the future (pre-existing scenario).
- `TestInsertChainProcFutureBlocksResumesImport` — once headers verify again, the queued tail imports and the head reaches the batch tip (head polled with a deadline because `InsertChain` uses `TryLock` and the background loop may be mid-import).

All three are mutation-verified: reverting either loop condition alone makes the corresponding test fail. `go test ./core/` and `go test ./eth/downloader/` pass, also under `-race`; `gofmt`/`go vet` clean.

## Compatibility

No consensus-rule changes: block/receipt structure, state transition and wire protocol are untouched. Only the error handling of the import path changes. No migration or node-operator action required. Suggested label: `consensus`.

